### PR TITLE
styling: update docs styles

### DIFF
--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -89,32 +89,33 @@ h6 {
 
 h1 {
   font-size: 3rem;
-  margin-top: -0.5rem;
+  margin-top: -0.75rem;
   @media (min-width: 90rem) {
-    font-size: 4.5rem;
+    font-size: 3.75rem;
     margin-top: -1rem;
   }
 }
 
 h2 {
-  font-size: 2.2rem;
+  font-size: 2rem;
   @media (min-width: 90rem) {
-    font-size: 2.8rem;
+    font-size: 2.7rem;
   }
 }
 
 h3 {
-  font-size: 1.8rem;
+  font-size: 1.5rem;
   @media (min-width: 90rem) {
-    font-size: 2rem;
+    font-size: 1.7rem;
   }
 }
 
 h4 {
-  font-size: 1.2rem;
-  @media (min-width: 90rem) {
-    font-size: 1.6rem;
-  }
+  font-size: 1.25rem;
+}
+
+h5 {
+  font-size: 1.1rem;
 }
 
 p {
@@ -193,7 +194,7 @@ code {
 
   :not(pre) > & {
     color: var(--section-color);
-    background-color: var(--section-color-dim);
+    background-color: var(--section-color-alt-dim);
     border-radius: 0.5lh;
     padding: 0.2rem 0.75ch;
     line-height: 1.8;

--- a/src/routes/docs/+layout.style.module.scss
+++ b/src/routes/docs/+layout.style.module.scss
@@ -32,7 +32,7 @@ main {
   @include section-color.set("red");
 
   $i: 1;
-  @each $color in "blue", "yellow", "green" {
+  @each $color in "blue", "green", "yellow" {
     & > section:nth-of-type(4n + #{$i}) {
       @include section-color.set($color);
     }
@@ -47,9 +47,16 @@ main {
   }
 
   h1 {
-    color: var(--color-red-light);
-    margin-bottom: 1.3rem;
-    line-height: 100%;
+    color: var(--section-color);
+    background: linear-gradient(to bottom, var(--section-color), color-mix(in srgb, var(--section-color-alt), var(--section-color)));
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 1rem;
+    line-height: 120%;
+  }
+
+  h2 {
+    margin-top: 1.5em;
   }
 
   h2,
@@ -58,11 +65,35 @@ main {
   h5,
   h6 {
     color: var(--section-color);
-    margin-top: 1.5em;
-    margin-bottom: 1.3rem;
+    background: linear-gradient(to bottom, var(--section-color), color-mix(in srgb, var(--section-color-alt), var(--section-color)));
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-top: 1em;
+    margin-bottom: 1rem;
 
     > a {
+      color: var(--section-color);
+      
+      code {
+        background: linear-gradient(to bottom, var(--section-color), color-mix(in srgb, var(--section-color-alt), var(--section-color)));
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        position: relative;
+        &::before {
+          content: "";
+          position: absolute;
+          background-color: var(--section-color-alt-dim); 
+          top:0;
+          left:0;
+          bottom:0;
+          right:0;
+          border-radius: 1em;
+          z-index:-1;
+        }
+      }
+
       &:hover {
+        color: var(--section-color);
         text-decoration: none;
 
         &::before {
@@ -98,7 +129,7 @@ main {
   }
 
   li::marker {
-    color: var(--section-color);
+    color: var(--section-color-alt);
     font-size: 1.2rem;
   }
 
@@ -180,10 +211,11 @@ main {
     position: relative;
     margin: 2rem 0;
     border: 1px solid var(--section-color);
-    background-color: var(--color-background);
+    background-color: color-mix(in srgb, var(--section-color-dim) 20%, var(--color-background));
+    background-image: linear-gradient(to bottom left, color-mix(in srgb, var(--section-color-dim) 24%, var(--color-background)), color-mix(in srgb, var(--section-color-dim) 8%, var(--color-background)));
     padding: 1rem;
     padding-bottom: 0;
-    border-radius: 1rem;
+    border-radius: 0.5rem;
     min-height: 9rem;
     &::after {
       position: absolute;

--- a/src/tags/app-menu/app-menu.module.scss
+++ b/src/tags/app-menu/app-menu.module.scss
@@ -67,7 +67,10 @@ $fixed-controls-height: 6rem;
   strong {
     font-weight: 500;
     text-transform: uppercase;
-    color: var(--color-red-light);
+    color: var(--color-red);
+    background: linear-gradient(to bottom, var(--color-red), color-mix(in srgb, var(--color-red-alt), var(--color-red)));
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
 }
 


### PR DESCRIPTION
Docs styling updates

- Adjusted heading font-sizes to match figma sizes relative to paragraph font-size
- Adjusted heading spacing
- Subtle gradients on headings
- Switch heading colors to be in hue order (red, blue, ~yellow~ _green_, ~green~ _yellow_)
- Use the appropriate red for light/dark for category and page headings
- Background for markdown alerts (tip, note, warning, important)

| BEFORE | AFTER |
|---------|--------|
|<img width="1728" alt="Image" src="https://github.com/user-attachments/assets/bad342b8-a1bd-4ffa-aa90-eca7cbbdd913" /> | <img width="1728" alt="Image" src="https://github.com/user-attachments/assets/637d4910-4968-417f-949f-9c8d6ad2d58a" />|
|<img width="1728" alt="Image" src="https://github.com/user-attachments/assets/6dd17839-bcc2-4919-bee8-078b2f78ac3a" />|<img width="1728" alt="Image" src="https://github.com/user-attachments/assets/0674826c-5cfb-4497-9d0b-e5978a13bff0" />|
|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/95f42f16-be51-46b9-b90e-4a4d538a444d" />|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a59ff4cf-014a-4181-99fa-ac99d4a0bab3" />|
|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/32bea3d7-4249-4522-b60c-debd4d27e7e5" />|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2e95ca47-92f4-4e07-8e2c-4b06353edc77" />|
