### PR TITLE
fix: links cleanup

### DIFF
--- a/docs/introduction/integrations.md
+++ b/docs/introduction/integrations.md
@@ -15,7 +15,7 @@ If [Prettier](https://prettier.io/) is installed, the official plugin will also 
 
 ## Bundlers
 
-The official recommendation for using Marko in a project is [Marko Run](../marko-run/getting-started.md), which uses [Vite](#vite) and requires no configuration.
+The official recommendation for using Marko in a project is [Marko Run](../marko-run/getting-started.md), which uses [Vite](https://github.com/marko-js/vite) and requires no configuration.
 
 For projects that _aren't_ using Marko Run, the following options are available.
 
@@ -31,4 +31,3 @@ Marko supports most test runners, through [`@marko/testing-library`](https://git
 ## Development
 
 [Storybook](https://storybook.js.org/) can be used to preview components using [`@storybook/marko`](https://github.com/storybookjs/marko).
-

--- a/docs/tutorial/components-and-reactivity.md
+++ b/docs/tutorial/components-and-reactivity.md
@@ -202,7 +202,5 @@ That's all we're going to build for now, but feel free to add more! Here are som
 
 ## Next Steps
 
-- [Marko for Experienced Developers](./experienced-developers.md)
 - [Nested Reactivity](../explanation/nested-reactivity.md)
-- [Publishing Components](../guide/publishing-components.md)
 - [Language Reference](../reference/language.md)

--- a/docs/tutorial/fundamentals.md
+++ b/docs/tutorial/fundamentals.md
@@ -136,4 +136,4 @@ And we can use the [`<for>` tag](../reference/core-tag.md#for) to display repeat
 ## Next Steps
 
 - [Components and Reactivity](./components-and-reactivity.md)
-- [Build an App](./app-from-scratch.md)
+- [Build an App](../marko-run/getting-started.md)


### PR DESCRIPTION
- Remove reference to 404 or empty pages.

I've kept the empty pages (mostly guides) as they are not referenced from anywhere.
I've also kep a few empty sections here and there as they seemed to be used as TODOs