### PR TITLE
fix: style main page scrollbar for consistency with section ones

### DIFF
--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -10,7 +10,9 @@
 :root {
   --root-min-gap: 1rem;
   --root-max-width: 80rem;
-  --root-gap: calc(max(var(--root-min-gap), (100dvw - var(--root-max-width)) / 2));
+  --root-gap: calc(
+    max(var(--root-min-gap), (100dvw - var(--root-max-width)) / 2)
+  );
 }
 
 * {
@@ -69,6 +71,10 @@ p {
 ::selection {
   background-color: var(--color-selection-background);
   color: var(--color-selection-foreground);
+}
+
+html {
+  scrollbar-color: var(--color-gray-dim) var(--color-background);
 }
 
 body {


### PR DESCRIPTION
Code blocks have special scrollbar colors:
<img width="548" alt="image" src="https://github.com/user-attachments/assets/113476ce-4561-406f-97ae-3d3780520a4e" />

Why shouldn't the whole page?
| before | after |
| :-----: | :---: |
| <img width="803" alt="image" src="https://github.com/user-attachments/assets/b9702aa6-f864-4505-a455-6e1d7baaa980" /> | <img width="804" alt="image" src="https://github.com/user-attachments/assets/2210d94c-95bf-4569-a4f6-d3df214e9dd6" /> |