### PR TITLE
fix: inline code blocks with underline

### DIFF
--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -11,7 +11,9 @@
 :root {
   --root-min-gap: 1rem;
   --root-max-width: 80rem;
-  --root-gap: calc(max(var(--root-min-gap), (100dvw - var(--root-max-width)) / 2));
+  --root-gap: calc(
+    max(var(--root-min-gap), (100dvw - var(--root-max-width)) / 2)
+  );
 }
 
 * {
@@ -141,8 +143,13 @@ code {
     color: var(--section-color);
     background-color: var(--section-color-alt-dim);
     border-radius: 0.5lh;
-    padding: 0.2rem 0.75ch;
+    padding: 0.2rem 0;
     line-height: 1.8;
+
+    &::before,
+    &::after {
+      content: "\00a0";
+    }
   }
 }
 

--- a/src/routes/docs/+layout.style.module.scss
+++ b/src/routes/docs/+layout.style.module.scss
@@ -91,6 +91,9 @@ main {
         background-clip: text;
         -webkit-text-fill-color: transparent;
         position: relative;
+        padding-left: 0.75ch;
+        padding-right: 0.75ch;
+
         &::before {
           content: "";
           position: absolute;
@@ -98,6 +101,9 @@ main {
           inset: 0;
           border-radius: 1em;
           z-index: -1;
+        }
+        &::after {
+          content: "";
         }
       }
 


### PR DESCRIPTION
Using padding for inline code blocks means that underlines don't look right:

<img width="291" alt="image" src="https://github.com/user-attachments/assets/90c34d8a-0fb8-4264-ae14-c11fe07352f1" />

This is ugly, and also clicking _on_ the padding doesn't even work as a link!

I fixed this by using `::before` and `::after` with empty spaces instead

<img width="285" alt="image" src="https://github.com/user-attachments/assets/62460ee0-7eb1-4623-b533-cc17c7304a0b" />
