### PR TITLE
docs: translate all documentation to Japanese

### DIFF
--- a/docs/explanation/controllable-components.md
+++ b/docs/explanation/controllable-components.md
@@ -1,17 +1,17 @@
-# Controllable Components
+# 制御可能なコンポーネント
 
 > [!TLDR]
 >
-> - **Controlled** components are driven by `input` props
-> - **Uncontrolled** components are driven by internal state
-> - **Controllable** components can be both controlled _and_ uncontrolled
-> - Marko provides first-class patterns for building controllable components
+> - **制御された**コンポーネントは `input` プロパティによって駆動される
+> - **非制御**コンポーネントは内部状態によって駆動される
+> - **制御可能な**コンポーネントは制御され_かつ_非制御にもなれる
+> - Marko は制御可能なコンポーネントを構築するための第一級のパターンを提供する
 
-In component-based frameworks, developers must know where the _source of truth_ is for state. Typically, a decision is made at the component level about whether it should be [**controlled** or **uncontrolled**](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+コンポーネントベースのフレームワークでは、開発者は状態の_信頼できる情報源_がどこにあるかを知る必要があります。通常、コンポーネントレベルで[**制御された**または**非制御**](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components)のどちらにするかの決定が行われます。
 
-## Uncontrolled Components
+## 非制御コンポーネント
 
-Uncontrolled components manage their own state.
+非制御コンポーネントは自身の状態を管理します。
 
 ```marko
 /* counter.marko */
@@ -22,31 +22,31 @@ Uncontrolled components manage their own state.
 </button>
 ```
 
-Because `<counter>` manages its own state (via `<let>`), it can be used anywhere without extra work.
+`<counter>` は自身の状態を管理する（`<let>` を介して）ため、追加の作業なしでどこでも使用できます。
 
 ```marko
 /* parent.marko */
 <counter/>
 ```
 
-However, since the state is created in `counter.marko`, `count` can _only_ be accessed within the component. This means there's no way for a parent to use the state. For example, how might a parent use this count and display it elsewhere on the page?
+しかし、状態は `counter.marko` 内で作成されるため、`count` はコンポーネント内でのみアクセスできます。つまり、親が状態を使用する方法がありません。例えば、親がこのカウントを使用してページの別の場所に表示するにはどうすればよいでしょうか？
 
 ```marko
 /* parent.marko */
 <counter/>
 
-// 🤔 How can we access `count` out here?
+// 🤔 ここで `count` にアクセスするにはどうすればよいでしょうか？
 <output>${count}</output>
 ```
 
-This isn't possible with only modifications to `parent.marko`! Instead, we need to change `<counter>` to give more **control** to its parent.
+これは `parent.marko` への変更だけでは不可能です！代わりに、`<counter>` を変更して親により多くの**制御**を与える必要があります。
 
-### State synchronization
+### 状態の同期
 
-A naive approach for allowing parents to access state is to trigger events when updates happen.
+親が状態にアクセスできるようにするための単純なアプローチは、更新が発生したときにイベントをトリガーすることです。
 
 > [!WARNING]
-> This is an anti-pattern! It is **almost always better** to use [the controllable pattern](#the-controllable-pattern) for cases like this instead of synchronizing state
+> これはアンチパターンです！このような場合は、状態を同期する代わりに[制御可能なパターン](#the-controllable-pattern)を使用する方が**ほぼ常に優れています**
 
 ```marko
 /* counter.marko */
@@ -63,7 +63,7 @@ export interface Input {
 </button>
 ```
 
-With this event handler, `parent.marko` could keep track of its own copy of `count`.
+このイベントハンドラを使用すると、`parent.marko` は独自の `count` のコピーを追跡できます。
 
 ```marko
 /* parent.marko */
@@ -74,17 +74,17 @@ With this event handler, `parent.marko` could keep track of its own copy of `cou
 <output>${count}</output>
 ```
 
-This approach leaves room for error:
+このアプローチにはエラーの余地があります：
 
-- We have _two_ `count` variables that must stay synchronized
-- If these variables get out of sync, our website will be broken
-- We must track _all_ changes in `<counter>` and synchronize them in the parent
+- _2つ_の `count` 変数を同期させる必要がある
+- これらの変数が同期しなくなると、ウェブサイトは壊れる
+- `<counter>` 内の_すべて_の変更を追跡し、親で同期する必要がある
 
-As we'll discuss later, most stateful [native HTML elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements) use this "uncontrolled with state synchronization" approach by default. Marko [extends](../reference/native-tag.md#change-handlers) these tags to enable [the controllable pattern](#the-controllable-pattern).
+後で説明するように、ほとんどのステートフルな[ネイティブ HTML 要素](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements)は、デフォルトでこの「状態同期を伴う非制御」アプローチを使用しています。Marko はこれらのタグを[拡張](../reference/native-tag.md#change-handlers)して[制御可能なパターン](#the-controllable-pattern)を有効にします。
 
-### Controlled Components
+### 制御されたコンポーネント
 
-Controlled components receive state from their parent and delegate changes back up the component tree.
+制御されたコンポーネントは、親から状態を受け取り、変更をコンポーネントツリーの上位に委譲します。
 
 ```marko
 /* counter.marko */
@@ -98,7 +98,7 @@ export interface Input {
 </button>
 ```
 
-If this `<counter>` component is used directly, it won't be interactive! To manage `<counter>` effectively, we need to _create state in the parent_.
+この `<counter>` コンポーネントを直接使用すると、インタラクティブになりません！`<counter>` を効果的に管理するには、親で状態を_作成_する必要があります。
 
 ```marko
 /* parent.marko */
@@ -110,24 +110,24 @@ If this `<counter>` component is used directly, it won't be interactive! To mana
 />
 ```
 
-This is great because the parent has full control over component state, but it has trade-offs:
+親がコンポーネントの状態を完全に制御できるため、これは素晴らしいことですが、トレードオフがあります：
 
-- _Every_ parent of `<counter>` needs this boilerplate, even if they don't use `count`
-- This refactor was only possible because _we_ authored `<counter>` and can change its API
+- `<counter>` の_すべて_の親にこのボイラープレートが必要であり、たとえ `count` を使用しない場合でも必要
+- このリファクタリングは、_私たち_が `<counter>` を作成し、その API を変更できるからこそ可能だった
 
-## The Controllable Pattern
+## 制御可能なパターン
 
-Ultimately, at _component authoring time_ it's impossible to know whether we want state to be controlled or uncontrolled. It may need to be controlled _sometimes_ but otherwise manage its own state. For these cases, Marko introduces the **controllable** pattern.
+最終的に、_コンポーネント作成時_に状態を制御するか非制御にするかを知ることは不可能です。_時には_制御する必要があるかもしれませんが、それ以外の場合は独自の状態を管理する必要があります。これらのケースのために、Marko は**制御可能な**パターンを導入しています。
 
-Controllable components are [uncontrolled](#uncontrolled-components) by default, but with a change handler they become [controlled](#controlled-components).
+制御可能なコンポーネントは、デフォルトで[非制御](#uncontrolled-components)ですが、変更ハンドラを使用すると[制御された](#controlled-components)ものになります。
 
-Before digging into our `<counter>` example and making it controllable, let's explore what this pattern looks like on native elements.
+`<counter>` の例を掘り下げて制御可能にする前に、このパターンがネイティブ要素でどのように見えるかを探ってみましょう。
 
-### Controllable Native Tags
+### 制御可能なネイティブタグ
 
-Most native HTML elements follow the [uncontrolled](#uncontrolled-components) pattern by default, but Marko enhances them with [change handlers](../reference/native-tag.md#change-handlers) to enable the [controlled](#controlled-components) pattern.
+ほとんどのネイティブ HTML 要素は、デフォルトで[非制御](#uncontrolled-components)パターンに従いますが、Marko は[変更ハンドラ](../reference/native-tag.md#change-handlers)を使用してそれらを拡張し、[制御された](#controlled-components)パターンを有効にします。
 
-To take control of a stateful HTML element, we can add a `Change` handler.
+ステートフルな HTML 要素を制御するには、`Change` ハンドラを追加できます。
 
 ```marko
 <let/textValue="">
@@ -135,9 +135,9 @@ To take control of a stateful HTML element, we can add a `Change` handler.
 <input value=textValue valueChange(v) { textValue = v }>
 ```
 
-Since `valueChange` is present, Marko knows this `<input>` is **controlled** and its value will always derive from `textValue`. This is called **binding**.
+`valueChange` が存在するため、Marko はこの `<input>` が**制御されている**ことを認識し、その値は常に `textValue` から派生します。これは**バインディング**と呼ばれます。
 
-Because this is a common pattern, Marko provides a [binding shorthand](../reference/language.md#shorthand-change-handlers-two-way-binding) using the `:=` operator.
+これは一般的なパターンであるため、Marko は `:=` 演算子を使用した[バインディングの省略記法](../reference/language.md#shorthand-change-handlers-two-way-binding)を提供しています。
 
 ```marko
 <let/textValue="">
@@ -146,11 +146,11 @@ Because this is a common pattern, Marko provides a [binding shorthand](../refere
 ```
 
 > [!NOTE]
-> The [binding shorthand](../reference/language.md#shorthand-change-handlers-two-way-binding) acts differently when used with an _identifier_ versus a _member expression_. Above is the identifier behavior; we'll see the member expression behavior next.
+> [バインディングの省略記法](../reference/language.md#shorthand-change-handlers-two-way-binding)は、_識別子_と_メンバー式_で使用される場合に異なる動作をします。上記は識別子の動作です。次にメンバー式の動作を見ていきます。
 
-### Controllable `<let>`
+### 制御可能な `<let>`
 
-We want our `<counter>` tag to follow the same controllable pattern as native tags like `<input>` in Marko. Let's take advantage of the fact that [`<let>` is _also_ controllable](../reference/core-tag.md#controllable-let).
+`<counter>` タグが、Marko の `<input>` のようなネイティブタグと同じ制御可能なパターンに従うようにしたいと考えています。[`<let>` も制御可能である](../reference/core-tag.md#controllable-let)という事実を利用しましょう。
 
 ```marko
 /* counter.marko */
@@ -166,25 +166,25 @@ export interface Input {
 </button>
 ```
 
-This component now has two behaviors, depending on the `<let>` tag's `valueChange`:
+このコンポーネントは、`<let>` タグの `valueChange` に応じて2つの動作を持つようになりました：
 
-- When `countChange` is a function
-  - `<let>` forfeits control of its state and acts as a derivation of `input.count`
-- When `countChange` is `undefined`
-  - `<let>` acts just as it did in our first example
+- `countChange` が関数の場合
+  - `<let>` は状態の制御を放棄し、`input.count` の派生として機能する
+- `countChange` が `undefined` の場合
+  - `<let>` は最初の例と同様に機能する
 
 ```marko
 /* parent.marko */
 <let/parentCount=0>
 
-// `parentCount` is the source of truth
+// `parentCount` が信頼できる情報源
 <counter count=parentCount countChange(count) { parentCount = count }/>
 
-// This one holds its own state
+// これは独自の状態を保持する
 <counter/>
 ```
 
-The [binding shorthand](../reference/language.md#shorthand-change-handlers-two-way-binding) accommodates both sides of this exchange, as it acts differently for identifiers and member expressions.
+[バインディングの省略記法](../reference/language.md#shorthand-change-handlers-two-way-binding)は、識別子とメンバー式で異なる動作をするため、この交換の両側に対応しています。
 
 ```marko
 /* counter.marko */
@@ -209,11 +209,11 @@ export interface Input {
 <output>${count}</output>
 ```
 
-## More Power
+## より多くの力
 
-The controllable pattern allows the _user_ of a component to decide whether to manage state. Simple cases remain simple, but complex state management is also possible.
+制御可能なパターンにより、コンポーネントの_ユーザー_が状態を管理するかどうかを決定できます。シンプルなケースはシンプルなままですが、複雑な状態管理も可能です。
 
-We've only scratched the surface! When a parent hoists state up, it takes _full_ control. This means we can add a max value:
+表面をなぞっただけです！親が状態を引き上げると、_完全な_制御を得ます。つまり、最大値を追加できます：
 
 ```marko
 /* parent.marko */
@@ -228,7 +228,7 @@ We've only scratched the surface! When a parent hoists state up, it takes _full_
 }/>
 ```
 
-or perform validation:
+または検証を実行できます：
 
 ```marko
 /* parent.marko */
@@ -241,9 +241,9 @@ or perform validation:
 }/>
 ```
 
-The key is that the _parent_ decides what to do with state. If components are designed with the controllable pattern, they can be used in various scenarios without requiring changes to the component itself.
+重要なのは、_親_が状態で何をするかを決定することです。コンポーネントが制御可能なパターンで設計されている場合、コンポーネント自体を変更することなく、さまざまなシナリオで使用できます。
 
-## Further Reading
+## さらに読む
 
-- [Nested Reactivity](./nested-reactivity.md)
-- [Separation of Concerns](./separation-of-concerns.md)
+- [ネストされたリアクティビティ](./nested-reactivity.md)
+- [関心の分離](./separation-of-concerns.md)

--- a/docs/explanation/fine-grained-bundling.md
+++ b/docs/explanation/fine-grained-bundling.md
@@ -1,17 +1,17 @@
-# Fine-Grained Bundling
+# 細粒度バンドリング
 
 > [!TLDR]
-> - Marko bundles only interactive JavaScript at compile time
-> - Static content requires zero client-side JavaScript
-> - Bundle size depends on interactivity, not architecture
+> - Marko はコンパイル時にインタラクティブな JavaScript のみをバンドルする
+> - 静的コンテンツにはクライアント側の JavaScript が不要
+> - バンドルサイズはアーキテクチャではなく、インタラクティビティに依存する
 
-Marko uses **compile-time analysis** to generate minimal JavaScript bundles by identifying which parts of templates actually need interactivity. Instead of shipping entire component trees, only the code necessary for dynamic behavior reaches the browser. This means that Marko is **zero-JS by default**, and interactive pages only ship JavaScript for the parts that truly need it.
+Marko は**コンパイル時解析**を使用して、テンプレートのどの部分が実際にインタラクティビティを必要とするかを識別することで、最小限の JavaScript バンドルを生成します。コンポーネントツリー全体を配信する代わりに、動的な動作に必要なコードのみがブラウザに到達します。つまり、Marko は**デフォルトで JavaScript ゼロ**であり、インタラクティブなページは真に必要な部分に対してのみ JavaScript を配信します。
 
-## Beyond Islands
+## アイランドを超えて
 
-Some frameworks, including older versions of Marko, use the [islands architecture](https://www.patterns.dev/vanilla/islands-architecture/) to reduce JavaScript in each page bundle. Islands are determined at the **component** level, so applications authored in an islands-based framework need clear distinction between _server_ components and _client_ components.
+Marko の古いバージョンを含む一部のフレームワークは、各ページバンドル内の JavaScript を削減するために[アイランドアーキテクチャ](https://www.patterns.dev/vanilla/islands-architecture/)を使用しています。アイランドは**コンポーネント**レベルで決定されるため、アイランドベースのフレームワークで作成されたアプリケーションは、_サーバー_コンポーネントと_クライアント_コンポーネントの明確な区別が必要です。
 
-In Marko 6 the compiler decides which code to is interactive based on the _state_ tree, and only includes what is necessary in the browser bundle. Consider this tag that includes an interactive "watch" button:
+Marko 6 では、コンパイラは_状態_ツリーに基づいてどのコードがインタラクティブかを決定し、ブラウザバンドルに必要なものだけを含めます。インタラクティブな「watch」ボタンを含むこのタグを考えてみましょう：
 
 ```marko
 /* shop-item.marko */
@@ -19,8 +19,8 @@ In Marko 6 the compiler decides which code to is interactive based on the _state
   <h3>${input.name}</h3>
 
   <${input.content}/>
-  
-  // Interactive toggle
+
+  // インタラクティブなトグル
   <let/watching:=input.watching>
   <button onClick() { watching = !watching }>
     ${watching ? "watching" : "watch"}
@@ -28,13 +28,12 @@ In Marko 6 the compiler decides which code to is interactive based on the _state
 </div>
 ```
 
-Only the JavaScript for toggling `watching` and updating the button text is included. JavaScript for rendering static content or creating the button element is not included.
+`watching` をトグルし、ボタンテキストを更新するための JavaScript のみが含まれます。静的コンテンツをレンダリングしたり、ボタン要素を作成したりするための JavaScript は含まれません。
 
-## Automatic Optimization
+## 自動最適化
 
-Marko's compiler automatically determines what needs JavaScript without manual configuration.
+Marko のコンパイラは、手動設定なしで何が JavaScript を必要とするかを自動的に判断します。
 
-Whether an application is structured as one large component or split into many small ones, the bundle size remains the same—determined purely by the amount of interactivity, not by component architecture. The compiler extracts only the interactive portions regardless of how the code is organized. This way, component can be split up according to [separation of concerns](./separation-of-concerns.md).
+アプリケーションが1つの大きなコンポーネントとして構造化されているか、多くの小さなコンポーネントに分割されているかにかかわらず、バンドルサイズは同じままです。つまり、コンポーネントアーキテクチャではなく、純粋にインタラクティビティの量によって決定されます。コンパイラは、コードがどのように構成されているかに関係なく、インタラクティブな部分のみを抽出します。このようにして、コンポーネントは[関心の分離](./separation-of-concerns.md)に従って分割できます。
 
-This creates a development experience where good performance emerges naturally from the compilation process. Architectural decisions become about maintainability and developer experience, while the compiler handles optimization automatically.
-
+これにより、コンパイルプロセスから自然に優れたパフォーマンスが生まれる開発体験が生まれます。アーキテクチャの決定は保守性と開発者体験に関するものになり、コンパイラが自動的に最適化を処理します。

--- a/docs/explanation/immutable-state.md
+++ b/docs/explanation/immutable-state.md
@@ -1,17 +1,17 @@
-# Immutable Data in State
+# 状態における不変データ
 
 > [!TLDR]
-> - Immutable updates prevent hidden side effects
-> - UI as a function of state requires immutability
-> - Server-to-client handoff needs serializable state
+> - 不変更新は隠れた副作用を防ぐ
+> - 状態の関数としての UI には不変性が必要
+> - サーバーからクライアントへの引き渡しにはシリアライズ可能な状態が必要
 
-Marko encourages treating application state as immutable, plain data. This aligns the render model with functional programming: the UI is a deterministic function of inputs and state. It also allows the compiler and runtime to optimize updates and safely hand work between server and client.
+Marko は、アプリケーションの状態を不変のプレーンデータとして扱うことを推奨しています。これにより、レンダリングモデルが関数型プログラミングと整合します：UI は入力と状態の決定論的な関数です。また、コンパイラとランタイムが更新を最適化し、サーバーとクライアント間で安全に作業を引き渡すことができます。
 
-## Immutability
+## 不変性
 
-Immutable updates replace data instead of mutating it in place. This avoids hidden coupling, makes changes easier to reason about, and ensures updates are detected.
+不変更新は、データをその場で変更するのではなく、置き換えます。これにより、隠れた結合を避け、変更を理解しやすくし、更新が確実に検出されるようにします。
 
-Consider this Marko template. Reassigning the array triggers an update; mutating in place does not.
+この Marko テンプレートを考えてみましょう。配列を再割り当てすると更新がトリガーされますが、その場で変更してもトリガーされません。
 
 ```marko
 /* list.marko */
@@ -22,20 +22,20 @@ Consider this Marko template. Reassigning the array triggers an update; mutating
     <li>${item}</li>
   </for>
   <button onClick() {
-    // ❌ BAD: in-place mutation
+    // ❌ 悪い例: その場での変更
     items.push("gamma")
 
-    // ✅ GOOD: immutable update
+    // ✅ 良い例: 不変更新
     items = items.concat("gamma");
   }>Add</button>
 </ul>
 ```
 
-Immutable updates work naturally with Marko's assignment-based reactivity. Replacing a value (object, array, map-like structure) makes change propagation explicit and reliable.
+不変更新は、Marko の代入ベースのリアクティビティと自然に連携します。値（オブジェクト、配列、マップのような構造）を置き換えることで、変更の伝播が明示的で信頼性の高いものになります。
 
-## Functional UI
+## 関数型 UI
 
-In modern UI frameworks, developers are encouraged to view the **rendered output** as a **function of state**. This works when state changes are visible and do not carry implicit side effects. In-place mutation breaks that mental model and can hide when and where the view should update.
+現代の UI フレームワークでは、開発者は**レンダリングされた出力**を**状態の関数**として見るように推奨されています。これは、状態の変更が可視化され、暗黙的な副作用を持たない場合に機能します。その場での変更はそのメンタルモデルを壊し、ビューをいつどこで更新すべきかを隠してしまう可能性があります。
 
 ```marko
 /* profile.marko */
@@ -44,36 +44,36 @@ In modern UI frameworks, developers are encouraged to view the **rendered output
 <p>Hello, ${user.name}! (${user.clicks} clicks)</p>
 
 <button onClick() {
-  // ❌ BAD: in-place mutation
+  // ❌ 悪い例: その場での変更
   user.clicks++;
 
-  // ✅ GOOD: immutable update
+  // ✅ 良い例: 不変更新
   user = { ...user, clicks: user.clicks + 1 };
 }>Visit</button>
 ```
 
-By replacing `user`, the view updates deterministically as a function of the new state.
+`user` を置き換えることで、ビューは新しい状態の関数として決定論的に更新されます。
 
-## Serialization
+## シリアライゼーション
 
-To pass work from server to client, state must be serialized. Only serializable data can be reliably embedded into HTML and later hydrated. Class instances, DOM nodes, and some types of closures cannot be serialized and should not be stored in state.
+サーバーからクライアントに作業を引き渡すには、状態をシリアライズする必要があります。シリアライズ可能なデータのみが、HTML に確実に埋め込まれ、後でハイドレートできます。クラスインスタンス、DOM ノード、一部のタイプのクロージャはシリアライズできないため、状態に保存すべきではありません。
 
 ```marko
 /* cart.marko */
-// ✅ GOOD: serializable data
+// ✅ 良い例: シリアライズ可能なデータ
 <let/cart={ items: [{ id: 1, qty: 2 }] }>
 
-// ❌ BAD: unserializable in state (class/function/DOM)
+// ❌ 悪い例: 状態内でシリアライズ不可能（クラス/関数/DOM）
 <let/cart=new Cart([{ id: 1, qty: 2 }])>
 ```
 
-Keeping state serializable enables streaming HTML on the server and interactive handoff in the browser without brittle custom hydration logic.
+状態をシリアライズ可能に保つことで、サーバー上での HTML のストリーミングと、脆弱なカスタムハイドレーションロジックなしでブラウザでのインタラクティブな引き渡しが可能になります。
 
 > [!TIP]
-> For details on what data is supported and patterns to avoid, see [serializable state](./serializable-state.md)
+> サポートされているデータと避けるべきパターンの詳細については、[シリアライズ可能な状態](./serializable-state.md)を参照してください
 
-## Further Reading
+## さらに読む
 
-- [Reactivity](../reference/reactivity.md)
-- [Nested Reactivity](./nested-reactivity.md)
-- [Fine-Grained Bundling](./fine-grained-bundling.md)
+- [リアクティビティ](../reference/reactivity.md)
+- [ネストされたリアクティビティ](./nested-reactivity.md)
+- [細粒度バンドリング](./fine-grained-bundling.md)

--- a/docs/explanation/let-vs-const.md
+++ b/docs/explanation/let-vs-const.md
@@ -1,6 +1,6 @@
 # `<let>` vs `<const>` vs `static`
 
 > [!TLDR]
-> - [`<let>`](../reference/core-tag.md#let): mutable reactive state
-> - [`<const>`](../reference/core-tag.md#const): derived value, pure, recomputes with dependencies
-> - [`static const`](../reference/language.md#static): module-level constant, initialized once, not reactive
+> - [`<let>`](../reference/core-tag.md#let): 可変なリアクティブ状態
+> - [`<const>`](../reference/core-tag.md#const): 派生値、純粋、依存関係とともに再計算される
+> - [`static const`](../reference/language.md#static): モジュールレベルの定数、一度だけ初期化、リアクティブではない

--- a/docs/explanation/nested-reactivity.md
+++ b/docs/explanation/nested-reactivity.md
@@ -1,15 +1,15 @@
-# Nested Reactivity
+# ネストされたリアクティビティ
 
 > [!TLDR]
-> Three approaches are explored for managing nested state
+> ネストされた状態を管理するための3つのアプローチを探る
 
-It is often the case in application development that state is stored in a top-level object which is then represented and mutated throughout the component tree. This guide will outline 3 ways of handling this type of pattern, using a To-Do List example as a base.
+アプリケーション開発では、状態がトップレベルのオブジェクトに格納され、コンポーネントツリー全体で表現および変更されることがよくあります。このガイドでは、To-Do リストの例をベースとして、このタイプのパターンを処理する3つの方法を概説します。
 
-Each method in this guide is more complex and has more overhead than those before it. Generally, you should use the _least_ complex method that still addresses the needs of your application.
+このガイドの各メソッドは、前のメソッドよりも複雑で、オーバーヘッドが大きくなります。一般的に、アプリケーションのニーズに対応できる_最も_複雑でないメソッドを使用する必要があります。
 
-## Core Example: To-Do List
+## コア例: To-Do リスト
 
-Each example in this guide will build on the following client-side To-Do list application.
+このガイドの各例は、次のクライアント側 To-Do リストアプリケーションをベースにします。
 
 ```marko
 <let/todos=[
@@ -43,11 +43,11 @@ Each example in this guide will build on the following client-side To-Do list ap
 </form>
 ```
 
-## Case 1: Local State
+## ケース 1: ローカル状態
 
-The first rule of nested reactivity is that you should try to avoid nested reactivity. Generally, **state should be managed as close to its uses as possible**. Before jumping right into hoisting state into a global object, _please_ consider whether it actually makes sense to do so.
+ネストされたリアクティビティの最初のルールは、ネストされたリアクティビティを避けるべきだということです。一般的に、**状態は可能な限りその使用場所に近い場所で管理すべきです**。グローバルオブジェクトに状態を引き上げる前に、実際にそうする意味があるかどうかを_必ず_検討してください。
 
-In most cases, it makes more sense to create local state than to add a value to some global store. For example, maybe we want to disable deleting items that haven't yet been completed. For this, we need to hoist state out of the input.
+ほとんどの場合、グローバルストアに値を追加するよりも、ローカル状態を作成する方が理にかなっています。たとえば、まだ完了していない項目の削除を無効にしたい場合があります。このためには、入力から状態を引き上げる必要があります。
 
 ```marko
 <let/todos=[
@@ -74,11 +74,11 @@ In most cases, it makes more sense to create local state than to add a value to 
 </ul>
 ```
 
-Notice that for this feature, there is _no need_ to modify the `todos` object at the top level. State can stay local, so nested reactivity on that object is unnecessary.
+この機能では、トップレベルの `todos` オブジェクトを変更する_必要がない_ことに注意してください。状態はローカルのままでよいため、そのオブジェクトのネストされたリアクティビティは不要です。
 
-## Case 2: Simple Hoisted State
+## ケース 2: シンプルな引き上げられた状態
 
-Sometimes, it _does_ make sense to hoist state up to a global object. Suppose we want to add a feature where clicking a button shows the first item in the list that isn't done yet. For that information to be known, we need to include the state in the `todos` object:
+時には、状態をグローバルオブジェクトに引き上げることが理にかなっている場合_も_あります。ボタンをクリックすると、リスト内でまだ完了していない最初の項目を表示する機能を追加したいとします。その情報を知るには、`todos` オブジェクトに状態を含める必要があります：
 
 ```marko
 <let/todos=[
@@ -107,7 +107,7 @@ Sometimes, it _does_ make sense to hoist state up to a global object. Suppose we
 </ul>
 ```
 
-Modifying state trees directly like this is often tedious and hard to follow, so we could also use a library like [immer](https://immerjs.github.io/immer/) to handle state updates:
+このように状態ツリーを直接変更することは、しばしば面倒で理解しにくいため、[immer](https://immerjs.github.io/immer/) のようなライブラリを使用して状態の更新を処理することもできます：
 
 ```marko
 import { produce } from "immer"
@@ -119,6 +119,6 @@ import { produce } from "immer"
 }>
 ```
 
-## Case 3: Complex Hoisted State
+## ケース 3: 複雑な引き上げられた状態
 
 <!-- TODO: discuss `<mut>` tag -->

--- a/docs/explanation/optimizing-performance.md
+++ b/docs/explanation/optimizing-performance.md
@@ -1,15 +1,15 @@
-# Optimizing Performance
+# パフォーマンスの最適化
 
-## Profiling
+## プロファイリング
 
-### Server-side
+### サーバーサイド
 
-### Client-side
+### クライアントサイド
 
-## Client-side JS Size
+## クライアントサイド JS サイズ
 
-## Promise Passing
+## Promise の受け渡し
 
 ## NODE_ENV
 
-## Reducing Hydration Data
+## ハイドレーションデータの削減

--- a/docs/explanation/separation-of-concerns.md
+++ b/docs/explanation/separation-of-concerns.md
@@ -1,15 +1,15 @@
-# What About Separation of Concerns?
+# 関心の分離について
 
 > [!TLDR]
-> Marko's approach doesn't violate separation of concerns, it applies the principle more correctly than traditional technology-based separation.
+> Marko のアプローチは関心の分離に違反するものではなく、従来の技術ベースの分離よりも正しくこの原則を適用しています。
 
-When developers first encounter Marko's Tags API, which allows tight coupling of component logic with structure and styling, a common concern arises: "Isn't this a violation of separation of concerns?"
+開発者が Marko の Tags API に初めて遭遇したとき、コンポーネントロジックを構造とスタイリングと密接に結合できることから、よくある懸念が生じます：「これは関心の分離に違反しているのではないか？」
 
-This question touches on one of the most fundamental principles in software engineering, but it also reveals a fundamental misunderstanding about what "concerns" actually are.
+この質問は、ソフトウェアエンジニアリングにおける最も基本的な原則の1つに触れていますが、「関心」が実際に何であるかについての根本的な誤解も明らかにしています。
 
-## The Actual Concerns
+## 実際の関心
 
-Consider a simple user interface component: a modal dialog. In traditional file-based separation, we organize it like this:
+シンプルなユーザーインターフェースコンポーネントを考えてみましょう：モーダルダイアログ。従来のファイルベースの分離では、次のように整理します：
 
 ```html
 /* modal.html */
@@ -47,45 +47,45 @@ document.getElementById("open-modal").addEventListener("click", openModal);
 document.getElementById("close-modal").addEventListener("click", closeModal);
 ```
 
-This organization seems to follow separation of concerns, but let's think about what the **_actual concerns_** should be:
+この整理は関心の分離に従っているように見えますが、**_実際の関心_**は何であるべきかを考えてみましょう：
 
-1. **Modal behavior**: Opening, closing, and managing modal state
-2. **Visual presentation**: How the modal appears and animates
-3. **User interaction**: Button clicks, keyboard navigation
-4. **Accessibility**: Focus management, screen reader support
+1. **モーダルの動作**: 開く、閉じる、モーダルの状態を管理する
+2. **視覚的なプレゼンテーション**: モーダルがどのように表示され、アニメーションするか
+3. **ユーザーインタラクション**: ボタンクリック、キーボードナビゲーション
+4. **アクセシビリティ**: フォーカス管理、スクリーンリーダーサポート
 
-Notice something important: **every single concern spans across HTML, CSS, and JavaScript**.
+重要なことに気づきましょう：**すべての関心が HTML、CSS、JavaScript にまたがっています**。
 
-- The modal's opening behavior needs JavaScript logic, CSS display properties, and HTML structure changes
-- Adding a feature like "close on escape key" touches HTML (focus management), CSS (styling), and JavaScript (event handling)
+- モーダルの開く動作には、JavaScript ロジック、CSS display プロパティ、HTML 構造の変更が必要です
+- 「Escape キーで閉じる」などの機能を追加すると、HTML（フォーカス管理）、CSS（スタイリング）、JavaScript（イベント処理）に触れます
 
-**The fundamental problem**: Traditional separation splits by _technology_ (HTML/CSS/JS files), while intent is to split by _functional concerns_.
+**根本的な問題**: 従来の分離は_技術_（HTML/CSS/JS ファイル）で分割しますが、意図は_機能的な関心_で分割することです。
 
-## The Fundamental Problem
+## 根本的な問題
 
-When we separate by technology instead of by concern, we create several serious issues:
+技術で分離する代わりに関心で分離する場合、いくつかの深刻な問題が生じます：
 
-1. **Fragmented Mental Models**
+1. **断片化されたメンタルモデル**
 
-   When you need to understand how the modal works, you must mentally piece together information from three different files. The cognitive overhead increases exponentially with application complexity.
+   モーダルがどのように機能するかを理解する必要がある場合、3つの異なるファイルから情報を精神的につなぎ合わせる必要があります。認知的オーバーヘッドは、アプリケーションの複雑さとともに指数関数的に増加します。
 
-1. **Change Amplification**
+1. **変更の増幅**
 
-   Adding a simple feature like "auto-close modal when clicking outside" requires changes in HTML (event handling structure), CSS (overlay styling), and JavaScript (event listeners). A single logical change becomes scattered across multiple files.
+   「モーダルの外側をクリックしたときに自動的に閉じる」などのシンプルな機能を追加するには、HTML（イベント処理構造）、CSS（オーバーレイスタイリング）、JavaScript（イベントリスナー）の変更が必要です。単一の論理的変更が複数のファイルに分散します。
 
-1. **Broken Encapsulation**
+1. **壊れたカプセル化**
 
-   Components cannot be truly self-contained when their definition is spread across multiple files. Moving or reusing a modal component requires careful coordination of HTML, CSS, and JavaScript files.
+   コンポーネントの定義が複数のファイルに分散している場合、コンポーネントは真に自己完結できません。モーダルコンポーネントを移動または再利用するには、HTML、CSS、JavaScript ファイルの慎重な調整が必要です。
 
-1. **Maintenance Overhead**
+1. **メンテナンスオーバーヘッド**
 
-   When technologies are separated, it becomes difficult to ensure consistency. CSS classes can become orphaned when HTML changes, JavaScript can reference DOM elements that no longer exist, and refactoring becomes a cross-file archaeological expedition.
+   技術が分離されている場合、一貫性を確保することが困難になります。HTML が変更されると CSS クラスが孤立する可能性があり、JavaScript は存在しなくなった DOM 要素を参照する可能性があり、リファクタリングはファイル間の考古学的な探検になります。
 
-## Organize by Functionality
+## 機能性で整理する
 
-Marko's Tags API embraces a different philosophy: **organize code by feature and functionality, not by technology**.
+Marko の Tags API は異なる哲学を受け入れています：**技術ではなく、機能と機能性でコードを整理する**。
 
-Here's how the same modal component looks in Marko:
+同じモーダルコンポーネントが Marko でどのように見えるかを以下に示します：
 
 ```marko
 /* modal.marko */
@@ -113,36 +113,36 @@ Here's how the same modal component looks in Marko:
 </style>
 ```
 
-Notice how everything related to the modal (state management, DOM structure, event handling, styling) is co-located in a single file. This isn't a violation of separation of concerns; it's **better separation of concerns**.
+モーダルに関連するすべて（状態管理、DOM 構造、イベント処理、スタイリング）が単一のファイルに共同配置されていることに注目してください。これは関心の分離に違反するものではありません。**より良い関心の分離**です。
 
-## Separation Boundaries
+## 分離の境界
 
-Instead of separating by technology, Marko encourages separation by actual business concerns:
+技術で分離する代わりに、Marko は実際のビジネス上の関心で分離することを推奨しています：
 
-- **Component boundaries**: Each `.marko` file represents a cohesive piece of functionality
-- **Feature boundaries**: Related components are grouped together
-- **Domain boundaries**: Different parts of your application are logically separated
-- **Abstraction levels**: Lower-level utilities are separated from higher-level components
+- **コンポーネントの境界**: 各 `.marko` ファイルは、まとまりのある機能の一部を表します
+- **機能の境界**: 関連するコンポーネントはグループ化されます
+- **ドメインの境界**: アプリケーションの異なる部分は論理的に分離されます
+- **抽象化レベル**: 低レベルのユーティリティは、高レベルのコンポーネントから分離されます
 
-This approach delivers measurable improvements:
+このアプローチは、測定可能な改善をもたらします：
 
-1. Cognitive Load Reduction
+1. 認知的負荷の削減
 
-   When developers need to understand or modify a feature, everything they need is in one place. There's no mental overhead of tracking relationships across multiple files.
+   開発者が機能を理解または変更する必要がある場合、必要なものはすべて1か所にあります。複数のファイル間の関係を追跡する精神的なオーバーヘッドはありません。
 
-1. Better Encapsulation
+1. より良いカプセル化
 
-   Each component is truly self-contained. You can move a `.marko` file to a different project, and it brings all its dependencies with it.
+   各コンポーネントは真に自己完結しています。`.marko` ファイルを別のプロジェクトに移動でき、すべての依存関係を持ち込みます。
 
-1. Easier Refactoring
+1. より簡単なリファクタリング
 
-   When a component needs to change, all the related code is co-located. There's no risk of forgetting to update a related CSS rule or JavaScript handler in a distant file.
+   コンポーネントを変更する必要がある場合、関連するすべてのコードが共同配置されています。遠くのファイルで関連する CSS ルールや JavaScript ハンドラを更新し忘れるリスクはありません。
 
-1. Natural Scoping
+1. 自然なスコープ
 
-   Styles and behavior are naturally scoped to their component. This eliminates the global scope pollution that plagues traditional approaches.
+   スタイルと動作は、自然にコンポーネントにスコープされます。これにより、従来のアプローチに悩まされるグローバルスコープの汚染が排除されます。
 
-Marko doesn't prescribe where the boundaries should be, it empowers you to define appropriate separations based on your application's needs. For example, if some functionality like the phone input in this form feels like it is becoming too large:
+Marko は境界がどこにあるべきかを規定するのではなく、アプリケーションのニーズに基づいて適切な分離を定義する力を与えます。たとえば、このフォームの電話番号入力のような機能が大きくなりすぎていると感じる場合：
 
 ```marko
 <form>
@@ -162,7 +162,7 @@ Marko doesn't prescribe where the boundaries should be, it empowers you to defin
 </form>
 ```
 
-You can extract it into a separate component:
+別のコンポーネントに抽出できます：
 
 ```marko
 /* index.marko */
@@ -187,23 +187,23 @@ You can extract it into a separate component:
 />
 ```
 
-The framework doesn't force artificial separations. Instead, it provides the tools to separate concerns at the **logical boundaries** that make sense for your specific application.
+フレームワークは人為的な分離を強制しません。代わりに、特定のアプリケーションにとって意味のある**論理的な境界**で関心を分離するためのツールを提供します。
 
-## Common Objections
+## 一般的な異議
 
-At this point, you might have some concerns. Let's address the most common ones:
+この時点で、いくつかの懸念があるかもしれません。最も一般的なものに対処しましょう：
 
-### "This Violates Single Responsibility Principle"
+### 「これは単一責任の原則に違反する」
 
-The Single Responsibility Principle states that a class should have only one reason to change. A Marko component typically _does_ have a single responsibility, which is that it implements one piece of user-facing functionality. The fact that it includes HTML, CSS, and JavaScript doesn't violate SRP any more than a class having both data and methods violates it.
+単一責任の原則は、クラスが変更する理由を1つだけ持つべきだと述べています。Marko コンポーネントは通常、_単一の責任_を持っており、それはユーザー向け機能の1つを実装することです。HTML、CSS、JavaScript を含むという事実は、クラスがデータとメソッドの両方を持つことが SRP に違反しないのと同様に、SRP に違反しません。
 
-A modal component has one responsibility— being a modal. All the HTML structure, CSS styling, and JavaScript behavior serve that single purpose. Splitting these across files doesn't create better separation; it fragments the implementation of a single concern.
+モーダルコンポーネントには1つの責任があります—モーダルであること。すべての HTML 構造、CSS スタイリング、JavaScript の動作は、その単一の目的に役立ちます。これらをファイル間で分割しても、より良い分離は作成されません。単一の関心の実装を断片化するだけです。
 
-### "What About Reusability?"
+### 「再利用性はどうですか？」
 
-Co-location of concerns actually _improves_ reusability. When you want to reuse a component, you get everything it needs in one package. There's no need to hunt down associated CSS files or JavaScript dependencies.
+関心の共同配置は、実際には再利用性を_改善_します。コンポーネントを再利用したい場合、必要なすべてのものを1つのパッケージで取得できます。関連する CSS ファイルや JavaScript の依存関係を探す必要はありません。
 
-Traditional approach:
+従来のアプローチ：
 
 ```sh
 ├── modal.html
@@ -212,64 +212,64 @@ Traditional approach:
 └── modal-theme.css
 ```
 
-Marko approach:
+Marko アプローチ：
 
 ```sh
 └── modal.marko
 ```
 
-### "Large Components Are Unwieldy"
+### 「大きなコンポーネントは扱いにくい」
 
-This is a valid concern, but the solution isn't to separate by technology. It's to break large components into smaller, more focused components. This is exactly the kind of logical separation that Marko encourages.
+これは正当な懸念ですが、解決策は技術で分離することではありません。大きなコンポーネントをより小さく、より焦点を絞ったコンポーネントに分割することです。これはまさに Marko が推奨する種類の論理的分離です。
 
-If your component is getting too large, extract logical sub-components:
+コンポーネントが大きくなりすぎている場合は、論理的なサブコンポーネントを抽出します：
 
 ```marko
-<!-- Instead of one giant user-profile.marko, break it down into multiple components -->
+<!-- 1つの巨大な user-profile.marko の代わりに、複数のコンポーネントに分割します -->
 <user-avatar user=input.user/>
 <user-details user=input.user/>
 <user-actions user=input.user/>
 <user-preferences user=input.user/>
 ```
 
-This maintains component boundaries based on functionality, not technology.
+これは、技術ではなく機能性に基づいてコンポーネントの境界を維持します。
 
-### "This Defies Web Standards"
+### 「これはウェブ標準に逆らう」
 
-Web standards define the technologies (HTML, CSS, JavaScript) but don't dictate how they should be organized in source code. The separation was a limitation of the tools, not a requirement of the standards.
+ウェブ標準は技術（HTML、CSS、JavaScript）を定義しますが、ソースコードでそれらをどのように整理すべきかは規定していません。分離はツールの制限であり、標準の要件ではありませんでした。
 
-Consider that:
+次のことを考えてください：
 
-- **Web Components** co-locate HTML, CSS, and JavaScript in a single custom element
-- **CSS-in-JS** brings styling into JavaScript
-- **Style attributes** have always mixed HTML and CSS
+- **Web Components** は、HTML、CSS、JavaScript を単一のカスタム要素に共同配置します
+- **CSS-in-JS** は、スタイリングを JavaScript に持ち込みます
+- **スタイル属性**は、常に HTML と CSS を混在させてきました
 
-The web platform itself has been moving toward more integrated approaches.
+ウェブプラットフォーム自体が、より統合されたアプローチに向かって進んでいます。
 
-## Industry Trends
+## 業界のトレンド
 
-Marko isn't alone in this approach. The frontend industry has been moving in this direction for years:
+Marko はこのアプローチで孤立していません。フロントエンド業界は何年もこの方向に進んでいます：
 
-- **Vue.js**: Single File Components (SFCs) co-locate template, script, and style
-- **React**: JSX mixes HTML and JavaScript; CSS-in-JS solutions bring styling closer to components
-- **Svelte**: Components include markup, styling, and logic in single files
-- **Angular**: Component decorator co-locates template and styles with the class
+- **Vue.js**: 単一ファイルコンポーネント（SFC）は、テンプレート、スクリプト、スタイルを共同配置します
+- **React**: JSX は HTML と JavaScript を混在させます。CSS-in-JS ソリューションは、スタイリングをコンポーネントに近づけます
+- **Svelte**: コンポーネントは、マークアップ、スタイリング、ロジックを単一のファイルに含めます
+- **Angular**: コンポーネントデコレーターは、テンプレートとスタイルをクラスと共同配置します
 
-Even in other technology stacks, we see similar patterns:
+他の技術スタックでも、同様のパターンが見られます：
 
-- **iOS**: SwiftUI combines layout and behavior
-- **Android**: Jetpack Compose merges UI and logic
-- **Desktop**: Many modern UI frameworks favor component-based approaches
+- **iOS**: SwiftUI はレイアウトと動作を組み合わせます
+- **Android**: Jetpack Compose は UI とロジックを統合します
+- **デスクトップ**: 多くの最新 UI フレームワークは、コンポーネントベースのアプローチを支持します
 
-## Conclusion
+## 結論
 
-Marko's approach isn't about abandoning separation of concerns, it's about applying that principle more thoughtfully. Instead of separating by arbitrary technological boundaries, we separate by logical, functional boundaries that align with how developers actually think about and build user interfaces.
+Marko のアプローチは、関心の分離を放棄することではなく、その原則をより慎重に適用することです。任意の技術的な境界で分離する代わりに、開発者が実際にユーザーインターフェースを考え、構築する方法と一致する論理的で機能的な境界で分離します。
 
-The result is code that's easier to understand, modify, and maintain. Components become true units of functionality rather than fragmented pieces scattered across multiple files. This approach respects the principle that **related things should be close together**, while still maintaining clear separations where they actually matter.
+その結果、理解、変更、維持が容易なコードになります。コンポーネントは、複数のファイルに散在する断片化された部分ではなく、真の機能の単位になります。このアプローチは、**関連するものは近くにあるべき**という原則を尊重しながら、実際に重要な場所で明確な分離を維持します。
 
-The question isn't whether to separate concerns, but **which concerns to separate** and **where to draw the boundaries**. Marko's Tags API gives you the flexibility to make those decisions based on your application's actual needs, not on outdated assumptions about web technology separation.
+問題は、関心を分離するかどうかではなく、**どの関心を分離するか**、**どこに境界を引くか**です。Marko の Tags API は、ウェブ技術の分離に関する時代遅れの仮定ではなく、アプリケーションの実際のニーズに基づいてこれらの決定を行う柔軟性を提供します。
 
-## Further Reading
+## さらに読む
 
-- [Nested Reactivity](./nested-reactivity.md)
-- [Optimizing Performance](./optimizing-performance.md)
+- [ネストされたリアクティビティ](./nested-reactivity.md)
+- [パフォーマンスの最適化](./optimizing-performance.md)

--- a/docs/explanation/serializable-state.md
+++ b/docs/explanation/serializable-state.md
@@ -1,54 +1,54 @@
-# Serializable State
+# シリアライズ可能な状態
 
-Marko seamlessly picks up where the server left off when it comes to events, scripts and client side updates through state.
-In order to do this Marko will attempt to serialize as little data as possible from the server to the client.
+Marko は、イベント、スクリプト、クライアント側の更新に関して、サーバーが中断したところからシームレスに引き継ぎます。
+これを実現するために、Marko はサーバーからクライアントへの可能な限り少ないデータのシリアライズを試みます。
 
-Most standard data types can be serialized, including:
+ほとんどの標準データ型はシリアライズできます。以下が含まれます：
 
-- Primitives: `null`, `boolean`, `number`, `string`, `bigint`
-- Arrays and plain objects with serializable values
-- Dates
+- プリミティブ: `null`, `boolean`, `number`, `string`, `bigint`
+- シリアライズ可能な値を持つ配列とプレーンオブジェクト
+- Date
 - Map, Set
-- Typed arrays and ArrayBuffer/DataView
-- URL and URLSearchParams
-- Additional built-in JS and Browser objects
-  - For a complete list, see the [serializer file](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/html/serializer.ts) from source
+- 型付き配列と ArrayBuffer/DataView
+- URL と URLSearchParams
+- 追加の組み込み JS およびブラウザオブジェクト
+  - 完全なリストについては、ソースの[シリアライザーファイル](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/html/serializer.ts)を参照してください
 
-... and many more.
+... など、さらに多くのデータ型があります。
 
-## Unserializable Data
+## シリアライズ不可能なデータ
 
-Some values cannot be serialized. When these values are encountered the Marko runtime will provide a helpful message to locate the relevant code.
+一部の値はシリアライズできません。これらの値が検出されると、Marko ランタイムは関連するコードを見つけるための役立つメッセージを提供します。
 
-Examples of unserializable data include:
-- Closures (top level functions are fine!)
-- Functions that come from arbitrary javascript code or imports
-- Class instances (except built-ins explicitly supported by the runtime)
-- DOM nodes and elements
+シリアライズ不可能なデータの例：
+- クロージャ（トップレベル関数は問題ありません！）
+- 任意の JavaScript コードまたはインポートから来る関数
+- クラスインスタンス（ランタイムによって明示的にサポートされている組み込みを除く）
+- DOM ノードと要素
 
 > [!NOTE]
-> Most functions and closures _are_ serializable.
-> 
+> ほとんどの関数とクロージャ_は_シリアライズ可能です。
+>
 > ```marko
 > <let/handler=null>
-> <const/onSecondClick() { 
->   // serializable!
+> <const/onSecondClick() {
+>   // シリアライズ可能！
 > }>
-> 
+>
 > <button onClick() { handler?.(); handler = onSecondClick }/>
 > ```
 
 ```marko
-// ❌ BAD: custom class instance in state
+// ❌ 悪い例: 状態内のカスタムクラスインスタンス
 <let/state=new Cart()>
 
-// ❌ BAD: DOM nodes in state
+// ❌ 悪い例: 状態内の DOM ノード
 <let/state={ el: document.body }>
 ```
 
-## Further Reading
+## さらに読む
 
-- [Immutable State](./immutable-state.md)
-- [Reactivity](../reference/reactivity.md)
-- [Fine-Grained Bundling](./fine-grained-bundling.md)
-- [Streaming](./streaming.md)
+- [不変状態](./immutable-state.md)
+- [リアクティビティ](../reference/reactivity.md)
+- [細粒度バンドリング](./fine-grained-bundling.md)
+- [ストリーミング](./streaming.md)

--- a/docs/explanation/streaming.md
+++ b/docs/explanation/streaming.md
@@ -1,72 +1,72 @@
-# HTML Streaming
+# HTML ストリーミング
 
 > [!TLDR]
 >
-> - HTML streaming sends content to browsers incrementally
-> - `<await>` and `<try>` tags enable async rendering
-> - Built-in error handling and loading states are included
+> - HTML ストリーミングはコンテンツをブラウザに段階的に送信する
+> - `<await>` と `<try>` タグは非同期レンダリングを可能にする
+> - 組み込みのエラーハンドリングとローディング状態が含まれる
 
-Marko provides a powerful, yet simple, declarative approach to HTML streaming via `<await>` and `<try>` to improve perceived and real performance of your pages.
+Marko は、`<await>` と `<try>` を介して HTML ストリーミングへの強力でありながらシンプルな宣言的アプローチを提供し、ページの知覚されるパフォーマンスと実際のパフォーマンスを向上させます。
 
-Streaming is the process of transmitting data incrementally as it’s generated. On the web, **HTML streaming** means sending HTML to the browser chunk-by-chunk, as soon as it's ready, rather than waiting until the entire document is completed.
+ストリーミングは、生成されるデータを段階的に送信するプロセスです。ウェブでは、**HTML ストリーミング**とは、ドキュメント全体が完成するまで待つのではなく、準備ができ次第、HTML をブラウザにチャンクごとに送信することを意味します。
 
-In contrast, **buffering** means generating the full HTML page first, and only then sending it to the browser.
+対照的に、**バッファリング**とは、完全な HTML ページを最初に生成し、その後でのみブラウザに送信することを意味します。
 
-## Background & History
+## 背景と歴史
 
-- **Origins of Progressive Rendering**
+- **プログレッシブレンダリングの起源**
 
-  - Browsers supported progressive rendering—the ability to render an partial HTML page—as early as Netscape Navigator 1.0 released in 1994
-  - Chunked transfer encoding—enabling servers to send a partial response—was introduced as part of HTTP/1.1 in 1999
-    - HTTP/2 and HTTP/3 are chunked (technically [framed](https://httpwg.org/specs/rfc7540.html#:~:text=of%20the%20connection.-,frame,-%3A)) by default
-  - Although supported at the protocol level, most high level web libraries across most programming languages have buffered HTML responses
-  - Within the JS ecosystem we've only seen HTML streaming become more mainstream in the 2020s
+  - ブラウザは、1994年にリリースされた Netscape Navigator 1.0 の頃から、部分的な HTML ページをレンダリングする能力であるプログレッシブレンダリングをサポートしていました
+  - チャンク転送エンコーディング（サーバーが部分的なレスポンスを送信できるようにする）は、1999年に HTTP/1.1 の一部として導入されました
+    - HTTP/2 と HTTP/3 はデフォルトでチャンク化されています（技術的には[フレーム化](https://httpwg.org/specs/rfc7540.html#:~:text=of%20the%20connection.-,frame,-%3A)）
+  - プロトコルレベルでサポートされているにもかかわらず、ほとんどのプログラミング言語のほとんどの高レベルウェブライブラリは HTML レスポンスをバッファリングしてきました
+  - JS エコシステム内では、2020年代になってようやく HTML ストリーミングがよりメインストリームになり始めました
 
-- **Marko’s Streaming History**
+- **Marko のストリーミング履歴**
 
-  - Marko has supported streaming [since its inception in 2014](https://innovation.ebayinc.com/stories/async-fragments-rediscovering-progressive-html-rendering-with-marko/)
+  - Marko は[2014年の設立以来](https://innovation.ebayinc.com/stories/async-fragments-rediscovering-progressive-html-rendering-with-marko/)ストリーミングをサポートしています
 
-### Types of HTML Streaming
+### HTML ストリーミングのタイプ
 
-- **In-order streaming**
+- **順序どおりのストリーミング**
 
-  - HTML arrives in the exact order of document structure.
+  - HTML はドキュメント構造の正確な順序で到着します。
 
-- **Out-of-order streaming**
+- **順序どおりでないストリーミング**
 
-  - HTML fragments arrive as data becomes ready, even if out of sequence.
-  - Requires minimal JavaScript client-side to rearrange HTML in correct order.
+  - HTML フラグメントは、シーケンスが順不同であっても、データが準備できると到着します。
+  - クライアント側で HTML を正しい順序に並べ替えるために、最小限の JavaScript が必要です。
 
-## Benefits of Streaming
+## ストリーミングのメリット
 
-### Perceived Performance (User Experience)
+### 知覚されるパフォーマンス（ユーザーエクスペリエンス）
 
-- Users see content immediately, improving engagement.
-- Reduces perceived loading times significantly by showing progressive content.
+- ユーザーは即座にコンテンツを見ることができ、エンゲージメントが向上します。
+- プログレッシブコンテンツを表示することで、知覚される読み込み時間を大幅に短縮します。
 
-### Real Performance (Network & Rendering)
+### 実際のパフォーマンス（ネットワークとレンダリング）
 
-- **Faster Time to First Byte (TTFB)**
-  Content starts arriving sooner, browsers begin parsing immediately.
-- **Earlier Asset Downloads**
-  CSS, fonts, and JavaScript can begin downloading before the entire page HTML completes.
-- **Improved Time to Interactive (TTI)**
-  Users can start interacting with visible components faster.
+- **最初のバイトまでの時間（TTFB）の短縮**
+  コンテンツがより早く到着し始め、ブラウザは即座に解析を開始します。
+- **より早いアセットのダウンロード**
+  ページ全体の HTML が完成する前に、CSS、フォント、JavaScript のダウンロードを開始できます。
+- **インタラクティブになるまでの時間（TTI）の改善**
+  ユーザーは表示されているコンポーネントとより早くインタラクションを開始できます。
 
-### Reduced Server Load
+### サーバー負荷の削減
 
-- Incremental streaming reduces memory usage.
-- Lower latency and increased throughput.
+- 段階的なストリーミングはメモリ使用量を削減します。
+- レイテンシの低下とスループットの向上。
 
-## How to Stream using Marko 6
+## Marko 6 を使用したストリーミング方法
 
-Marko provides intuitive built-in tags to handle asynchronous HTML generation and streaming:
+Marko は、非同期 HTML 生成とストリーミングを処理するための直感的な組み込みタグを提供します：
 
 ### `<await>`
 
-Wait for a promise to render a section of the template
+テンプレートのセクションをレンダリングするために Promise を待機します
 
-**Syntax example:**
+**構文例：**
 
 ```marko
 <await|user|=getUser()>
@@ -75,14 +75,14 @@ Wait for a promise to render a section of the template
 </await>
 ```
 
-- Marko will flush as much HTML content as possible up to an `<await>`
-- Upon resolution of `getUser()`, the remaining HTML will be flushed
+- Marko は `<await>` まで可能な限り多くの HTML コンテンツをフラッシュします
+- `getUser()` が解決されると、残りの HTML がフラッシュされます
 
 ### `<try>`
 
-Manage asynchronous boundaries, handle loading states, and gracefully catch errors within streaming (and non-streaming) HTML.
+非同期境界を管理し、ローディング状態を処理し、ストリーミング（および非ストリーミング）HTML 内でエラーを適切にキャッチします。
 
-**Basic syntax:**
+**基本構文：**
 
 ```marko
 <try>
@@ -102,48 +102,48 @@ Manage asynchronous boundaries, handle loading states, and gracefully catch erro
 
 #### `@placeholder`
 
-- Provides temporary content displayed immediately while asynchronous data is loading.
-- Opts into out of order rendering.
-  - Marko supports rendering HTML fragments as soon as they’re ready, regardless of document order.
-  - Automatically inserts minimal JavaScript to rearrange DOM elements on the client-side for correct final positioning.
+- 非同期データが読み込まれている間、即座に表示される一時的なコンテンツを提供します。
+- 順序どおりでないレンダリングを選択します。
+  - Marko は、ドキュメントの順序に関係なく、準備ができ次第 HTML フラグメントをレンダリングすることをサポートします。
+  - 正しい最終的な配置のために、クライアント側で DOM 要素を並べ替えるための最小限の JavaScript を自動的に挿入します。
 
 #### `@catch`
 
-- Captures and handles runtime errors occurring within rendered content, preventing the entire page from breaking.
+- レンダリングされたコンテンツ内で発生するランタイムエラーをキャプチャして処理し、ページ全体が壊れるのを防ぎます。
 
-## Troubleshooting & Common Pitfalls
+## トラブルシューティングと一般的な落とし穴
 
-### Avoiding Layout Shift (CLS)
+### レイアウトシフトの回避（CLS）
 
-Out-of-order streaming involves temporary placeholders being replaced with real content once it is ready. If not handled properly, this can cause content the user is reading or interacting with to shift, leading to a poor user experience.
+順序どおりでないストリーミングには、準備ができると実際のコンテンツに置き換えられる一時的なプレースホルダーが含まれます。適切に処理されないと、ユーザーが読んでいたりインタラクションしているコンテンツがシフトし、ユーザーエクスペリエンスが低下する可能性があります。
 
-- Use placeholders that reserve the correct amount of space.
-- Utilize loading indicators/skeleton screens that accurately represent the content.
-- Fallback to in-order streaming where it makes sense or content size cannot be determined
+- 正しいスペースを確保するプレースホルダーを使用します。
+- コンテンツを正確に表すローディングインジケーター/スケルトン画面を利用します。
+- 意味がある場合や、コンテンツサイズを決定できない場合は、順序どおりのストリーミングにフォールバックします
 
-### Avoiding Buffering
+### バッファリングの回避
 
-Even though streaming has been supported on the web for decades and more tools are utilizing it, you may still find that some default configurations of third parties may assume a buffered response. Here are some known culprits that may buffer your server’s output HTTP streams:
+ストリーミングは数十年前からウェブでサポートされており、より多くのツールがそれを利用していますが、サードパーティのデフォルト設定の一部は、バッファリングされたレスポンスを前提としている場合があります。以下は、サーバーの出力 HTTP ストリームをバッファリングする可能性のある既知の原因です：
 
-#### Reverse proxies/load balancers
+#### リバースプロキシ/ロードバランサー
 
-- Turn off proxy buffering, or if you can’t, set the proxy buffer sizes to be reasonably small.
-- Make sure the “upstream” HTTP version is 1.1 or higher; HTTP/1.0 and lower do not support streaming.
-- Some software doesn’t support HTTP/2 or higher “upstream” connections at all or very well — if your Node server uses HTTP/2, you may need to downgrade.
-- Check if “upstream” connections are `keep-alive`: overhead from closing and reopening connections may delay responses.
-- For typical modern webpage filesizes, the following bullet points probably won’t matter. But if you want to stream **small chunks of data with the lowest latency**, investigate these sources of buffering:
-  - Automatic gzip/brotli compression may have their buffer sizes set too high; you can tune their buffers to be smaller for faster streaming in exchange for slightly worse compression.
-  - You can [tune HTTPS record sizes for lower latency, as described in High Performance Browser Networking](https://hpbn.co/transport-layer-security-tls/#optimize-tls-record-size).
-  - Turning off MIME sniffing with [the `X-Content-Type-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) header eliminates browser buffering at the very beginning of HTTP responses
+- プロキシバッファリングをオフにするか、できない場合は、プロキシバッファサイズを合理的に小さく設定します。
+- 「アップストリーム」HTTP バージョンが 1.1 以上であることを確認してください。HTTP/1.0 以下はストリーミングをサポートしていません。
+- 一部のソフトウェアは、HTTP/2 以上の「アップストリーム」接続をまったくサポートしていないか、あまりうまくサポートしていません。Node サーバーが HTTP/2 を使用している場合は、ダウングレードが必要になる場合があります。
+- 「アップストリーム」接続が `keep-alive` かどうかを確認してください：接続を閉じて再度開くオーバーヘッドがレスポンスを遅らせる可能性があります。
+- 典型的な現代のウェブページファイルサイズの場合、以下の項目はおそらく重要ではありません。しかし、**最も低いレイテンシで小さなデータチャンクをストリーミングしたい**場合は、以下のバッファリングのソースを調査してください：
+  - 自動 gzip/brotli 圧縮のバッファサイズが高すぎる設定になっている可能性があります。わずかに圧縮が悪化する代わりに、より高速なストリーミングのためにバッファを小さくチューニングできます。
+  - [High Performance Browser Networking で説明されているように、低レイテンシのために HTTPS レコードサイズをチューニング](https://hpbn.co/transport-layer-security-tls/#optimize-tls-record-size)できます。
+  - [`X-Content-Type-Options` ヘッダー](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)で MIME スニッフィングをオフにすると、HTTP レスポンスの最初でのブラウザバッファリングが排除されます
 
 <details>
   <summary><strong>NGiNX</strong></summary>
 
-Most of NGiNX’s relevant parameters are inside [its builtin `http_proxy` module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering):
+NGiNX の関連するパラメータのほとんどは[組み込みの `http_proxy` モジュール](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering)内にあります：
 
 ```
-proxy_http_version 1.1; # 1.0 by default
-proxy_buffering off; # on by default
+proxy_http_version 1.1; # デフォルトは 1.0
+proxy_buffering off; # デフォルトは on
 ```
 
 </details>
@@ -151,24 +151,24 @@ proxy_buffering off; # on by default
 <details>
   <summary><strong>Apache</strong></summary>
 
-Apache’s default configuration works fine with streaming, but your host may have it configured differently. The relevant Apache configuration is inside [its `mod_proxy` and `mod_proxy_*` modules](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html) and their [associated environment variables](https://httpd.apache.org/docs/2.4/env.html).
+Apache のデフォルト設定はストリーミングで問題なく動作しますが、ホストが異なる設定をしている可能性があります。関連する Apache 設定は[`mod_proxy` および `mod_proxy_*` モジュール](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html)と、それらの[関連する環境変数](https://httpd.apache.org/docs/2.4/env.html)内にあります。
 
 </details>
 
-#### CDNs
+#### CDN
 
-Content Delivery Networks (CDNs) consider efficient streaming one of their best features, but it may be off by default or if certain features are enabled.
+コンテンツデリバリーネットワーク（CDN）は、効率的なストリーミングを最良の機能の1つと考えていますが、デフォルトでオフになっているか、特定の機能が有効になっている場合があります。
 
 <details>
   <summary><strong>Fastly (Varnish)</strong></summary>
 
-For Fastly or another provider that uses VCL configuration, check [if backend responses have `beresp.do_stream = true` set](https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-do-stream/).
+Fastly または VCL 設定を使用する別のプロバイダーの場合、[バックエンドレスポンスに `beresp.do_stream = true` が設定されているかどうか](https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-do-stream/)を確認してください。
 
 </details>
 <details>
   <summary><strong>Akamai</strong></summary>
 
-Some [Akamai features designed to mitigate slow backends can ironically slow down fast chunked responses](https://community.akamai.com/customers/s/question/0D50f00006n975d/enabling-chunked-transfer-encoding-responses). Try toggling off Adaptive Acceleration, Ion, mPulse, Prefetch, and/or similar performance features. Also check for the following in the configuration:
+遅いバックエンドを軽減するように設計された[一部の Akamai 機能は、皮肉なことに高速チャンクレスポンスを遅くする可能性があります](https://community.akamai.com/customers/s/question/0D50f00006n975d/enabling-chunked-transfer-encoding-responses)。Adaptive Acceleration、Ion、mPulse、Prefetch、および/または類似のパフォーマンス機能をオフにしてみてください。また、設定内で以下を確認してください：
 
 ```
 <network:http.buffer-response-v2>off</network:http.buffer-response-v2>
@@ -176,9 +176,9 @@ Some [Akamai features designed to mitigate slow backends can ironically slow dow
 
 </details>
 
-#### Node.js itself
+#### Node.js 自体
 
-For extreme cases where [Node streams very small HTML chunks with its built-in compression modules](https://github.com/marko-js/marko/pull/1641), you may need to tweak the compressor stream settings. Here’s an example with `createGzip` and its `Z_PARTIAL_FLUSH` flag:
+[Node が組み込みの圧縮モジュールで非常に小さな HTML チャンクをストリーミングする](https://github.com/marko-js/marko/pull/1641)極端なケースでは、コンプレッサーストリーム設定を調整する必要がある場合があります。以下は `createGzip` とその `Z_PARTIAL_FLUSH` フラグの例です：
 
 ```js
 import http from "http";

--- a/docs/explanation/targeted-compilation.md
+++ b/docs/explanation/targeted-compilation.md
@@ -1,20 +1,19 @@
-# Targeted Compilation
+# ターゲット コンパイル
 
 > [!TLDR]
-> - Marko chooses what to compile to based on the environment
-> - String concatenation on the server
-> - DOM manipulation on the client
+> - Marko は環境に基づいて何をコンパイルするかを選択する
+> - サーバー上での文字列連結
+> - クライアント上での DOM 操作
 
-Marko's compiler intelligently generates different code based on the target environment, optimizing templates for their specific runtime constraints. This dual-target approach ensures maximum performance on both server and client without compromising developer experience or forcing architectural decisions.
+Marko のコンパイラは、ターゲット環境に基づいて異なるコードをインテリジェントに生成し、特定のランタイム制約に合わせてテンプレートを最適化します。このデュアルターゲットアプローチにより、開発者体験を損なったり、アーキテクチャの決定を強制したりすることなく、サーバーとクライアントの両方で最大のパフォーマンスを保証します。
 
-Instead of using a one-size-fits-all compilation strategy, Marko recognizes that server-side rendering and client-side interactions have fundamentally different
-performance characteristics and optimization opportunities.
+万能のコンパイル戦略を使用する代わりに、Marko はサーバーサイドレンダリングとクライアントサイドのインタラクションが根本的に異なるパフォーマンス特性と最適化の機会を持っていることを認識しています。
 
-## Server Compilation
+## サーバーコンパイル
 
-On the server, templates compile to string concatenation operations that build HTML through efficient string manipulation, avoiding DOM creation overhead entirely.
+サーバー上では、テンプレートは効率的な文字列操作を通じて HTML を構築する文字列連結操作にコンパイルされ、DOM 作成のオーバーヘッドを完全に回避します。
 
-Consider this Marko template:
+この Marko テンプレートを考えてみましょう：
 
 ```marko
 /* article.marko */
@@ -26,20 +25,20 @@ Consider this Marko template:
 </article>
 ```
 
-The compiler pre-computes static markup, escapes and inserts dynamic values, and translates conditional logic to minimal branching that writes the appropriate HTML segments. Advanced optimizations include pre-evaluating static portions and ensuring server code works seamlessly with Marko's [HTML streaming](./streaming.md) capabilities.
+コンパイラは静的マークアップを事前計算し、動的値をエスケープして挿入し、条件ロジックを適切な HTML セグメントを書き込む最小限の分岐に変換します。高度な最適化には、静的部分の事前評価と、サーバーコードが Marko の [HTML ストリーミング](./streaming.md) 機能とシームレスに連携することの保証が含まれます。
 
-## Client Compilation
+## クライアントコンパイル
 
-When templates need interactivity, client compilation takes a different approach. Instead of generating full HTML rendering code, it produces minimal JavaScript for targeted DOM updates.
+テンプレートがインタラクティビティを必要とする場合、クライアントコンパイルは異なるアプローチを取ります。完全な HTML レンダリングコードを生成する代わりに、ターゲット DOM 更新のための最小限の JavaScript を生成します。
 
-Consider this interactive version of the previous example:
+前の例のインタラクティブバージョンを考えてみましょう：
 
 ```marko
 /* article.marko */
 <article>
   <h2>${input.title}</h2>
 
-  // Interactive like toggle
+  // インタラクティブなライクトグル
   <let/liked:=input.liked>
   <button class=liked && 'liked' onClick() { liked = !liked }>
     ${liked ? '❤️ liked' : '🤍 like'}
@@ -47,22 +46,22 @@ Consider this interactive version of the previous example:
 </article>
 ```
 
-The compiler generates minimal JavaScript focused exclusively on interactive portions: reactive state for declared variables, targeted update functions that modify only affected DOM nodes, and event handlers that trigger necessary updates.
+コンパイラは、インタラクティブな部分に専念する最小限の JavaScript を生成します：宣言された変数のリアクティブ状態、影響を受ける DOM ノードのみを変更するターゲット更新関数、必要な更新をトリガーするイベントハンドラ。
 
-Static content such as `${input.title}` produces no client-side JavaScript because it does not change after initial render.
+`${input.title}` のような静的コンテンツは、初期レンダリング後に変更されないため、クライアント側の JavaScript を生成しません。
 
-## Environment Coordination
+## 環境の調整
 
-Server and client compilation work together seamlessly. The server renders complete initial HTML while the client receives only the minimal JavaScript needed for interactivity. This pattern aligns with [fine-grained bundling](./fine-grained-bundling.md).
+サーバーとクライアントのコンパイルはシームレスに連携します。サーバーは完全な初期 HTML をレンダリングし、クライアントはインタラクティビティに必要な最小限の JavaScript のみを受け取ります。このパターンは[細粒度バンドリング](./fine-grained-bundling.md)と整合します。
 
-Consider a tabs component that mixes static and interactive content:
+静的コンテンツとインタラクティブコンテンツを混在させたタブコンポーネントを考えてみましょう：
 
 ```marko
 /* tabs.marko */
-// Static
+// 静的
 <h1>${input.title}</h1>
 
-// Interactive
+// インタラクティブ
 <let/active=0>
 <div>
   <for|section, i| of=input.section>
@@ -75,22 +74,22 @@ Consider a tabs component that mixes static and interactive content:
   </for>
 </div>
 
-// Static content dependent on interactive state
+// インタラクティブ状態に依存する静的コンテンツ
 <for|section, i| of=input.section>
   <div hidden=(i !== active)>${section.content}</div>
 </for>
 ```
 
-Server compilation renders the initial HTML, including the header and initial tab state. Client compilation generates JavaScript only for tab switching and visibility updates. The bundle includes no code for rendering the static header or static tab content.
+サーバーコンパイルは、ヘッダーと初期タブ状態を含む初期 HTML をレンダリングします。クライアントコンパイルは、タブの切り替えと可視性の更新のためだけに JavaScript を生成します。バンドルには、静的ヘッダーや静的タブコンテンツをレンダリングするためのコードは含まれません。
 
-## Benefits
+## メリット
 
-Targeted compilation delivers compound performance benefits that improve as applications scale.
+ターゲットコンパイルは、アプリケーションがスケールするにつれて改善される複合的なパフォーマンスメリットを提供します。
 
-Components are written once using natural syntax, while the compiler handles environment-specific optimizations automatically. There is no need to maintain separate server and client implementations or coordinate between different rendering approaches.
+コンポーネントは自然な構文を使用して一度だけ記述され、コンパイラが環境固有の最適化を自動的に処理します。別々のサーバーとクライアントの実装を維持したり、異なるレンダリングアプローチ間で調整したりする必要はありません。
 
-Server-side rendering achieves maximum throughput through string operations, while client-side updates achieve minimum overhead through targeted DOM manipulation. Each environment gets code optimized for its specific constraints.
+サーバーサイドレンダリングは文字列操作を通じて最大のスループットを達成し、クライアントサイドの更新はターゲット DOM 操作を通じて最小限のオーバーヘッドを達成します。各環境は、その特定の制約に最適化されたコードを取得します。
 
-Only interactive portions of applications generate client-side JavaScript, creating naturally optimal bundle sizes that scale with actual interactivity rather than codebase size. Applications function completely without JavaScript and enhance progressively, supporting diverse user environments while maintaining full functionality for all users.
+アプリケーションのインタラクティブな部分のみがクライアント側の JavaScript を生成するため、コードベースのサイズではなく実際のインタラクティビティに応じてスケールする自然に最適なバンドルサイズが作成されます。アプリケーションは JavaScript なしで完全に機能し、段階的に拡張されるため、すべてのユーザーに完全な機能を維持しながら、多様なユーザー環境をサポートします。
 
-This compilation strategy exemplifies Marko's philosophy of shifting complexity from runtime to build time, allowing developers to focus on features while the compiler automatically handles performance optimization across execution environments.
+このコンパイル戦略は、ランタイムからビルド時に複雑さをシフトするという Marko の哲学を体現しており、開発者が機能に集中できるようにしながら、コンパイラが実行環境全体でパフォーマンスの最適化を自動的に処理します。

--- a/docs/guide/duplicate-form-submissions.md
+++ b/docs/guide/duplicate-form-submissions.md
@@ -1,3 +1,3 @@
-# Preventing Multiple Form Submissions
+# 複数回のフォーム送信を防ぐ
 
-This guide will discuss disabling buttons & forms after the first submission.
+このガイドでは、最初の送信後にボタンとフォームを無効にする方法について説明します。

--- a/docs/guide/library-integration.md
+++ b/docs/guide/library-integration.md
@@ -1,8 +1,8 @@
-# Library Integration
+# ライブラリ統合
 
-## Framework-agnostic Libraries
+## フレームワークに依存しないライブラリ
 
-Use `<lifecycle>` tag
+`<lifecycle>`タグを使用します
 
 ```marko
 import Map from "map"
@@ -20,12 +20,12 @@ import Map from "map"
 />
 ```
 
-## Marko Libraries
+## Markoライブラリ
 
-## Web Component Libraries
+## Web Componentライブラリ
 
-### Consuming in Marko
+### Markoでの使用
 
-### Using Marko in a Web Component
+### Web ComponentでのMarkoの使用
 
-### Wrapping Imperative APIs
+### 命令型APIのラップ

--- a/docs/guide/low-level-apis.md
+++ b/docs/guide/low-level-apis.md
@@ -1,7 +1,7 @@
-# Low-Level APIs
+# 低レベルAPI
 
-Marko's compiler provides the capabilities to write custom migrators and translators for when the core language does not cover your use cases. You should only do this when you absolutely need it, as the goal of the Marko language is to be generic enough that you can accomplish all web tasks without workarounds.
+Markoのコンパイラは、コア言語がユースケースをカバーしない場合に、カスタムマイグレーターやトランスレーターを作成する機能を提供します。Marko言語の目標は、回避策なしにすべてのWebタスクを達成できるほど汎用的であることであるため、これは絶対に必要な場合にのみ行うべきです。
 
-## Writing a Migrator
+## マイグレーターの作成
 
-## Writing a Translator
+## トランスレーターの作成

--- a/docs/guide/marko-5-interop.md
+++ b/docs/guide/marko-5-interop.md
@@ -1,3 +1,3 @@
-# Using Marko 5 and Marko 6 together
+# Marko 5とMarko 6を一緒に使用する
 
-All Marko 5 apps are equipped to use tags API components without any changes. To use both Marko 5 and Marko 6 together, ensure that Marko 5 is installed at the project root.
+すべてのMarko 5アプリは、変更なしでTags APIコンポーネントを使用できるように装備されています。Marko 5とMarko 6を一緒に使用するには、プロジェクトルートにMarko 5がインストールされていることを確認してください。

--- a/docs/guide/publishing-components.md
+++ b/docs/guide/publishing-components.md
@@ -1,5 +1,5 @@
-# Publishing Components
+# コンポーネントの公開
 
-## Best Practices
+## ベストプラクティス
 
-## Storybook Integration
+## Storybook統合

--- a/docs/guide/styling.md
+++ b/docs/guide/styling.md
@@ -1,16 +1,16 @@
-# Styling
+# スタイリング
 
-This section explains some different ways to style HTML within Marko. From simple inline styles to powerful techniques like CSS Modules for organized and maintainable stylesheets.
+このセクションでは、Marko 内で HTML をスタイリングするためのいくつかの異なる方法を説明します。シンプルなインラインスタイルから、整理された保守可能なスタイルシートのための CSS モジュールのような強力な手法まで。
 
-## Inline Styles
+## インラインスタイル
 
-Marko [enhances the HTML `<style>` tag](../reference/core-tag.md#style) to be processed and optimized by the [bundler used in the project](TODO). A template may specify any number of `<style>` tags.
+Marko は[HTML `<style>` タグを拡張](../reference/core-tag.md#style)して、[プロジェクトで使用されているバンドラー](TODO)によって処理および最適化されるようにします。テンプレートは任意の数の `<style>` タグを指定できます。
 
-By default, all styles defined in the template are **globally scoped**. As such, many Marko projects use patterns like [BEM](https://getbem.com/introduction/) to avoid name conflicts.
+デフォルトでは、テンプレートで定義されたすべてのスタイルは**グローバルスコープ**です。そのため、多くの Marko プロジェクトは[BEM](https://getbem.com/introduction/)のようなパターンを使用して名前の競合を回避しています。
 
 ```marko
 <style>
-  /* Bundled and loaded once */
+  /* 一度バンドルされ、読み込まれる */
   .fancy {
     color: green;
   }
@@ -19,7 +19,7 @@ By default, all styles defined in the template are **globally scoped**. As such,
 <div class="fancy">Hello!</div>
 ```
 
-The `<style>` may include a file extension to enable css preprocessors such as [scss](https://sass-lang.com/documentation/syntax/#scss) and [less](https://lesscss.org/).
+`<style>` には、[scss](https://sass-lang.com/documentation/syntax/#scss) や [less](https://lesscss.org/) などの CSS プリプロセッサを有効にするためのファイル拡張子を含めることができます。
 
 ```marko
 <style.scss>
@@ -43,9 +43,9 @@ The `<style>` may include a file extension to enable css preprocessors such as [
 <div class="fancy-less">Hello!</div>
 ```
 
-### Inline CSS Modules
+### インライン CSS モジュール
 
-If the `<style>` tag has a [Tag Variable](../reference/language.md#tag-variables), it leverages [CSS Modules](https://github.com/css-modules/css-modules) to expose its classes as an object.
+`<style>` タグに[タグ変数](../reference/language.md#tag-variables)がある場合、[CSS モジュール](https://github.com/css-modules/css-modules)を活用して、そのクラスをオブジェクトとして公開します。
 
 ```marko
 <style/styles>
@@ -59,9 +59,9 @@ If the `<style>` tag has a [Tag Variable](../reference/language.md#tag-variables
 <div.${styles.foo} />
 ```
 
-This approach allows for scoping of CSS class names without needing to follow naming conventions such as [BEM](https://getbem.com/introduction/).
+このアプローチにより、[BEM](https://getbem.com/introduction/)のような命名規則に従う必要なく、CSS クラス名のスコープを設定できます。
 
-You may still provide a custom file extension to enable to use of preprocessors.
+プリプロセッサを使用するために、カスタムファイル拡張子を提供することもできます。
 
 ```marko
 <style.scss/styles>
@@ -75,9 +75,9 @@ You may still provide a custom file extension to enable to use of preprocessors.
 <div class=styles.fancy>Hello</div>
 ```
 
-## Auto-Discovered Styles
+## 自動検出されるスタイル
 
-Styling files adjacent a [custom tag are automatically discovered](../reference/custom-tag.md#supporting-files). These files are imported and processed the same as [inline styles](#inline-styles).
+[カスタムタグに隣接するスタイリングファイルは自動的に検出されます](../reference/custom-tag.md#supporting-files)。これらのファイルは、[インラインスタイル](#inline-styles)と同じようにインポートおよび処理されます。
 
 ```css
 /* style.css */
@@ -92,11 +92,11 @@ Styling files adjacent a [custom tag are automatically discovered](../reference/
 ```
 
 > [!TIP]
-> When a template is becoming too large it can be helpful to pull its styling into an associated style file such as this.
+> テンプレートが大きくなりすぎた場合、このようにスタイリングを関連するスタイルファイルに抽出すると便利です。
 
-## Imported Styles
+## インポートされたスタイル
 
-Styles may also be [imported](../reference/language.md#import).
+スタイルは[インポート](../reference/language.md#import)することもできます。
 
 ```css
 /* fancy.css */
@@ -113,11 +113,11 @@ import "./fancy.css";
 ```
 
 > [!TIP]
-> Although generally [inline](#inline-styles) or [auto-discovered](#auto-discovered-styles) styles are preferred, importing styles can be helpful when sharing across templates.
+> 一般的には[インライン](#inline-styles)または[自動検出](#auto-discovered-styles)スタイルが好まれますが、テンプレート間で共有する場合は、スタイルをインポートすると便利です。
 
-### Imported CSS Modules
+### インポートされた CSS モジュール
 
-[CSS Module files](https://github.com/css-modules/css-modules) may also be imported.
+[CSS モジュールファイル](https://github.com/css-modules/css-modules)もインポートできます。
 
 ```css
 /* something.module.css */
@@ -133,4 +133,4 @@ import * as styles from "./something.module.css";
 ```
 
 > [!CAUTION]
-> Since most bundlers are configured by default to support css modules for `*.module.css` files, this should work out of the box. If it is not supported by a bundler there is almost certainly a plugin.
+> ほとんどのバンドラーは、デフォルトで `*.module.css` ファイルに対して CSS モジュールをサポートするように設定されているため、これはそのまま動作するはずです。バンドラーでサポートされていない場合でも、ほぼ確実にプラグインがあります。

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -1,21 +1,21 @@
-# Getting Started
+# はじめに
 
 > [!NOTE]
-> This is the documentation for Marko 6 and the Tags API. If you are looking for v5 docs, use the version selector on the bottom left or visit [v5.markojs.com](https://v5.markojs.com/docs/getting-started/).
+> これはMarko 6とTags APIのドキュメントです。v5のドキュメントをお探しの場合は、左下のバージョンセレクターを使用するか、[v5.markojs.com](https://v5.markojs.com/docs/getting-started/)をご覧ください。
 
-Marko re-imagines HTML as a language for building dynamic and reactive user interfaces. Nearly any valid HTML is also valid Marko, but Marko extends the HTML language to enable building modern applications in a declarative way.
+Markoは、動的でリアクティブなユーザーインターフェースを構築するための言語としてHTMLを再構築します。ほぼすべての有効なHTMLは有効なMarkoでもありますが、Markoは宣言的な方法で最新のアプリケーションを構築できるようにHTML言語を拡張します。
 
-## Prerequisite Knowledge
+## 前提知識
 
-Marko's goal is to be easy and accessible for every web developer. Familiarity with the following will help you when developing Marko applications:
+Markoの目標は、すべてのウェブ開発者にとって簡単でアクセスしやすいことです。Markoアプリケーションを開発する際、以下に精通していると役立ちます：
 
 - HTML
 - CSS
 - JavaScript
 
-Numerous guides and tutorials are available online for learning web development. Marko builds on HTML, so everything you learn about HTML can be applied to Marko. For comprehensive guides, some of our favorites include [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML) and [Free Code Camp](https://www.freecodecamp.org/news/introduction-to-html-basics/).
+ウェブ開発を学ぶためのガイドやチュートリアルはオンラインで多数利用できます。MarkoはHTMLをベースに構築されているため、HTMLについて学んだことはすべてMarkoに適用できます。包括的なガイドとして、お気に入りには[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML)や[Free Code Camp](https://www.freecodecamp.org/news/introduction-to-html-basics/)などがあります。
 
-## Next Steps
+## 次のステップ
 
-- [Installation](./installation.md)
-- [Welcome to Marko](./welcome-to-marko.md)
+- [インストール](./installation.md)
+- [Markoへようこそ](./welcome-to-marko.md)

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -1,19 +1,19 @@
-# Install Marko
+# Markoのインストール
 
 > [!NOTE]
-> If you'd like to experiment and learn about Marko directly in your browser, head over to our [Playground](/playground). You can develop a Marko application right there without any local setup.
+> ブラウザで直接Markoを試して学びたい場合は、[Playground](/playground)にアクセスしてください。ローカルセットアップなしでMarkoアプリケーションをすぐに開発できます。
 
-## Prerequisites
+## 前提条件
 
-- [Node.js](https://nodejs.org/en) `v18`, `v20`, `v22` or higher.
-- IDE - We recommend [VS Code](https://code.visualstudio.com/) and our [Official Marko extension](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode)
-- Terminal - You will use the command-line interface (CLI) to set up and start the application.
+- [Node.js](https://nodejs.org/en) `v18`、`v20`、`v22`以降
+- IDE - [VS Code](https://code.visualstudio.com/)と[公式Marko拡張機能](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode)を推奨します
+- ターミナル - コマンドラインインターフェース（CLI）を使用してアプリケーションをセットアップし、起動します
 
-## Marko Run Setup (Recommended)
+## Marko Runのセットアップ（推奨）
 
-[Marko Run](https://github.com/marko-js/run) makes it easy to get started with minimal configuration and is the recommended starting point for a new Marko project. It's the official application framework from the Marko team and powered by [Vite](https://vite.dev/).
+[Marko Run](https://github.com/marko-js/run)は最小限の設定で簡単に始められ、新しいMarkoプロジェクトの推奨開始点です。Markoチームの公式アプリケーションフレームワークで、[Vite](https://vite.dev/)を使用しています。
 
-To set up your project:
+プロジェクトをセットアップするには：
 
 ```bash
 npm init marko -- -t basic
@@ -21,46 +21,46 @@ cd ./my-marko-application
 npm run dev
 ```
 
-Open `src/routes/+page.marko` in your editor to modify the index page. See the [routing documentation](https://github.com/marko-js/run#file-based-routing) to learn how to add additional pages to your project.
+エディタで`src/routes/+page.marko`を開いてインデックスページを編集してください。プロジェクトにページを追加する方法については、[ルーティングドキュメント](https://github.com/marko-js/run#file-based-routing)を参照してください。
 
-## Manual Setup
+## 手動セットアップ
 
-If you prefer to create your own application structure, you can set up your project using your preferred bundler. The Marko team maintains the plugins for [Vite](https://github.com/marko-js/vite), [Webpack](https://github.com/marko-js/webpack), and [Rollup](https://github.com/marko-js/rollup). The following guide will help you set up Vite.
+独自のアプリケーション構造を作成したい場合は、お好みのバンドラを使用してプロジェクトをセットアップできます。Markoチームは[Vite](https://github.com/marko-js/vite)、[Webpack](https://github.com/marko-js/webpack)、[Rollup](https://github.com/marko-js/rollup)のプラグインを保守しています。以下のガイドでは、Viteのセットアップを行います。
 
-1. **Create your project directory**
+1. **プロジェクトディレクトリを作成する**
 
-   Create an empty directory with your project's name and navigate into it:
+   プロジェクト名で空のディレクトリを作成し、その中に移動します：
 
    ```bash
    mkdir my-marko-application
    cd my-marko-application
    ```
 
-   Once inside the directory, initialize your `package.json` file, which is used to manage your project's dependencies:
+   ディレクトリ内で、プロジェクトの依存関係を管理するために使用される`package.json`ファイルを初期化します：
 
    ```bash
    npm init --yes
    ```
 
-1. **Install Marko**
+1. **Markoをインストールする**
 
-   Let's install the dependencies required for Marko.
+   Markoに必要な依存関係をインストールしましょう。
 
-   First, install `marko` 6 as your dependency.
+   まず、`marko` 6を依存関係としてインストールします。
 
    ```bash
    npm install marko@next
    ```
 
-   Next, install Vite and the Marko plugin as development dependencies using the npm `-D` flag:
+   次に、npmの`-D`フラグを使用して、Viteとmarkoプラグインを開発依存関係としてインストールします：
 
    ```bash
    npm install -D vite @marko/vite
    ```
 
-1. **Create the `vite.config.ts` file**
+1. **`vite.config.ts`ファイルを作成する**
 
-   Create `vite.config.ts` file to export the [Vite configuration](https://vite.dev/config/) and add the `marko()` plugin to the `plugins` list.
+   [Vite設定](https://vite.dev/config/)をエクスポートし、`plugins`リストに`marko()`プラグインを追加するために、`vite.config.ts`ファイルを作成します。
 
    ```typescript
    import { defineConfig } from "vite";
@@ -71,9 +71,9 @@ If you prefer to create your own application structure, you can set up your proj
    });
    ```
 
-1. **Create your first Marko page**
+1. **最初のMarkoページを作成する**
 
-   In your text editor, create a `src/routes/index.marko` file. This will be your first Marko page of the project. Copy and paste the following content into the new file:
+   テキストエディタで`src/routes/index.marko`ファイルを作成します。これがプロジェクトの最初のMarkoページになります。新しいファイルに以下の内容をコピー＆ペーストします：
 
    ```marko
    <html lang="en">
@@ -83,17 +83,17 @@ If you prefer to create your own application structure, you can set up your proj
    </html>
    ```
 
-1. **Add a server**
+1. **サーバーを追加する**
 
-   By default, the `marko()` plugin requires the use of [Vite Server Side Rendering (SSR) mode](https://vite.dev/guide/ssr.html#server-side-rendering-ssr) (this can be disabled with the Marko plugin's `linked` option). Therefore, you need to create a server file to start your application. This guide will use [`express`](https://expressjs.com/).
+   デフォルトでは、`marko()`プラグインは[Vite Server Side Rendering (SSR) モード](https://vite.dev/guide/ssr.html#server-side-rendering-ssr)の使用を必要とします（これはMarkoプラグインの`linked`オプションで無効にできます）。したがって、アプリケーションを起動するためにサーバーファイルを作成する必要があります。このガイドでは[`express`](https://expressjs.com/)を使用します。
 
-   First, install `express`:
+   まず、`express`をインストールします：
 
    ```bash
    npm install express
    ```
 
-   Now, create the server logic inside an `index.js` file. This code sets up an Express server and integrates with Vite for handling server-side rendering of a Marko template. For simplicity, this setup is intended for development environments only. For more examples, refer to the [Marko JS examples repository](https://github.com/marko-js/examples/tree/master/examples).
+   次に、`index.js`ファイル内にサーバーロジックを作成します。このコードは、Expressサーバーをセットアップし、Markoテンプレートのサーバーサイドレンダリングを処理するためにViteと統合します。簡単にするために、このセットアップは開発環境専用です。より多くの例については、[Marko JSサンプルリポジトリ](https://github.com/marko-js/examples/tree/master/examples)を参照してください。
 
    ```javascript
    import express from "express";
@@ -122,23 +122,23 @@ If you prefer to create your own application structure, you can set up your proj
    app.listen(3000);
    ```
 
-   Note that `?marko-server-entry` is used to indicate the server code's entry point to the Vite plugin.
+   `?marko-server-entry`は、サーバーコードのエントリーポイントをViteプラグインに示すために使用されることに注意してください。
 
-1. **Start the application**
+1. **アプリケーションを起動する**
 
-   You can now start the application using the command below and access http://localhost:3000 to see the preview of your code while you build your app!
+   以下のコマンドを使用してアプリケーションを起動し、http://localhost:3000 にアクセスして、アプリの構築中にコードのプレビューを確認できます！
 
    ```bash
    node index.js
    ```
 
-## Set up TypeScript
+## TypeScriptのセットアップ
 
-Marko’s TypeScript support offers in-editor error checking, makes refactoring less scary, verifies that data matches expectations, and even helps with API design.
+MarkoのTypeScriptサポートは、エディタ内でのエラーチェック、リファクタリングの不安軽減、データが期待に一致することの検証、さらにはAPI設計の支援を提供します。
 
-Or perhaps you simply want more autocomplete in VS Code—that works too!
+または、単にVS Codeでより多くのオートコンプリートが欲しいだけかもしれません。それもうまくいきます！
 
-To add TypeScript support to your Marko application, add a `tsconfig.json` file in the project's root directory. You can use the following `tsconfig.json` as a starting point:
+MarkoアプリケーションにTypeScriptサポートを追加するには、プロジェクトのルートディレクトリに`tsconfig.json`ファイルを追加します。開始点として以下の`tsconfig.json`を使用できます：
 
 ```json
 {
@@ -161,28 +161,28 @@ To add TypeScript support to your Marko application, add a `tsconfig.json` file 
 }
 ```
 
-For type checking Marko files in the CLI, you can install `@marko/type-check` in your project with the following command:
+CLIでMarkoファイルの型チェックを行うには、以下のコマンドでプロジェクトに`@marko/type-check`をインストールできます：
 
 ```bash
 npm install -D @marko/type-check
 ```
 
-You can then use `mtc` (Marko type check) instead of `tsc`:
+その後、`tsc`の代わりに`mtc`（Marko type check）を使用できます：
 
 ```bash
 mtc
 ```
 
-For more information about working with Marko and TypeScript check [this reference page](../reference/typescript.md).
+MarkoとTypeScriptの使用に関する詳細については、[このリファレンスページ](../reference/typescript.md)をご覧ください。
 
-## IDE Plugin
+## IDEプラグイン
 
-The Marko team maintains a [Marko VS Code extension](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode) that provides Marko syntax highlighting, pretty-printing, TypeScript, IntelliSense, and more.
+Markoチームは、Markoのシンタックスハイライト、整形、TypeScript、IntelliSenseなどを提供する[Marko VS Code拡張機能](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode)を保守しています。
 
-For other editors, you can use the Marko [language server](https://github.com/marko-js/language-server/tree/main) to enhance the developer experience with Marko in your IDE.
+他のエディタの場合、Marko [language server](https://github.com/marko-js/language-server/tree/main)を使用してIDEでのMarkoの開発者エクスペリエンスを向上させることができます。
 
-## Next steps
+## 次のステップ
 
-- [Syntax Fundamentals](../tutorial/fundamentals.md)
-- [Components & Reactivity](../tutorial/components-and-reactivity.md)
-- [Tooling Integrations](./integrations.md)
+- [構文の基礎](../tutorial/fundamentals.md)
+- [コンポーネントとリアクティビティ](../tutorial/components-and-reactivity.md)
+- [ツール統合](./integrations.md)

--- a/docs/introduction/integrations.md
+++ b/docs/introduction/integrations.md
@@ -1,33 +1,33 @@
-# Tooling Integrations
+# ツール統合
 
-In addition to Marko itself, the core team maintains a variety of integrations and other tooling for the language.
+Marko本体に加えて、コアチームは言語のためのさまざまな統合やその他のツールを保守しています。
 
-## Editor Tooling
+## エディタツール
 
-[Marko VSCode](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode) includes _all_ editor tooling, so if it is installed no other editor setup is necessary.
+[Marko VSCode](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode)は_すべての_エディタツールを含んでいるため、インストールすれば他のエディタセットアップは不要です。
 
-The [Language Server](https://github.com/marko-js/language-server) provides syntax highlighting, IntelliSense, type checking, and accessibility hints for Marko files in any editor that supports the Language Server Protocol.
+[Language Server](https://github.com/marko-js/language-server)は、Language Server Protocolをサポートする任意のエディタで、Markoファイルのシンタックスハイライト、IntelliSense、型チェック、アクセシビリティヒントを提供します。
 
 > [!TIP]
-> For more information about type checking in Marko, check out [the TypeScript reference](../reference/typescript.md).
+> Markoの型チェックの詳細については、[TypeScriptリファレンス](../reference/typescript.md)をご覧ください。
 
-If [Prettier](https://prettier.io/) is installed, the official plugin will also provide code formatting out of the box through [`prettier-plugin-marko`](https://github.com/marko-js/prettier).
+[Prettier](https://prettier.io/)がインストールされている場合、公式プラグインは[`prettier-plugin-marko`](https://github.com/marko-js/prettier)を通じてすぐに使えるコードフォーマットも提供します。
 
-## Bundlers
+## バンドラ
 
-The official recommendation for using Marko in a project is [Marko Run](../marko-run/getting-started.md), which uses [Vite](https://github.com/marko-js/vite) and requires no configuration.
+プロジェクトでMarkoを使用する場合の公式推奨は、[Vite](https://github.com/marko-js/vite)を使用し、設定不要の[Marko Run](../marko-run/getting-started.md)です。
 
-For projects that _aren't_ using Marko Run, the following options are available.
+Marko Runを使用_していない_プロジェクトの場合、以下のオプションが利用可能です。
 
 - [Vite](https://github.com/marko-js/vite)
 - [Webpack](https://github.com/marko-js/webpack)
 - [Rollup](https://github.com/marko-js/rollup)
 - [Lasso](https://github.com/lasso-js/lasso-marko)
 
-## Testing
+## テスト
 
-Marko supports most test runners, through [`@marko/testing-library`](https://github.com/marko-js/testing-library). The official examples use [Vitest](https://vitest.dev/), but [Jest](https://jestjs.io/), [Mocha](https://mochajs.org/), and a variety of other testing frameworks may also be used.
+Markoは、[`@marko/testing-library`](https://github.com/marko-js/testing-library)を通じてほとんどのテストランナーをサポートします。公式の例では[Vitest](https://vitest.dev/)を使用していますが、[Jest](https://jestjs.io/)、[Mocha](https://mochajs.org/)、その他さまざまなテストフレームワークも使用できます。
 
-## Development
+## 開発
 
-[Storybook](https://storybook.js.org/) can be used to preview components using [`@storybook/marko`](https://github.com/storybookjs/marko).
+[Storybook](https://storybook.js.org/)は、[`@storybook/marko`](https://github.com/storybookjs/marko)を使用してコンポーネントをプレビューするために使用できます。

--- a/docs/introduction/welcome-to-marko.md
+++ b/docs/introduction/welcome-to-marko.md
@@ -1,24 +1,24 @@
-# Welcome to Marko!
+# Markoへようこそ！
 
-Marko is a language designed to make it easier to write performant and "correct" websites. It offers a unique and compelling approach to web development, built upon core principles and features that set it apart.
+Markoは、パフォーマンスが高く「正確な」ウェブサイトを簡単に作成できるように設計された言語です。ウェブ開発に対して独自で説得力のあるアプローチを提供し、他とは一線を画すコア原則と機能に基づいています。
 
-## What's Missing from Vanilla HTML, CSS, and JavaScript?
+## バニラHTML、CSS、JavaScriptに欠けているものは？
 
-The rise of frameworks in the frontend ecosystem didn't happen for no reason. For complex applications, vanilla technologies fall short in a few important areas.
+フロントエンドエコシステムにおけるフレームワークの台頭は、理由もなく起こったわけではありません。複雑なアプリケーションでは、バニラテクノロジーはいくつかの重要な領域で不足しています。
 
-- **Scalability**: Maintaining large applications is challenging due to the imperative nature of JavaScript and the global scope of CSS
-- **Performance**: Manual DOM manipulation is unwieldy and hard to follow, and it can lead to performance bottlenecks unless executed properly
-- **Maintainability**: Verbose HTML and complex JavaScript logic can make codebases difficult to understand and maintain
+- **スケーラビリティ**: JavaScriptの命令的な性質とCSSのグローバルスコープにより、大規模アプリケーションの保守が困難
+- **パフォーマンス**: 手動でのDOM操作は扱いにくくフォローしづらく、適切に実行されない限りパフォーマンスのボトルネックにつながる可能性がある
+- **保守性**: 冗長なHTMLと複雑なJavaScriptロジックにより、コードベースの理解と保守が困難になる
 
-Frameworks and languages for the web address these issues through concepts like component-based architecture, declarative UI, and managed state. Marko provides a familiar but unique solution for each of these common problems.
+ウェブ向けのフレームワークや言語は、コンポーネントベースアーキテクチャ、宣言的UI、管理された状態などの概念を通じてこれらの問題に対処します。Markoは、これらの一般的な問題に対して、馴染み深くも独自のソリューションを提供します。
 
-## Declarative Language
+## 宣言的言語
 
-Marko embraces a declarative approach, allowing developers to describe what the UI should look like instead of how it should be rendered. This paradigm enables powerful compiler optimizations and simplifies state management.
+Markoは宣言的アプローチを採用しており、開発者がUIをどのようにレンダリングすべきかではなく、どのように見えるべきかを記述できます。このパラダイムにより、強力なコンパイラの最適化が可能になり、状態管理が簡素化されます。
 
-### Components
+### コンポーネント
 
-Marko's component model promotes reusability and modularity, simplifying the construction of complex UIs.
+Markoのコンポーネントモデルは、再利用性とモジュール性を促進し、複雑なUIの構築を簡素化します。
 
 ```marko
 /* hello.marko */
@@ -34,9 +34,9 @@ export interface Input {
 <hello name="Marko"/>
 ```
 
-### State Management
+### 状態管理
 
-The Marko language allows developers to declare state within markup, which automatically propagates updates, while imperative blocks and statements allow for control over side effects.
+Marko言語により、開発者はマークアップ内で状態を宣言でき、更新が自動的に伝播されます。一方、命令的ブロックとステートメントにより、副作用を制御できます。
 
 ```marko
 <let/count=0>
@@ -45,13 +45,13 @@ The Marko language allows developers to declare state within markup, which autom
 </button>
 ```
 
-## Performance-first Architecture
+## パフォーマンス第一のアーキテクチャ
 
-Marko prioritizes performance at the architectural level, maximizing developer experience while ensuring that the experience of the website's users is never sacrificed.
+Markoはアーキテクチャレベルでパフォーマンスを優先し、開発者エクスペリエンスを最大化すると同時に、ウェブサイトのユーザーエクスペリエンスが決して犠牲にならないようにします。
 
-### Targeted Compilation
+### ターゲット化されたコンパイル
 
-Marko compiles every template twice; once for the server, and once for the browser. Server code is optimized for speed, while client code for bundle size. At compile time, the Marko compiler also figures out which parts of your application _need_ to be sent to the client and which can stay on the server.
+Markoはすべてのテンプレートを2回コンパイルします。1回はサーバー用、1回はブラウザ用です。サーバーコードは速度のために最適化され、クライアントコードはバンドルサイズのために最適化されます。コンパイル時に、Markoコンパイラは、アプリケーションのどの部分をクライアントに送信する_必要がある_か、どの部分をサーバーに残せるかも判断します。
 
 ```marko
 <div>
@@ -64,13 +64,13 @@ Marko compiles every template twice; once for the server, and once for the brows
 </div>
 ```
 
-#### Fine-grained Reactivity
+#### きめ細かいリアクティビティ
 
-Marko determines at compile time which changes need to happen to the page whenever state is updated, so granular updates are ensured to improve client-side performance.
+Markoは、状態が更新されるたびにページに必要な変更をコンパイル時に決定するため、きめ細かい更新が保証され、クライアント側のパフォーマンスが向上します。
 
-### Streaming
+### ストリーミング
 
-Marko takes advantage of HTML streaming to send content to the client as soon as it becomes available. Both in-order _and_ out-of-order streaming are supported, enabling developers to decide how to show content as quickly as possible.
+Markoは、コンテンツが利用可能になり次第クライアントに送信するために、HTMLストリーミングを活用します。順序どおりのストリーミング_と_順序に関係ないストリーミングの両方がサポートされており、開発者はコンテンツをできるだけ早く表示する方法を決定できます。
 
 ```marko
 <header>Sent immediately</header>
@@ -79,14 +79,14 @@ Marko takes advantage of HTML streaming to send content to the client as soon as
 </await>
 ```
 
-### Resumability
+### 再開可能性
 
-When Marko streams HTML, it also includes serialized values for state so the client can pick up where the server left off without performing any extra calculations. This ensures a faster time-to-interactive and reduced client-side JavaScript.
+MarkoがHTMLをストリーミングする際、状態のシリアル化された値も含まれるため、クライアントは追加の計算を実行することなく、サーバーが中断したところから続行できます。これにより、インタラクティブになるまでの時間が短縮され、クライアント側のJavaScriptが削減されます。
 
-## The Marko Mindset
+## Markoマインドセット
 
-Marko aims to provide a developer experience that feels as close to writing declarative HTML as possible, while enabling the capabilities of complex applications.
+Markoは、宣言的なHTMLを書くのにできるだけ近い開発者エクスペリエンスを提供しながら、複雑なアプリケーションの機能を可能にすることを目指しています。
 
-## Next Steps
+## 次のステップ
 
-- [Installation](./installation.md)
+- [インストール](./installation.md)

--- a/docs/introduction/why-marko.md
+++ b/docs/introduction/why-marko.md
@@ -1,16 +1,16 @@
-# Why Marko?
+# なぜMarkoなのか？
 
-Marko delivers fast, scalable, robust, and maintainable applications without sacrificing developer experience or user performance. It addresses three fundamental problems in web development by evolving HTML itself rather than replacing it with JavaScript abstractions.
+Markoは、開発者エクスペリエンスやユーザーパフォーマンスを犠牲にすることなく、高速でスケーラブル、堅牢で保守性の高いアプリケーションを提供します。JavaScriptの抽象化で置き換えるのではなく、HTML自体を進化させることで、ウェブ開発における3つの基本的な問題に対処します。
 
-## Three Problems
+## 3つの問題
 
-Modern web development faces a series of interconnected challenges that have shaped the evolution of frontend frameworks. Understanding these problems is essential to evaluating whether current solutions have overcorrected and created new issues.
+最新のウェブ開発は、フロントエンドフレームワークの進化を形成してきた一連の相互接続された課題に直面しています。これらの問題を理解することは、現在のソリューションが過剰に修正され、新しい問題を生み出しているかどうかを評価するために不可欠です。
 
-### HTML Can't Scale
+### HTMLはスケールできない
 
-HTML was designed for static documents, not dynamic applications. This fundamental limitation creates several cascading problems as applications grow in complexity.
+HTMLは動的なアプリケーションではなく、静的なドキュメント用に設計されました。この基本的な制限により、アプリケーションの複雑さが増すにつれて、いくつかの連鎖的な問題が発生します。
 
-HTML provides no mechanism for coordinating dynamic state across different parts of an application. Consider a shopping cart page:
+HTMLは、アプリケーションのさまざまな部分にわたって動的な状態を調整するメカニズムを提供しません。ショッピングカートページを考えてみましょう：
 
 ```html
 /* index.html */
@@ -51,27 +51,27 @@ function addItem(name, price) {
   const navCount = document.getElementById('nav-count');
   const newNavCount = parseInt(navCount.textContent) + 1;
   navCount.textContent = newNavCount;
-  
+
   // Update cart summary
   const cartCount = document.getElementById('cart-count');
   const cartTotal = document.getElementById('cart-total');
-  
+
   cartCount.textContent = newNavCount;
   cartTotal.textContent = parseFloat(cartTotal.textContent) + price;
-  
+
   // Enable checkout button if it was disabled
   const checkout = document.getElementById('checkout');
   if (newNavCount > 0) {
     checkout.disabled = false;
   }
-  
+
   // Any other UI that depends on cart state also needs manual updates...
 }
 ```
 
-Every state change requires manual coordination across multiple DOM elements. The function must update the navigation badge, cart summary, and checkout button state independently. Each UI element that depends on cart state needs explicit updates, and as applications grow, this coordination becomes exponentially complex.
+すべての状態変更には、複数のDOM要素にわたる手動の調整が必要です。この関数は、ナビゲーションバッジ、カートサマリー、チェックアウトボタンの状態を独立して更新する必要があります。カートの状態に依存する各UI要素には明示的な更新が必要であり、アプリケーションが成長するにつれて、この調整は指数関数的に複雑になります。
 
-Componentization presents another challenge. Modern platform features like custom elements and `<template>` tags provide some encapsulation, but introduce their own complexity:
+コンポーネント化は別の課題を提示します。カスタム要素や`<template>`タグのような最新のプラットフォーム機能は、ある程度のカプセル化を提供しますが、独自の複雑さをもたらします：
 
 ```javascript
 /* modal-dialog.js */
@@ -109,13 +109,13 @@ customElements.define('modal-dialog', ModalDialog);
 </modal-dialog>
 ```
 
-While this provides encapsulation, it requires significant boilerplate for basic functionality. State management across components still requires manual coordination, and the imperative API (calling `.open()` and `.close()`) doesn't compose well with reactive data flow.
+これはカプセル化を提供しますが、基本的な機能には大量のボイラープレートが必要です。コンポーネント間の状態管理には依然として手動の調整が必要であり、命令的API（`.open()`と`.close()`の呼び出し）はリアクティブなデータフローとうまく組み合わせることができません。
 
-### Component Coordination
+### コンポーネントの調整
 
-Building reusable, encapsulated components requires significant boilerplate and manual coordination. Even modern platform features like custom elements impose complexity that grows with application requirements, making component development tedious and error-prone.
+再利用可能でカプセル化されたコンポーネントを構築するには、大量のボイラープレートと手動の調整が必要です。カスタム要素のような最新のプラットフォーム機能でさえ、アプリケーション要件とともに増大する複雑さを課し、コンポーネント開発を面倒でエラーが発生しやすいものにします。
 
-Consider implementing a modal component with custom elements:
+カスタム要素でモーダルコンポーネントを実装することを考えてみましょう：
 
 ```javascript
 /* modal-dialog.js */
@@ -152,9 +152,9 @@ customElements.define('modal-dialog', ModalDialog);
 </modal-dialog>
 ```
 
-The component provides encapsulation but requires extensive setup code for basic functionality. State management across components still requires manual coordination, and the imperative API (calling `.open()` and `.close()`) doesn't compose well with reactive data flow.
+このコンポーネントはカプセル化を提供しますが、基本的な機能には広範なセットアップコードが必要です。コンポーネント間の状態管理には依然として手動の調整が必要であり、命令的API（`.open()`と`.close()`の呼び出し）はリアクティブなデータフローとうまく組み合わせることができません。
 
-Component communication becomes increasingly complex. Consider a shopping cart that needs to coordinate between multiple interface elements:
+コンポーネント間の通信はますます複雑になります。複数のインターフェース要素間で調整する必要があるショッピングカートを考えてみましょう：
 
 ```javascript
 // Manual coordination across components
@@ -163,16 +163,16 @@ class CartManager {
     this.items = [];
     this.subscribers = [];
   }
-  
+
   addItem(item) {
     this.items.push(item);
     this.notifySubscribers();
   }
-  
+
   subscribe(callback) {
     this.subscribers.push(callback);
   }
-  
+
   notifySubscribers() {
     this.subscribers.forEach(callback => callback(this.items));
   }
@@ -197,29 +197,29 @@ class CartTotal extends HTMLElement {
 }
 ```
 
-Every component requiring cart data must manually subscribe to updates, handle cleanup, and coordinate its own state. Adding features like quantity management, discounts, or persistence requires touching multiple components and maintaining manual synchronization. The coordination overhead grows exponentially with application complexity.
+カートデータを必要とするすべてのコンポーネントは、更新を手動でサブスクライブし、クリーンアップを処理し、独自の状態を調整する必要があります。数量管理、割引、または永続化などの機能を追加するには、複数のコンポーネントに触れ、手動の同期を維持する必要があります。調整のオーバーヘッドは、アプリケーションの複雑さとともに指数関数的に増大します。
 
-### Runtime Burden
+### ランタイムの負担
 
-Development decisions impose ongoing costs on users rather than developers. Work that could happen once during the build process gets repeated millions of times across user sessions, creating unnecessary overhead that accumulates as applications scale.
+開発の決定は、開発者ではなくユーザーに継続的なコストを課します。ビルドプロセス中に1回で済む作業が、ユーザーセッション全体で何百万回も繰り返され、アプリケーションのスケールとともに蓄積される不必要なオーバーヘッドを生み出します。
 
-Consider template parsing across user sessions. Every user's browser repeats identical analysis:
+ユーザーセッション全体でのテンプレート解析を考えてみましょう。すべてのユーザーのブラウザが同一の分析を繰り返します：
 
 ```javascript
 // This analysis happens for every user, every session
 function processTemplate(template) {
   // Parse component structure
   const ast = parseTemplate(template);
-  
+
   // Identify dynamic parts
   const dynamicNodes = findDynamicNodes(ast);
-  
+
   // Build dependency graph
   const dependencies = analyzeDependencies(dynamicNodes);
-  
+
   // Generate update strategies
   const updatePlan = createUpdatePlan(dependencies);
-  
+
   return { ast, dynamicNodes, dependencies, updatePlan };
 }
 
@@ -229,9 +229,9 @@ const userSession2 = processTemplate(blogTemplate); // Same result
 const userSession3 = processTemplate(blogTemplate); // Same result
 ```
 
-This analysis produces identical results for every user because the template structure is static. The parsing logic, dependency relationships, and update strategies remain constant, yet each browser performs this work independently.
+この分析は、テンプレート構造が静的であるため、すべてのユーザーに対して同一の結果を生成します。解析ロジック、依存関係、更新戦略は一定のままですが、各ブラウザはこの作業を独立して実行します。
 
-Component optimization demonstrates the burden clearly. Simple implementations create ongoing costs, while optimized versions require extensive coordination:
+コンポーネントの最適化は、負担を明確に示します。シンプルな実装は継続的なコストを生み出し、最適化されたバージョンには広範な調整が必要です：
 
 ```javascript
 // Creates burden: every render recalculates everything
@@ -240,7 +240,7 @@ class ProductList extends Component {
     const sortedProducts = this.props.products
       .sort((a, b) => a.price - b.price)  // Repeated calculation
       .filter(p => p.inStock);            // Repeated filtering
-    
+
     return sortedProducts.map(product =>   // Repeated mapping
       `<div class="product">${product.name}: $${product.price}</div>`
     ).join('');
@@ -254,53 +254,53 @@ class OptimizedProductList extends Component {
     this.memoizedSort = framework.createMemo();
     this.virtualizer = framework.createVirtualizer();
   }
-  
+
   render() {
     const sorted = this.memoizedSort(
       () => this.props.products.sort((a, b) => a.price - b.price),
       [this.props.products]
     );
-    
+
     return this.virtualizer.render(sorted, this.renderProduct);
   }
 }
 ```
 
-The burden extends to server-side operations where identical work repeats across requests. Each request rebuilds the same component hierarchies and executes predictable render logic:
+負担はサーバーサイドの操作にも及び、同一の作業がリクエスト全体で繰り返されます。各リクエストは同じコンポーネント階層を再構築し、予測可能なレンダリングロジックを実行します：
 
 ```javascript
 app.get('/product/:id', async (req, res) => {
   // 1. Parse and compile component tree structure
   const componentTree = buildServerComponents();
-  
-  // 2. Resolve data dependencies 
+
+  // 2. Resolve data dependencies
   const productData = await fetchProduct(req.params.id);
   const recommendations = await fetchRecommendations(productData.category);
-  
+
   // 3. Execute render logic
   const html = framework.renderToString('ProductPage', {
     product: productData,
     recommendations: recommendations
   });
-  
+
   // 4. Generate final HTML with boilerplate
   res.send(wrapWithLayout(html));
 });
 ```
 
-Every request performs template compilation, dependency resolution, and HTML generation work that could be pre-computed for static portions. This overhead multiplies across concurrent users, consuming server resources and increasing response times.
+すべてのリクエストは、テンプレートのコンパイル、依存関係の解決、静的部分に対して事前計算できるHTML生成作業を実行します。このオーバーヘッドは同時ユーザー全体で倍増し、サーバーリソースを消費し、応答時間を増加させます。
 
-The burden shifts to users because frameworks prioritize developer convenience over runtime efficiency. Each user pays CPU cycles and battery life for analysis that benefits no one after the first calculation. Applications with millions of users repeat identical computations billions of times, consuming collective resources that could be eliminated through build-time analysis.
+フレームワークがランタイム効率よりも開発者の利便性を優先するため、負担はユーザーに転嫁されます。各ユーザーは、最初の計算後は誰にも利益をもたらさない分析のためにCPUサイクルとバッテリー寿命を支払います。数百万人のユーザーを持つアプリケーションは、同一の計算を数十億回繰り返し、ビルド時の分析によって排除できる集合的なリソースを消費します。
 
-## Three Solutions
+## 3つのソリューション
 
-Marko addresses these problems through fundamental architectural decisions that eliminate the tradeoffs rather than managing them. The approach focuses on extending HTML's capabilities while preserving its strengths.
+Markoは、トレードオフを管理するのではなく排除する基本的なアーキテクチャの決定を通じて、これらの問題に対処します。このアプローチは、HTMLの強みを保持しながら、その機能を拡張することに焦点を当てています。
 
-### Augment HTML
+### HTMLを拡張する
 
-Rather than generating HTML from JavaScript, Marko enhances HTML with the language features modern applications require. This preserves platform alignment while addressing scalability limitations.
+JavaScriptからHTMLを生成するのではなく、Markoは最新のアプリケーションが必要とする言語機能でHTMLを強化します。これにより、スケーラビリティの制限に対処しながら、プラットフォームの整合性が保たれます。
 
-Templates begin as familiar HTML and evolve naturally. Almost all HTML code works as Marko code.
+テンプレートは馴染みのあるHTMLとして始まり、自然に進化します。ほぼすべてのHTMLコードがMarkoコードとして機能します。
 
 ```marko
 /* products.marko */
@@ -311,7 +311,7 @@ Templates begin as familiar HTML and evolve naturally. Almost all HTML code work
 </ul>
 ```
 
-State and control flow integrate directly into the markup:
+状態と制御フローはマークアップに直接統合されます：
 
 ```marko
 /* products.marko */
@@ -323,7 +323,7 @@ State and control flow integrate directly into the markup:
 </ul>
 ```
 
-Asynchronous operations become declarative:
+非同期操作は宣言的になります：
 
 ```marko
 /* products.marko */
@@ -336,24 +336,24 @@ Asynchronous operations become declarative:
       </for>
     </ul>
   </await>
-  
+
   <@placeholder>
     Loading products...
   </@placeholder>
-  
+
   <@catch|error|>
     Failed to load: ${error.message}
   </@catch>
 </try>
 ```
 
-This progression requires no architectural changes. State management becomes part of the markup language, eliminating the conceptual gap between document structure and application logic. The approach preserves HTML's readability and browser compatibility while adding necessary capabilities.
+この進化にはアーキテクチャの変更は必要ありません。状態管理はマークアップ言語の一部となり、ドキュメント構造とアプリケーションロジック間の概念的なギャップが解消されます。このアプローチは、必要な機能を追加しながら、HTMLの可読性とブラウザの互換性を保持します。
 
-### Component Encapsulation
+### コンポーネントのカプセル化
 
-Marko provides true component encapsulation without the boilerplate and complexity of custom elements. Components group related HTML, styling, and behavior into cohesive units that work declaratively rather than imperatively.
+Markoは、カスタム要素のボイラープレートと複雑さなしに、真のコンポーネントカプセル化を提供します。コンポーネントは、関連するHTML、スタイリング、動作を、命令的ではなく宣言的に機能する凝集性のある単位にグループ化します。
 
-The modal component that required extensive custom element setup becomes straightforward:
+広範なカスタム要素のセットアップが必要だったモーダルコンポーネントは、シンプルになります：
 
 ```marko
 /* modal.marko */
@@ -376,7 +376,7 @@ The modal component that required extensive custom element setup becomes straigh
 </style>
 ```
 
-Usage requires no imperative API calls or manual state coordination:
+使用には命令的なAPI呼び出しや手動の状態調整は必要ありません：
 
 ```marko
 <modal>
@@ -384,9 +384,9 @@ Usage requires no imperative API calls or manual state coordination:
 </modal>
 ```
 
-State flows declaratively through the component. Opening and closing behaviors integrate naturally with the markup structure.
+状態はコンポーネントを通じて宣言的に流れます。開閉動作はマークアップ構造と自然に統合されます。
 
-This encapsulation extends to interactive components. Consider a rating component that coordinates between multiple elements:
+このカプセル化はインタラクティブなコンポーネントにも拡張されます。複数の要素間で調整する評価コンポーネントを考えてみましょう：
 
 ```marko
 <let/rating=0>
@@ -394,7 +394,7 @@ This encapsulation extends to interactive components. Consider a rating componen
 
 <div>
   <for|i| from=1 to=5>
-    <button 
+    <button
       class=((hovering || rating) >= i && 'filled')
       onPointerEnter() { hovering = i }
       onPointerLeave() { hovering = 0 }
@@ -415,19 +415,19 @@ This encapsulation extends to interactive components. Consider a rating componen
 </div>
 ```
 
-Component communication happens through props and events rather than global references or manual coordination. State changes propagate automatically to dependent elements without explicit wiring.
+コンポーネント間の通信は、グローバル参照や手動調整ではなく、プロパティとイベントを通じて行われます。状態の変更は、明示的な配線なしで、依存する要素に自動的に伝播します。
 
-### Compile-Time Intelligence
+### コンパイル時のインテリジェンス
 
-Marko's compilation approach enables optimizations that runtime-only solutions cannot achieve. By analyzing templates during the build process, the compiler makes decisions about code generation, dependency tracking, and performance optimizations that would be impossible or expensive at runtime.
+Markoのコンパイルアプローチにより、ランタイムのみのソリューションでは達成できない最適化が可能になります。ビルドプロセス中にテンプレートを分析することで、コンパイラはコード生成、依存関係の追跡、ランタイムでは不可能または高コストなパフォーマンス最適化について決定を下します。
 
-Selective code generation produces minimal JavaScript bundles:
+選択的なコード生成により、最小限のJavaScriptバンドルが生成されます：
 
 ```marko
 <div>
   // Static content: no JavaScript generated
   <p>This is static content</p>
-  
+
   // Stateful content: targeted JavaScript generated
   <let/count=0>
   <button onClick() { count++ }>
@@ -436,9 +436,9 @@ Selective code generation produces minimal JavaScript bundles:
 </div>
 ```
 
-The compiler generates client-side JavaScript only for components requiring interactive behavior. Static content compiles to plain HTML, while dynamic sections include only necessary JavaScript for their specific behavior.
+コンパイラは、インタラクティブな動作を必要とするコンポーネントに対してのみクライアント側のJavaScriptを生成します。静的コンテンツはプレーンなHTMLにコンパイルされ、動的セクションには特定の動作に必要なJavaScriptのみが含まれます。
 
-Reactivity analysis happens at compile time rather than runtime:
+リアクティビティの分析は、ランタイムではなくコンパイル時に行われます：
 
 ```marko
 <let/firstName="John">
@@ -452,26 +452,26 @@ Reactivity analysis happens at compile time rather than runtime:
 <p>Your initials are ${firstName[0]}${lastName[0]}</p>
 ```
 
-When `firstName` changes, the compiler ensures updates to the input value, derived `fullName`, h1 text, and paragraph initials. This analysis generates optimal update code affecting only dependent elements, eliminating runtime dependency tracking overhead while enabling surgical DOM updates.
+`firstName`が変更されると、コンパイラは入力値、派生した`fullName`、h1テキスト、段落のイニシャルへの更新を保証します。この分析により、依存する要素のみに影響する最適な更新コードが生成され、ランタイムの依存関係追跡オーバーヘッドを排除しながら、外科的なDOM更新が可能になります。
 
-Dual environment optimization compiles templates separately for server and client, each optimized for specific constraints. Server compilation prioritizes HTML generation throughput with efficient string concatenation and streaming support. Client compilation focuses on bundle size and precise updates, generating direct DOM manipulation rather than framework abstractions.
+デュアル環境最適化は、サーバーとクライアント用にテンプレートを個別にコンパイルし、それぞれが特定の制約に最適化されます。サーバーコンパイルは、効率的な文字列連結とストリーミングサポートによりHTML生成のスループットを優先します。クライアントコンパイルは、バンドルサイズと正確な更新に焦点を当て、フレームワークの抽象化ではなく直接的なDOM操作を生成します。
 
-## The Result
+## 結果
 
-These architectural decisions produce applications with characteristics that improve rather than degrade over time. The compilation approach handles complexity at build time, allowing development teams to focus on feature implementation rather than framework coordination.
+これらのアーキテクチャの決定により、時間の経過とともに劣化するのではなく改善する特性を持つアプリケーションが生成されます。コンパイルアプローチはビルド時に複雑さを処理し、開発チームがフレームワークの調整ではなく機能実装に集中できるようにします。
 
-Performance becomes automatic rather than effortful. Default streaming delivers content as soon as available. Selective JavaScript generation minimizes bundle sizes while maintaining full functionality. Precise updates affect only dependent DOM nodes. Progressive loading renders critical content first while interactive features enhance progressively.
+パフォーマンスは努力の結果ではなく自動的なものになります。デフォルトのストリーミングは、コンテンツが利用可能になり次第配信します。選択的なJavaScript生成は、完全な機能を維持しながらバンドルサイズを最小化します。正確な更新は依存するDOMノードのみに影響します。プログレッシブローディングは、インタラクティブな機能が段階的に強化される間、重要なコンテンツを最初にレンダリングします。
 
-Maintainability emerges from systematic design. Co-located concerns ensure component structure, styling, and behavior remain unified, eliminating coordination overhead that typically grows with application complexity. TypeScript integration provides template-level type checking equivalent to JavaScript analysis. The compiler identifies error categories at build time that would otherwise manifest as runtime failures.
+保守性は体系的な設計から生まれます。共同配置された関心事により、コンポーネント構造、スタイリング、動作が統一され、アプリケーションの複雑さとともに通常増大する調整オーバーヘッドが排除されます。TypeScript統合により、JavaScript分析と同等のテンプレートレベルの型チェックが提供されます。コンパイラは、ランタイムの失敗として現れるであろうエラーカテゴリをビルド時に識別します。
 
-Component flexibility supports evolving requirements without architectural changes. Applications can start with simple uncontrolled components and add coordination as needed, or implement complex validation and synchronization patterns when appropriate.
+コンポーネントの柔軟性は、アーキテクチャの変更なしに進化する要件をサポートします。アプリケーションは、シンプルな非制御コンポーネントから始めて必要に応じて調整を追加したり、適切な場合に複雑な検証と同期パターンを実装したりできます。
 
-Progressive enhancement occurs naturally from the architecture. Applications function without JavaScript and enhance with it, supporting diverse user environments and improving resilience. This characteristic becomes increasingly valuable as applications serve broader user bases with varying device capabilities and network conditions.
+プログレッシブエンハンスメントは、アーキテクチャから自然に発生します。アプリケーションはJavaScriptなしで機能し、JavaScriptで強化され、多様なユーザー環境をサポートし、回復力を向上させます。この特性は、アプリケーションがさまざまなデバイス機能とネットワーク条件を持つより広いユーザーベースにサービスを提供するにつれて、ますます価値が高まります。
 
-The result is a development approach that aligns with web platform evolution rather than working against it, producing applications that achieve high performance and maintainability through systematic design rather than optimization techniques.
+結果として、最適化技術ではなく体系的な設計を通じて高いパフォーマンスと保守性を達成するアプリケーションを生み出す、ウェブプラットフォームの進化と対立するのではなく整合する開発アプローチが得られます。
 
-## Next Steps
+## 次のステップ
 
-- [Welcome to Marko](./welcome-to-marko.md)
-- [Components & Reactivity Tutorial](../tutorial/components-and-reactivity.md)
-- [Language Reference](../reference/language.md)
+- [Markoへようこそ](./welcome-to-marko.md)
+- [コンポーネントとリアクティビティのチュートリアル](../tutorial/components-and-reactivity.md)
+- [言語リファレンス](../reference/language.md)

--- a/docs/marko-run/file-based-routing.md
+++ b/docs/marko-run/file-based-routing.md
@@ -1,10 +1,10 @@
-# File-based Routing
+# ファイルベースルーティング
 
-## Routes Directory
+## ルートディレクトリ
 
-The plugin looks for route files in the configured **routes directory**. By default, this is set to `./src/routes` relative to the Vite config file. This directory contains all the routing logic for the application.
+プラグインは、設定された **ルートディレクトリ** でルートファイルを検索します。デフォルトでは、Vite 設定ファイルからの相対パスで `./src/routes` に設定されています。このディレクトリには、アプリケーションのすべてのルーティングロジックが含まれます。
 
-Here's how to configure a different routes directory:
+異なるルートディレクトリを設定する方法は次のとおりです：
 
 ```ts
 /* vite.config.ts */
@@ -14,24 +14,24 @@ import marko from "@marko/run/vite";
 export default defineConfig({
   plugins: [
     marko({
-      routesDir: "src/pages", // Use `./src/pages` (relative to this file) as the routes directory
+      routesDir: "src/pages", // ルートディレクトリとして `./src/pages`（このファイルからの相対パス）を使用
     }),
   ],
 });
 ```
 
-## Routable Files
+## ルーティング可能なファイル
 
-The router only recognizes certain filenames, all prefixed with `+`. The following filenames will be discovered in any directory inside your application’s [routes directory](#routes-directory).
+ルーターは特定のファイル名のみを認識し、すべて `+` で始まります。以下のファイル名は、アプリケーションの [ルートディレクトリ](#ルートディレクトリ) 内の任意のディレクトリで検出されます。
 
 ### `+page.marko`
 
-These files establish a route at the current directory path, which will be served for `GET` requests with the HTML content of the page. Only one page may exist for any served path.
+これらのファイルは、現在のディレクトリパスにルートを確立し、`GET` リクエストに対してページの HTML コンテンツが提供されます。提供されるパスごとに存在できるページは 1 つだけです。
 
 ### `+layout.marko`
 
-These files provide a **layout component**, which will wrap all nested layouts and pages. Information is obtained from [`$global`](../reference/language.md#global) and `input`
-Layouts are like any other Marko component, with no extra constraints. Each layout receives the request, path params, URL, and route metadata as input, as well as a `content` which refers to the nested page that is being rendered.
+これらのファイルは **レイアウトコンポーネント** を提供し、すべてのネストされたレイアウトとページをラップします。情報は [`$global`](../reference/language.md#global) と `input` から取得されます。
+レイアウトは他の Marko コンポーネントと同様で、追加の制約はありません。各レイアウトは、リクエスト、パスパラメータ、URL、ルートメタデータを入力として受け取り、レンダリングされるネストされたページを参照する `content` も受け取ります。
 
 ```marko
 /* +layout.marko */
@@ -42,27 +42,27 @@ export interface Input {
 <main>
   <h1>My Products</h1>
 
-  <${input.content}/> // render the page or layout here
+  <${input.content}/> // ここでページまたはレイアウトをレンダリング
 </main>
 ```
 
 ### `+handler.*`
 
-These files establish a route at the current directory path that can handle requests for `GET`, `POST`, `PUT`, and `DELETE` HTTP methods. <!-- TODO: what about HEAD? -->
+これらのファイルは、`GET`、`POST`、`PUT`、`DELETE` HTTP メソッドのリクエストを処理できる現在のディレクトリパスにルートを確立します。<!-- TODO: what about HEAD? -->
 
-Typically, these will be `.js` or `.ts` files, depending on your project. Like pages, only one handler for each method may exist for any served path. A handler should export functions
+通常、これらはプロジェクトに応じて `.js` または `.ts` ファイルになります。ページと同様に、提供されるパスごとに各メソッドのハンドラーは 1 つだけ存在できます。ハンドラーは関数をエクスポートする必要があります
 
-- Valid exports are functions named `GET`, `POST`, `PUT`, or `DELETE`.
-- Exports can be one of the following
-  - Handler function (see below)
-  - Array of handler functions - will be composed by calling them in order
-  - Promise that resolves to a handler function or an array of handler functions
-- Handler functions are synchronous or asynchronous functions that
+- 有効なエクスポートは、`GET`、`POST`、`PUT`、または `DELETE` という名前の関数です
+- エクスポートは以下のいずれかになります
+  - ハンドラー関数（下記参照）
+  - ハンドラー関数の配列 - 順番に呼び出されて構成されます
+  - ハンドラー関数またはハンドラー関数の配列に解決される Promise
+- ハンドラー関数は同期または非同期関数で
 
-  - Receives a `context` and `next` argument,
-    - The `context` argument contains the WHATWG request object, path parameters, URL, and route metadata.
-    - The `next` argument will call the page for `GET` requests where applicable or return a `204` response.
-  - Return a WHATWG response, throw a WHATWG response, and return undefined. If the function returns undefined, the `next` argument will be automatically called and used as the response.
+  - `context` と `next` 引数を受け取ります
+    - `context` 引数には、WHATWG リクエストオブジェクト、パスパラメータ、URL、ルートメタデータが含まれます
+    - `next` 引数は、該当する場合は `GET` リクエストのページを呼び出すか、`204` レスポンスを返します
+  - WHATWG レスポンスを返すか、WHATWG レスポンスをスローするか、undefined を返します。関数が undefined を返す場合、`next` 引数が自動的に呼び出され、レスポンスとして使用されます
 
     ```ts
     /* +handler.ts */
@@ -72,7 +72,7 @@ Typically, these will be `.js` or `.ts` files, depending on your project. Like p
     }
 
     export async function GET(context, next) {
-      // do something before calling `next`
+      // `next` を呼び出す前に何かをする
       const response = await next();
       return response;
     }
@@ -80,21 +80,21 @@ Typically, these will be `.js` or `.ts` files, depending on your project. Like p
 
 ### `+middleware.*`
 
-These files are like layouts, but for handlers. Middleware files are called before handlers and let you perform arbitrary work before and after.
+これらのファイルはレイアウトに似ていますが、ハンドラー用です。ミドルウェアファイルはハンドラーの前に呼び出され、前後に任意の作業を実行できます。
 
 > [!NOTE]
-> Unlike handlers, middleware runs for all HTTP methods.
+> ハンドラーとは異なり、ミドルウェアはすべての HTTP メソッドで実行されます。
 
-- Expects a `default` export that can be one of the following
-  - Handler function (see below)
-  - Array of handler functions - will be composed by calling them in order
-  - Promise that resolves to a handler function or an array of handler functions
-- Handler functions are synchronous or asynchronous functions that
+- `default` エクスポートが必要で、以下のいずれかになります
+  - ハンドラー関数（下記参照）
+  - ハンドラー関数の配列 - 順番に呼び出されて構成されます
+  - ハンドラー関数またはハンドラー関数の配列に解決される Promise
+- ハンドラー関数は同期または非同期関数で
 
-  - Receives a `context` and `next` argument,
-    - The `context` argument contains the WHATWG request object, path parameters, URL, and route metadata.
-    - The `next` argument will call the page for `GET` requests where applicable or return a `204` response.
-  - Return a WHATWG response, throw a WHATWG response, and return undefined. If the function returns undefined, the `next` argument will be automatically called and used as the response.
+  - `context` と `next` 引数を受け取ります
+    - `context` 引数には、WHATWG リクエストオブジェクト、パスパラメータ、URL、ルートメタデータが含まれます
+    - `next` 引数は、該当する場合は `GET` リクエストのページを呼び出すか、`204` レスポンスを返します
+  - WHATWG レスポンスを返すか、WHATWG レスポンスをスローするか、undefined を返します。関数が undefined を返す場合、`next` 引数が自動的に呼び出され、レスポンスとして使用されます
 
     ```ts
     /* +middleware.ts */
@@ -103,7 +103,7 @@ These files are like layouts, but for handlers. Middleware files are called befo
       let success = true;
       console.log(`${requestName} request started`);
       try {
-        return await next(); // Wait for subsequent middleware, handler, and page
+        return await next(); // 後続のミドルウェア、ハンドラー、ページを待機
       } catch (err) {
         success = false;
         throw err;
@@ -117,35 +117,35 @@ These files are like layouts, but for handlers. Middleware files are called befo
 
 ### `+meta.*`
 
-These files represent static metadata to attach to the route. This metadata will be automatically provided on the route `context` when invoking a route.
+これらのファイルは、ルートに添付する静的メタデータを表します。このメタデータは、ルートを呼び出すときにルート `context` で自動的に提供されます。
 
-## Special Files
+## 特別なファイル
 
-In addition to the files above, which can be defined in any directory under the [routes directory](#routes-directory), some special files can only be defined at its top level. <!-- TODO: do we want to keep this restriction? Having nested 404s would be handy for disambiguating things like “there’s no user with that name” or “that promotion wasn’t found, it may have expired” -->
+[ルートディレクトリ](#ルートディレクトリ) 下の任意のディレクトリで定義できる上記のファイルに加えて、一部の特別なファイルはそのトップレベルでのみ定義できます。<!-- TODO: do we want to keep this restriction? Having nested 404s would be handy for disambiguating things like "there's no user with that name" or "that promotion wasn't found, it may have expired" -->
 
-These special pages are subject to a root layout file (`pages/+layout.marko` in the default configuration).
+これらの特別なページは、ルートレイアウトファイル（デフォルト設定では `pages/+layout.marko`）の対象となります。
 
 ### `+404.marko`
 
-This special page responds to any request where:
+この特別なページは、以下の条件のリクエストに応答します：
 
-- The `Accept` request header includes `text/html`
-- _And_ no other handler or page rendered the request
+- `Accept` リクエストヘッダーに `text/html` が含まれている
+- _かつ_ 他のハンドラーまたはページがリクエストをレンダリングしなかった
 
-Responses with this page will have a `404` status code.
+このページでのレスポンスは `404` ステータスコードになります。
 
 ### `+500.marko`
 
-This special page responds to any request where:
+この特別なページは、以下の条件のリクエストに応答します：
 
-- The `Accept` request header includes `text/html`
-- _And_ an uncaught error occurs while serving the request
+- `Accept` リクエストヘッダーに `text/html` が含まれている
+- _かつ_ リクエストの処理中にキャッチされないエラーが発生した
 
-Responses with this page will have a `500` status code.
+このページでのレスポンスは `500` ステータスコードになります。
 
-## Execution Order
+## 実行順序
 
-Given the following routes directory structure
+次のようなルートディレクトリ構造が与えられた場合
 
 ```
 routes/
@@ -159,22 +159,22 @@ routes/
   +page.marko
 ```
 
-When the path `/about` is requested, the routable files execute in the following order:
+パス `/about` がリクエストされると、ルーティング可能なファイルは次の順序で実行されます：
 
-1. Middlewares from root-most to leaf-most
-2. Handler
-3. Layouts from root-most to leaf-most
-4. Page
+1. ルートから最も近いものから葉に最も近いものまでのミドルウェア
+2. ハンドラー
+3. ルートから最も近いものから葉に最も近いものまでのレイアウト
+4. ページ
 
 <!-- mermaid diagram from README -->
 
-## Path Structure
+## パス構造
 
-Within the [routes directory](#routes-directory), the directory structure determines the path from which the route is served. There are four types of directory names: **static**, **pathless**, **dynamic**, and **catch-all**.
+[ルートディレクトリ](#ルートディレクトリ) 内では、ディレクトリ構造によってルートが提供されるパスが決まります。ディレクトリ名には、**静的**、**パスレス**、**動的**、**キャッチオール** の 4 つのタイプがあります。
 
-1. **Static directories** - The most common type, and the default behavior. Each static directory contributes its name as a segment in the route's served path, similar to a traditional file server. Unless a directory name matches the requirements for one of the below types, it is seen as a static directory.
+1. **静的ディレクトリ** - 最も一般的なタイプであり、デフォルトの動作です。各静的ディレクトリは、従来のファイルサーバーと同様に、ルートの提供パスにセグメントとしてその名前を提供します。ディレクトリ名が以下のタイプのいずれかの要件に一致しない限り、静的ディレクトリと見なされます。
 
-   Examples:
+   例：
 
    ```
    /foo
@@ -182,18 +182,18 @@ Within the [routes directory](#routes-directory), the directory structure determ
    /projects
    ```
 
-2. **Pathless directories** - These directories do **not** contribute their name to the route's served path. Directory names that start with an underscore (`_`) will be ignored when parsing the route.
+2. **パスレスディレクトリ** - これらのディレクトリは、ルートの提供パスにその名前を提供 **しません**。アンダースコア（`_`）で始まるディレクトリ名は、ルートを解析する際に無視されます。
 
-   Examples:
+   例：
 
    ```
    /_users
    /_public
    ```
 
-3. **Dynamic directories** - These directories introduce a dynamic parameter to the route's served path and will match any value at that segment. Any directory name that starts with a single dollar sign (`$`) will be a dynamic directory, and the remaining directory name will be the parameter at runtime. If the directory name is exactly `$`, the parameter will not be captured, but it will be matched.
+3. **動的ディレクトリ** - これらのディレクトリは、ルートの提供パスに動的パラメータを導入し、そのセグメントの任意の値と一致します。1 つのドル記号（`$`）で始まるディレクトリ名は動的ディレクトリになり、残りのディレクトリ名が実行時のパラメータになります。ディレクトリ名が正確に `$` の場合、パラメータはキャプチャされませんが、一致します。
 
-   Examples:
+   例：
 
    ```
    /$id
@@ -201,11 +201,11 @@ Within the [routes directory](#routes-directory), the directory structure determ
    /$
    ```
 
-4. **Catch-all directories** - These directories are similar to dynamic directories and introduce a dynamic parameter, but instead of matching a single path segment, they match to the end of the path. Any directory that starts with two dollar signs (`$$`) will be a catch-all directory, and the remaining directory name will be the parameter at runtime. In the case of a directory named `$$`, the parameter name will not be captured, but it will match. Catch-all directories can be used to make `404` Not Found routes at any level, including the root.
+4. **キャッチオールディレクトリ** - これらのディレクトリは動的ディレクトリに似ており、動的パラメータを導入しますが、単一のパスセグメントと一致するのではなく、パスの最後まで一致します。2 つのドル記号（`$$`）で始まるディレクトリはキャッチオールディレクトリになり、残りのディレクトリ名が実行時のパラメータになります。`$$` という名前のディレクトリの場合、パラメータ名はキャプチャされませんが、一致します。キャッチオールディレクトリは、ルートを含む任意のレベルで `404` Not Found ルートを作成するために使用できます。
 
-   Because catch-all directories match any path segment and consume the rest of the path, you cannot nest route files in them, and no further directories will be traversed.
+   キャッチオールディレクトリは任意のパスセグメントと一致し、パスの残りを消費するため、その中にルートファイルをネストすることはできず、それ以上のディレクトリは走査されません。
 
-   Examples:
+   例：
 
    ```
    /$$all
@@ -213,15 +213,15 @@ Within the [routes directory](#routes-directory), the directory structure determ
    /$$
    ```
 
-## Flat Routes
+## フラットルート
 
-Flat routes let you define paths without needing additional directories. Instead, the directory structure can be defined either in the file or directory name. This allows you to decouple your routes from your directory structure or co-locate them as needed. To define a flat route, use periods (`.`) to delineate each path segment. This behaves exactly like creating a new directory, and each segment will be parsed using the rules described above for static, dynamic, and pathless routes.
+フラットルートを使用すると、追加のディレクトリを必要とせずにパスを定義できます。代わりに、ディレクトリ構造をファイル名またはディレクトリ名で定義できます。これにより、ルートをディレクトリ構造から切り離したり、必要に応じて配置したりできます。フラットルートを定義するには、ピリオド（`.`）を使用して各パスセグメントを区切ります。これは新しいディレクトリを作成するのと全く同じように動作し、各セグメントは上記で説明した静的、動的、パスレスルートのルールを使用して解析されます。
 
-Flat routes syntax can be used for both directories and routable files (eg. pages, handlers, middleware, etc.). For these files, anything preceding the plus (`+`) will be treated as the flat route.
+フラットルート構文は、ディレクトリとルーティング可能なファイル（ページ、ハンドラー、ミドルウェアなど）の両方に使用できます。これらのファイルの場合、プラス（`+`）の前にあるものはすべてフラットルートとして扱われます。
 
-For example, to define a page at `/projects/$projectId/members` with a root layout and a project layout:
+たとえば、ルートレイアウトとプロジェクトレイアウトを使用して `/projects/$projectId/members` にページを定義するには：
 
-Without flat routes, you would have a file structure like:
+フラットルートを使用しない場合、次のようなファイル構造になります：
 
 ```
 routes/
@@ -233,7 +233,7 @@ routes/
         +layout.marko
 ```
 
-With flat routes, move the path defined by the directories into the files and separate with a period
+フラットルートを使用すると、ディレクトリで定義されたパスをファイルに移動し、ピリオドで区切ります
 
 ```
 routes/
@@ -242,7 +242,7 @@ routes/
   projects.$projectId.members+page.marko
 ```
 
-Additionally, you can continue to organize files under directories to decrease duplication and use flat route syntax in the folder name
+さらに、フォルダー名でフラットルート構文を使用して、重複を減らすためにディレクトリの下にファイルを整理し続けることができます
 
 ```
 routes/
@@ -252,7 +252,7 @@ routes/
   +layout.marko
 ```
 
-Finally, flat routes and routes defined with directories are all treated equally and merged together. For example, this page will have layout
+最後に、フラットルートとディレクトリで定義されたルートはすべて同等に扱われ、マージされます。たとえば、このページにはレイアウトが適用されます
 
 ```
 routes/
@@ -262,18 +262,18 @@ routes/
   projects.$projectId+page.marko
 ```
 
-## Multiple Paths, Groups and Optional Segments
+## 複数のパス、グループ、オプショナルセグメント
 
-Along with describing multiple segments, flat route syntax supports defining routes that match more than one path and segments that are optional. To describe a route that matches multiple paths, use a comma (`,`) and define each route.
+複数のセグメントを記述するだけでなく、フラットルート構文は、複数のパスと一致するルートとオプショナルなセグメントの定義をサポートしています。複数のパスと一致するルートを記述するには、カンマ（`,`）を使用して各ルートを定義します。
 
-For example the following page matches `/projects/$projectId/members` and `/projects/$projectId/people`
+たとえば、次のページは `/projects/$projectId/members` と `/projects/$projectId/people` に一致します
 
 ```
 routes/
   projects.$projectId.members,projects.$projectId.people+page.marko
 ```
 
-This file name is a bit long, so you might do something like this
+このファイル名は少し長いので、次のようにすることもできます
 
 ```
 routes/
@@ -281,27 +281,27 @@ routes/
   members,people+page.marko
 ```
 
-We can simplify this by introducing another concept: **grouping**. Groups allow you to define segments within a flat route that match multiple sub-paths by surrounding them with parentheses (`(` and `)`). For the example, this means you can do the following:
+別の概念を導入することで、これを簡素化できます：**グループ化**。グループを使用すると、括弧（`(` と `)`）で囲むことで、複数のサブパスと一致するフラットルート内のセグメントを定義できます。この例では、次のようにできます：
 
 ```
 routes/
   projects.$projectId.(members,people)+page.marko
 ```
 
-This is a simple example of grouping, but you can nest groups and make them as complicated as you want.
+これはグループ化の簡単な例ですが、グループをネストして、必要なだけ複雑にすることができます。
 
-The last concept is **optionality**. By introducing an empty segment or pathless segment along with another value, you can make that segment optional. For example, if we want a page that matches `/projects` and `/projects/home`, you can create a flat route that optionally matches `home`
+最後の概念は **オプショナリティ** です。空のセグメントまたはパスレスセグメントを別の値と一緒に導入することで、そのセグメントをオプショナルにすることができます。たとえば、`/projects` と `/projects/home` に一致するページが必要な場合、`home` をオプショナルに一致させるフラットルートを作成できます
 
 ```
 routes/
   projects.(home,)+page.marko
 ```
 
-or
+または
 
 ```
 routes/
   projects.(home,_pathless)+page.marko
 ```
 
-While both of these create a route which matches the paths, they have slightly different semantics. Using a pathless segment is the same as creating a pathless directory, which allows you to isolate middleware and layouts. Using an empty segment is the same as defining a file at the current location.
+これらはどちらもパスに一致するルートを作成しますが、セマンティクスが少し異なります。パスレスセグメントを使用することは、パスレスディレクトリを作成することと同じで、ミドルウェアとレイアウトを分離できます。空のセグメントを使用することは、現在の場所にファイルを定義することと同じです。

--- a/docs/marko-run/getting-started.md
+++ b/docs/marko-run/getting-started.md
@@ -1,77 +1,77 @@
-# Getting Started
+# はじめに
 
-Marko Run is a framework for building web applications with Marko. This is a _meta_-framework for Marko, similar to Next.js or Remix for React, SvelteKit for Svelte, and Nuxt for Vue.
+Marko Run は、Marko で Web アプリケーションを構築するためのフレームワークです。これは Marko の _メタ_ フレームワークで、React の Next.js や Remix、Svelte の SvelteKit、Vue の Nuxt と同様のものです。
 
-Marko Run is powered by Vite, a fast and modern build tool that provides a great developer experience. It is designed to be easy to use and flexible, allowing developers to build applications with Marko quickly and efficiently.
+Marko Run は、優れた開発者体験を提供する高速で最新のビルドツールである Vite を使用しています。使いやすく柔軟性があり、開発者が Marko でアプリケーションを迅速かつ効率的に構築できるように設計されています。
 
-## Using a Template
+## テンプレートの使用
 
-Marko's CLI provides a variety of templates to get started with Marko, many of which use Marko Run.
+Marko の CLI は、Marko を始めるためのさまざまなテンプレートを提供しており、その多くは Marko Run を使用しています。
 
 ```sh
 npm init marko
 ```
 
-## Starting from Zero
+## ゼロから始める
 
-The smallest possible Marko Run project requires just a few files.
+最小限の Marko Run プロジェクトには、わずか数個のファイルが必要です。
 
 ```sh
 npm init
 npm install @marko/run
 ```
 
-## Adding to an Existing Project
+## 既存のプロジェクトへの追加
 
-Marko Run can be added to an existing Marko project by installing the package.
+Marko Run は、パッケージをインストールすることで既存の Marko プロジェクトに追加できます。
 
 ```sh
 npm install @marko/run
 ```
 
-## Zero Config Setup
+## ゼロコンフィグ設定
 
-`marko-run` enables quick project initialization with minimal configuration. The package ships with a default Vite config and node-based adapter.
+`marko-run` は、最小限の設定で迅速なプロジェクトの初期化を可能にします。パッケージには、デフォルトの Vite 設定と node ベースのアダプターが付属しています。
 
-Starting with a template:
+テンプレートから始める場合：
 
-1. Create a new project
+1. 新しいプロジェクトを作成
 
    ```sh
    npm init marko -- -t basic
    ```
 
-2. Navigate to project directory
+2. プロジェクトディレクトリに移動
 
    ```sh
    cd PROJECT_NAME
    ```
 
-3. Start development server
+3. 開発サーバーを起動
 
    ```sh
    npm run dev
    ```
 
-Manual project setup:
+手動でプロジェクトを設定する場合：
 
-1. Install the required package: `npm install @marko/run`
-2. Create the entry file: `src/routes/+page.marko`
-3. Start the development server: `npm exec marko-run`
+1. 必要なパッケージをインストール：`npm install @marko/run`
+2. エントリーファイルを作成：`src/routes/+page.marko`
+3. 開発サーバーを起動：`npm exec marko-run`
 
-The application will be available at `http://localhost:3000` 🚀
+アプリケーションは `http://localhost:3000` で利用可能になります 🚀
 
-## CLI Commands
+## CLI コマンド
 
 ### `marko-run dev`
 
-Starts a development server in watch mode
+ウォッチモードで開発サーバーを起動します
 
 ```sh
 npm exec marko-run
 ```
 
-or (with explicit sub command)
+または（明示的なサブコマンドを使用）
 
 ```sh
 npm exec marko-run dev
@@ -79,7 +79,7 @@ npm exec marko-run dev
 
 ### `marko-run build`
 
-Creates a production build
+本番用ビルドを作成します
 
 ```sh
 npm exec marko-run build
@@ -87,7 +87,7 @@ npm exec marko-run build
 
 ### `marko-run preview`
 
-Creates a production build and start the preview server
+本番用ビルドを作成し、プレビューサーバーを起動します
 
 ```sh
 npm exec marko-run preview

--- a/docs/marko-run/typescript.md
+++ b/docs/marko-run/typescript.md
@@ -1,51 +1,51 @@
 # TypeScript
 
-## Global Namespace
+## グローバル名前空間
 
-`marko/run` provides a global namespace `MarkoRun` with the following types:
+`marko/run` は、以下の型を持つグローバル名前空間 `MarkoRun` を提供します：
 
-**`MarkoRun.Handler`** - Type that represents a handler function to be exported by a +handler or +middleware file
+**`MarkoRun.Handler`** - +handler または +middleware ファイルでエクスポートされるハンドラー関数を表す型
 
-**`MarkoRun.Route`** - Type of the route's params and metadata
+**`MarkoRun.Route`** - ルートのパラメータとメタデータの型
 
-**`MarkoRun.Context`** - Type of the request context object in a handler and `$global` in your Marko files. This type can be extended using TypeScript's module and interface merging by declaring a `Context` interface on the `@marko/run` module within your applcation code
+**`MarkoRun.Context`** - ハンドラー内のリクエストコンテキストオブジェクトの型、および Marko ファイル内の `$global` の型。この型は、アプリケーションコード内で `@marko/run` モジュールに `Context` インターフェースを宣言することで、TypeScript のモジュールとインターフェースのマージを使用して拡張できます
 
 ```ts
 declare module "@marko/run" {
   interface Context {
-    customPropery: MyCustomThing; // will be globally defined on MarkoRun.Context
+    customPropery: MyCustomThing; // MarkoRun.Context にグローバルに定義されます
   }
 }
 ```
 
-**`MarkoRun.Platform`** - Type of the platform object provided by the adapter in use. This interface can be extended in that same way as `Context` (see above) by declaring a `Platform` interface:
+**`MarkoRun.Platform`** - 使用中のアダプターによって提供されるプラットフォームオブジェクトの型。このインターフェースは、`Context` と同じ方法で（上記を参照）、`Platform` インターフェースを宣言することで拡張できます：
 
 ```ts
 declare module "@marko/run" {
   interface Platform {
-    customPropery: MyCustomThing; // will be globally defined on MarkoRun.Platform
+    customPropery: MyCustomThing; // MarkoRun.Platform にグローバルに定義されます
   }
 }
 ```
 
-## Generated Types
+## 生成される型
 
-If a [TSConfig](https://www.typescriptlang.org/tsconfig) file is discovered in the project root, the Vite plugin will automatically generate a .d.ts file which provides more specific types for each of your middleware, handlers, layouts, and pages. This file will be generated at `.marko-run/routes.d.ts` whenever the project is built - including dev.
+プロジェクトルートで [TSConfig](https://www.typescriptlang.org/tsconfig) ファイルが見つかった場合、Vite プラグインは、各ミドルウェア、ハンドラー、レイアウト、ページに対してより具体的な型を提供する .d.ts ファイルを自動的に生成します。このファイルは、開発環境を含め、プロジェクトがビルドされるたびに `.marko-run/routes.d.ts` に生成されます。
 
-> [!NOTE] TypeScript will not include this file by default. You should use the [Marko VSCode plugin](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode) and [add it in your tsconfig](https://www.typescriptlang.org/tsconfig#include).
+> [!NOTE] TypeScript はデフォルトでこのファイルを含めません。[Marko VSCode プラグイン](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode) を使用し、[tsconfig に追加する](https://www.typescriptlang.org/tsconfig#include) 必要があります。
 
-These types are replaced with more specific versions per routable file:
+これらの型は、ルーティング可能なファイルごとに、より具体的なバージョンに置き換えられます：
 
 **`MarkoRun.Handler`**
 
-- Overrides context with specific MarkoRun.Context
+- コンテキストを特定の MarkoRun.Context でオーバーライド
 
 **`MarkoRun.Route`**
 
-- Adds specific parameters and meta types
-- In middleware and layouts which are used in many routes, this type will be a union of all possible routes that the file will see
+- 特定のパラメータとメタタイプを追加
+- 多くのルートで使用されるミドルウェアとレイアウトでは、この型はファイルが参照するすべての可能なルートのユニオンになります
 
 **`MarkoRun.Context`**
 
-- In middleware and layouts which are used in many routes, this type will be a union of all possible routes that the file will see.
-- When an adapter is used, it can provide types for the platform
+- 多くのルートで使用されるミドルウェアとレイアウトでは、この型はファイルが参照するすべての可能なルートのユニオンになります
+- アダプターが使用されている場合、プラットフォームの型を提供できます

--- a/docs/reference/concise-syntax.md
+++ b/docs/reference/concise-syntax.md
@@ -1,34 +1,34 @@
-# Concise syntax
+# 簡潔構文
 
-Marko's concise syntax is very similar to the HTML syntax, except it's more... concise. Angle brackets are removed, and nesting is indentation-based.
+Markoの簡潔構文は、HTML構文に非常に似ていますが、より...簡潔です。山括弧が削除され、ネストはインデントベースになります。
 
-All Marko files are in concise mode by default, and switch to HTML mode once there is a tag that uses the HTML syntax.
+すべてのMarkoファイルはデフォルトで簡潔モードになっており、HTML構文を使用するタグがある場合にHTMLモードに切り替わります。
 
 ```marko no-format
 div class="thumbnail"
     img src="https://example.com/thumb.png"
 
-// identical to
+// これと同じ
 
 <div class="thumbnail"><img src="https://example.com/thumb.png" /></div>
 ```
 
-## Attributes on multiple lines
+## 複数行の属性
 
-Attributes may be comma-separated in all Marko tags.
+すべてのMarkoタグで、属性はカンマ区切りにできます。
 
 ```marko no-format
 div id="hello", class=["class1", "class2", "class3"], style={ border: "1px solid red" }
 ```
 
-Since commas indicate that another attribute is expected, they may be used to spread attributes across multiple lines.
+カンマは別の属性が続くことを示すため、複数行にわたって属性を広げるために使用できます。
 
 ```marko no-format
 div id="hello" class="world",
   style={ border: "1px solid red" }
 ```
 
-By convention, readability is improved if commas are organized at the _beginning_ of each line with attributes.
+慣例として、カンマを属性のある各行の_先頭_に配置すると、可読性が向上します。
 
 ```marko no-format
 div
@@ -38,18 +38,18 @@ div
   -- hello
 ```
 
-## Text
+## テキスト
 
-Two or more hyphens (`--`) followed by whitespace may be used to begin [content](./language.md#tag-content).
+2つ以上のハイフン（`--`）の後に空白を続けることで、[コンテンツ](./language.md#tag-content)を開始できます。
 
-If text immediately follows the hyphens, the content is terminated at the end of the line.
+ハイフンの直後にテキストが続く場合、コンテンツは行の終わりで終了します。
 
 ```marko no-format
 -- Hello world
 div -- Hello world
 ```
 
-If hyphens are followed by a newline, the content is terminated by the same number of hyphens or at the next dedentation.
+ハイフンの後に改行が続く場合、コンテンツは同じ数のハイフンまたは次のデデンテーションで終了します。
 
 ```marko no-format
 --
@@ -71,7 +71,7 @@ details
 ```
 
 > [!TIP]
-> There may be _more_ than two hyphens if necessary, but the number hyphens in the open and close must match.
+> 必要に応じて2つ_以上_のハイフンを使用できますが、開始と終了のハイフンの数は一致する必要があります。
 >
 > ```marko no-format
 > pre
@@ -84,22 +84,22 @@ details
 >   ---------------------
 > ```
 
-### Root level text
+### ルートレベルのテキスト
 
-The Marko parser starts out in the concise mode. Therefore, given the following template:
+Markoパーサーは簡潔モードで開始します。したがって、次のテンプレートが与えられた場合:
 
 ```marko no-format
 Hello World
 Welcome to Marko
 ```
 
-The output is:
+出力は次のようになります:
 
 ```html
 <Hello World></Hello> <Welcome to Marko></Welcome>
 ```
 
-The proper way to include root level text is with [code fences](#text).
+ルートレベルのテキストを含める適切な方法は、[コードフェンス](#text)を使用することです。
 
 ```marko no-format
 -- Welcome to Marko

--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -1,15 +1,15 @@
-# Core Tags
+# コアタグ
 
 ## `<if>` / `<else>`
 
-The `<if>` and `<else>` control flow tags are used to conditionally display content or apply [attribute tags](./language.md#attribute-tags).
+`<if>`と`<else>`の制御フロータグは、コンテンツを条件付きで表示したり、[属性タグ](./language.md#attribute-tags)を適用するために使用されます。
 
-An `<if>` is applied when its `value=` attribute ([shorthand used below](./language.md#shorthand-value)) is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) and may be followed by an `<else>`.
+`<if>`は、その`value=`属性（[以下で使用される省略記法](./language.md#shorthand-value)）が[truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)の場合に適用され、`<else>`を後に続けることができます。
 
-The `<else>` tag may have its own condition as an `if=` attribute.
-When it has a condition, the condition is checked before the `<else>` is applied and another `<else>` may follow.
+`<else>`タグは、`if=`属性として独自の条件を持つことができます。
+条件がある場合、`<else>`が適用される前に条件がチェックされ、別の`<else>`を後に続けることができます。
 
-Expressions in the if/else chain are evaluated in order.
+if/elseチェーン内の式は順番に評価されます。
 
 ```marko
 <if=EXPRESSION>
@@ -25,11 +25,11 @@ Expressions in the if/else chain are evaluated in order.
 
 ## `<for>`
 
-The `<for>` control flow tag allows for writing content or applying [attribute tags](./language.md#attribute-tags) while iterating. Its [content](./language.md#tag-content) has access to information about each iteration through the [Tag Parameters](./language.md#tag-parameters).
+`<for>`制御フロータグは、イテレーション中にコンテンツを書き込んだり、[属性タグ](./language.md#attribute-tags)を適用したりすることを可能にします。その[コンテンツ](./language.md#tag-content)は、[タグパラメータ](./language.md#tag-parameters)を通じて各イテレーションの情報にアクセスできます。
 
-The `<for>` tag can iterate over:
+`<for>`タグは以下を反復処理できます:
 
-- Arrays and [Iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) with the `of=` attribute
+- `of=`属性を使用した配列と[イテラブル](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)
 
   ```marko
   <for|item, index| of=["a", "b", "c"]>
@@ -37,7 +37,7 @@ The `<for>` tag can iterate over:
   </for>
   ```
 
-- Object properties and values with the `in=` attribute
+- `in=`属性を使用したオブジェクトのプロパティと値
 
   ```marko
   <for|key, value| in={a: 1, b: 2, c: 3}>
@@ -45,7 +45,7 @@ The `<for>` tag can iterate over:
   </for>
   ```
 
-- **Exclusive** ranges of numbers with the `until=`, `from=`, and `step=` attributes
+- `until=`、`from=`、`step=`属性を使用した**排他的**な数値の範囲
 
   ```marko
   <for|num| until=5>${num}</for>
@@ -58,7 +58,7 @@ The `<for>` tag can iterate over:
   // 2 4 6 8
   ```
 
-- **Inclusive** ranges of numbers with the `to=`, `from=`, and `step=` attributes
+- `to=`、`from=`、`step=`属性を使用した**包括的**な数値の範囲
 
   ```marko
   <for|num| to=5>${num}</for>
@@ -71,7 +71,7 @@ The `<for>` tag can iterate over:
   // 2 4 6 8 10
   ```
 
-The `<for>` tag has a `by=` attribute which helps preserve state while reordering content within the loop. The value should be a function (which receives the same parameters as the loop itself) that is used to give each iteration a unique key.
+`<for>`タグには`by=`属性があり、ループ内のコンテンツを並べ替える際に状態を保持するのに役立ちます。値は関数である必要があり（ループ自体と同じパラメータを受け取ります）、各イテレーションに一意のキーを与えるために使用されます。
 
 ```marko
 <for|user| of=users by=user => user.id>
@@ -79,11 +79,11 @@ The `<for>` tag has a `by=` attribute which helps preserve state while reorderin
 </for>
 ```
 
-The `by=` attribute above keys each iteration by its `user.id` property.
+上記の`by=`属性は、各イテレーションを`user.id`プロパティでキー付けします。
 
-Additionally, when using the `of=` attribute, `by=` may be a string. This will key the items by the corresponding property on each item.
+さらに、`of=`属性を使用する場合、`by=`は文字列でもかまいません。これにより、各アイテムの対応するプロパティでアイテムがキー付けされます。
 
-This means the previous example can simplified to:
+これは、前の例を次のように簡略化できることを意味します:
 
 ```marko
 <for|user| of=users by="id">
@@ -93,15 +93,15 @@ This means the previous example can simplified to:
 
 ## `<let>`
 
-The `<let>` tag introduces mutable state through its [Tag Variable](./language.md#tag-variables).
+`<let>`タグは、その[タグ変数](./language.md#tag-variables)を通じて可変状態を導入します。
 
 ```marko
 <let/x=1>
 ```
 
-The `value=` attribute (usually with a [shorthand](./language.md#shorthand-value)) provides an initial value for its state.
+`value=`属性（通常は[省略記法](./language.md#shorthand-value)を使用）は、その状態の初期値を提供します。
 
-When a tag variable is updated, everywhere it is used also re-runs. This is the core of Marko's reactive system.
+タグ変数が更新されると、それが使用されているすべての場所も再実行されます。これがMarkoのリアクティブシステムの核心です。
 
 ```marko
 <let/count=1>
@@ -111,10 +111,10 @@ When a tag variable is updated, everywhere it is used also re-runs. This is the 
 </button>
 ```
 
-In this template, `count` is incremented when the button is clicked. Since `count` is a [Tag Variable](./language.md#tag-variables), it will cause any downstream expression (in this case the text in the button) to be updated every time it changes.
+このテンプレートでは、ボタンがクリックされたときに`count`が増分されます。`count`は[タグ変数](./language.md#tag-variables)であるため、変更されるたびに下流の式（この場合はボタン内のテキスト）が更新されます。
 
 > [!NOTE]
-> The `<let>` tag is not reactive to changes in its `value=` attribute unless it is [controllable](#controllable-let). Its tag variable updates only through direct assignment or its change handler.
+> `<let>`タグは、[制御可能](#controllable-let)でない限り、その`value=`属性の変更に対してリアクティブではありません。そのタグ変数は、直接代入または変更ハンドラを通じてのみ更新されます。
 >
 > ```marko
 > export interface Input {
@@ -126,24 +126,24 @@ In this template, `count` is incremented when the button is clicked. Since `coun
 > <p>Input Count: ${input.initialCount}</p>
 > ```
 >
-> Here, even if `input.initialCount` changes, `count` remains at its initial value.
+> ここでは、`input.initialCount`が変更されても、`count`は初期値のままです。
 
-### Controllable Let
+### 制御可能なLet
 
-The `<let>` tag can be made **controllable** using its `valueChange=` attribute, similarly to [native tag change handlers](./native-tag.md#change-handlers). This enables interception and transformation of state changes, or synchronization of state between parent and child components.
+`<let>`タグは、[ネイティブタグの変更ハンドラ](./native-tag.md#change-handlers)と同様に、`valueChange=`属性を使用して**制御可能**にできます。これにより、状態変更の傍受と変換、または親と子コンポーネント間の状態の同期が可能になります。
 
 ```marko
 <let/value="HELLO">
 <let/controlled_value=value valueChange(newValue) { value = newValue.toUpperCase() }>
 ```
 
-In this example:
+この例では:
 
-1. `value` holds the base state with an initial value of "HELLO"
-2. `controlled_value` reflects the value of `value`, but its `valueChange` handler ensures all updates are uppercase
-3. Any changes to `controlled_value` are intercepted, transformed to uppercase, and stored in `value`
+1. `value`は「HELLO」の初期値を持つベース状態を保持します
+2. `controlled_value`は`value`の値を反映しますが、その`valueChange`ハンドラはすべての更新が大文字であることを保証します
+3. `controlled_value`への変更はすべて傍受され、大文字に変換され、`value`に格納されます
 
-A more common use case is creating state that can be optionally controlled by a parent component:
+より一般的なユースケースは、親コンポーネントによってオプションで制御できる状態を作成することです:
 
 ```marko
 /* counter.marko */
@@ -159,15 +159,15 @@ export interface Input {
 </button>
 ```
 
-This creates two possible behaviors:
+これにより、2つの可能な動作が作成されます:
 
-1. **Uncontrolled**: If the parent only provides `count=`, the child maintains its own state:
+1. **非制御**: 親が`count=`のみを提供する場合、子は独自の状態を維持します:
 
    ```marko
    <counter count=0/>
    ```
 
-2. **Controlled**: If the parent provides both `count=` and `countChange=`, the parent takes control of the state:
+2. **制御**: 親が`count=`と`countChange=`の両方を提供する場合、親が状態を制御します:
 
    ```marko
    <let/count=0>
@@ -179,9 +179,9 @@ This creates two possible behaviors:
 
 ## `<const>`
 
-The `<const>` exposes its `value=` attribute (usually with a [shorthand](./language.md#shorthand-value)) through its [Tag Variable](./language.md#tag-variables).
+`<const>`は、その`value=`属性（通常は[省略記法](./language.md#shorthand-value)を使用）を[タグ変数](./language.md#tag-variables)を通じて公開します。
 
-Extending the [`<let>`](#let) example we could derive data from the `count` state like so:
+[`<let>`](#let)の例を拡張して、`count`状態からデータを導出できます:
 
 ```marko
 <let/count=1>
@@ -194,10 +194,10 @@ Extending the [`<let>`](#let) example we could derive data from the `count` stat
 ```
 
 > [!NOTE]
-> The `<const>` tag is locally scoped and will be initialized for every instance of a component. If your goal is to expose a program wide constant, you should use [`static const`](./language.md#static) instead.
+> `<const>`タグはローカルスコープであり、コンポーネントのすべてのインスタンスに対して初期化されます。プログラム全体の定数を公開することが目的の場合は、代わりに[`static const`](./language.md#static)を使用する必要があります。
 
 > [!TIP]
-> The implementation of the [`<const>`](#const) tag is conceptually identical to [`<return>`](#return)ing its `input.value`. 🤯
+> [`<const>`](#const)タグの実装は、概念的にはその`input.value`を[`<return>`](#return)するのと同じです。🤯
 >
 > ```marko
 > /* const.marko */
@@ -210,16 +210,16 @@ Extending the [`<let>`](#let) example we could derive data from the `count` stat
 
 ## `<return>`
 
-The `<return>` tag allows any [custom tag](./custom-tag.md) to expose a [Tag Variable](./language.md#tag-variables).
+`<return>`タグは、任意の[カスタムタグ](./custom-tag.md)が[タグ変数](./language.md#tag-variables)を公開することを可能にします。
 
-The `value=` attribute (usually expressed via the [shorthand](./language.md#shorthand-value)) is made available as the tag variable of the template.
+`value=`属性（通常は[省略記法](./language.md#shorthand-value)を介して表現されます）は、テンプレートのタグ変数として利用可能になります。
 
 ```marko
 /* answer.marko */
 <return=42>
 ```
 
-The return value may then be used in the parent template:
+戻り値は、親テンプレートで使用できます:
 
 ```marko
 <answer/value/>
@@ -227,11 +227,11 @@ The return value may then be used in the parent template:
 <div>${value}</div>
 ```
 
-### Assignable Return Value
+### 代入可能な戻り値
 
-By default, an exposed variable can not be assigned a value. Value assignment may be enabled with the `valueChange=` attribute on the `<return>`.
+デフォルトでは、公開された変数には値を代入できません。値の代入は、`<return>`の`valueChange=`属性で有効にできます。
 
-If a `valueChange=` attribute is provided, it is called whenever the tag variable is assigned a value.
+`valueChange=`属性が提供されている場合、タグ変数に値が代入されるたびに呼び出されます。
 
 ```marko
 /* uppercase.marko */
@@ -246,20 +246,20 @@ export interface Input {
 }/>
 ```
 
-In the above example, the exposed tag variable is initialized to an UPPERCASE version of `input.value` and when new values are assigned it will first UPPERCASE the value before storing it in state.
+上記の例では、公開されたタグ変数は`input.value`の大文字バージョンに初期化され、新しい値が代入されると、状態に格納する前にまず値を大文字にします。
 
 ```marko
 <uppercase/value=""/>
 <input onInput(e) { value = e.target.value }/>
-<div>${value}</div> // value is always uppercased
+<div>${value}</div> // valueは常に大文字
 ```
 
 ## `<script>`
 
-The `<script>` tag has special behavior in Marko.
+`<script>`タグは、Markoで特別な動作をします。
 
-The content of a `<script>` tag is executed first when the template has finished rendering and is mounted in the browser.
-It will also be executed _again_ after any [Tag Variable](./language.md#tag-variables) or [Tag Parameter](./language.md#tag-parameters) it references has changed.
+`<script>`タグのコンテンツは、テンプレートのレンダリングが完了し、ブラウザにマウントされたときに最初に実行されます。
+また、参照している[タグ変数](./language.md#tag-variables)または[タグパラメータ](./language.md#tag-parameters)のいずれかが変更された後に_再度_実行されます。
 
 ```marko
 <let/count=1>
@@ -268,13 +268,13 @@ It will also be executed _again_ after any [Tag Variable](./language.md#tag-vari
 </button>
 
 <script>
-  // Runs in the browser for each instance of this tag.
-  // Also runs when either `myButton` or `count` updates
+  // このタグの各インスタンスに対してブラウザで実行されます。
+  // また、`myButton`または`count`が更新されたときにも実行されます
   console.log("clicked", myButton(), count, "times");
 </script>
 ```
 
-Often the `<script>` tag is coupled with the [`$signal` api](./language.md#signal) to apply some side effect, and cleanup afterward.
+多くの場合、`<script>`タグは[`$signal` API](./language.md#signal)と組み合わせて、副作用を適用し、その後クリーンアップします。
 
 ```marko
 <script>
@@ -287,22 +287,22 @@ Often the `<script>` tag is coupled with the [`$signal` api](./language.md#signa
 ```
 
 > [!TIP]
-> There are very few cases where you should be using a _real_ `<script>` tag, but if you absolutely need it you can use the [`<html-script>`](#html-script--html-style) fallback.
+> _本物の_`<script>`タグを使用すべきケースはほとんどありませんが、絶対に必要な場合は[`<html-script>`](#html-script--html-style)のフォールバックを使用できます。
 
 ## `<style>`
 
-The `<style>` tag has special behavior in Marko. No matter how many times a component renders, its styles are only loaded once.
+`<style>`タグは、Markoで特別な動作をします。コンポーネントが何回レンダリングされても、そのスタイルは一度だけロードされます。
 
 ```marko
 <style>
-  /* Bundled and loaded once */
+  /* バンドルされ、一度だけロードされます */
   body {
     color: green;
   }
 </style>
 ```
 
-The `<style>` may include a file extension to enable css preprocessors such as [scss](https://sass-lang.com/documentation/syntax/#scss) and [less](https://lesscss.org/).
+`<style>`には、[scss](https://sass-lang.com/documentation/syntax/#scss)や[less](https://lesscss.org/)などのCSSプリプロセッサを有効にするファイル拡張子を含めることができます。
 
 ```marko
 <style.scss>
@@ -326,7 +326,7 @@ The `<style>` may include a file extension to enable css preprocessors such as [
 <div class="fancy-less">Hello!</div>
 ```
 
-If the `<style>` tag has a [Tag Variable](./language.md#tag-variables), it leverages [CSS Modules](https://github.com/css-modules/css-modules) to expose its classes as an object.
+`<style>`タグに[タグ変数](./language.md#tag-variables)がある場合、[CSSモジュール](https://github.com/css-modules/css-modules)を活用して、そのクラスをオブジェクトとして公開します。
 
 ```marko
 <style/styles>
@@ -341,11 +341,11 @@ If the `<style>` tag has a [Tag Variable](./language.md#tag-variables), it lever
 ```
 
 > [!TIP]
-> There are very few cases where you should be using a _real_ inline `<style>` tag but if needed you can use the fallback [`<html-style>`](#html-script--html-style) tag.
+> _本物の_インライン`<style>`タグを使用すべきケースはほとんどありませんが、必要な場合はフォールバック[`<html-style>`](#html-script--html-style)タグを使用できます。
 
 ## `<define>`
 
-The `<define>` tag is primarily used to create reusable snippets of markup that can be shared across the template.
+`<define>`タグは、主にテンプレート全体で共有できる再利用可能なマークアップのスニペットを作成するために使用されます。
 
 ```marko
 <define/MyTag|input: { name: string }| foo=1>
@@ -358,10 +358,10 @@ The `<define>` tag is primarily used to create reusable snippets of markup that 
 <div>${MyTag.foo}</div>
 ```
 
-The [Tag Variable](./language.md#tag-variables) reflects the attributes the `<define>` tag was provided (including the [content](./language.md#tag-content)).
+[タグ変数](./language.md#tag-variables)は、`<define>`タグに提供された属性（[コンテンツ](./language.md#tag-content)を含む）を反映します。
 
 > [!TIP]
-> The implementation of the `<define>` tag above is conceptually identical to [`<return>`](#return)ing its `input`. 🤯
+> 上記の`<define>`タグの実装は、概念的にはその`input`を[`<return>`](#return)するのと同じです。🤯
 >
 > ```marko
 > /* define.marko */
@@ -371,23 +371,23 @@ The [Tag Variable](./language.md#tag-variables) reflects the attributes the `<de
 
 ## `<lifecycle>`
 
-The `<lifecycle>` tag is used to synchronize side-effects from imperative client APIs.
+`<lifecycle>`タグは、命令型クライアントAPIからの副作用を同期するために使用されます。
 
 ```marko
 <lifecycle
   onMount() {
-    // Called once this tag is attached to the dom, and never again.
+    // このタグがDOMに接続されたときに一度だけ呼び出され、二度と呼び出されません。
   }
   onUpdate() {
-    // Called every time the dependencies of the `onUpdate` function are invalidated.
+    // `onUpdate`関数の依存関係が無効化されるたびに呼び出されます。
   }
   onDestroy() {
-    // Called once this tag is removed from the dom.
+    // このタグがDOMから削除されたときに一度だけ呼び出されます。
   }
 />
 ```
 
-The `this` is consistent across the lifetime of the `<lifecycle>` tag and can be mutated.
+`this`は`<lifecycle>`タグの生涯にわたって一貫しており、変更できます。
 
 ```marko
 client import { WorldMap } from "world-map-api";
@@ -410,11 +410,11 @@ client import { WorldMap } from "world-map-api";
 ```
 
 > [!TIP]
-> All attributes on the `<lifecycle>` tag attributes available as the `this` in any of the event handler attributes.
+> `<lifecycle>`タグのすべての属性は、イベントハンドラ属性のいずれかで`this`として利用できます。
 
 ## `<id>`
 
-The `<id>` tag exposes a [Tag Variable](./language.md#tag-variables) with a short unique id string (compatible with [`id=` and aria attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)).
+`<id>`タグは、短い一意のID文字列（[`id=`およびaria属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)と互換性があります）を持つ[タグ変数](./language.md#tag-variables)を公開します。
 
 ```marko
 <id/cheeseId/>
@@ -422,7 +422,7 @@ The `<id>` tag exposes a [Tag Variable](./language.md#tag-variables) with a shor
 <input id=cheeseId type="checkbox" name="cheese">
 ```
 
-If the `value=` attribute contains a non-nullable value, it will be used instead of the generated one.
+`value=`属性にnull不可の値が含まれている場合、生成されたものの代わりにそれが使用されます。
 
 ```marko
 /* textbox.marko */
@@ -439,9 +439,9 @@ export interface Input {
 
 ## `<log>`
 
-The `<log>` tag performs a [console.log](https://developer.mozilla.org/en-US/docs/Web/API/console/log_static) of its `value=` attribute (shown here using [the shorthand](./language.md#shorthand-value)).
+`<log>`タグは、その`value=`属性の[console.log](https://developer.mozilla.org/en-US/docs/Web/API/console/log_static)を実行します（ここでは[省略記法](./language.md#shorthand-value)を使用して示されています）。
 
-The log is re-executed each time its tag variable updates.
+ログは、タグ変数が更新されるたびに再実行されます。
 
 ```marko
 <let/count=0>
@@ -449,11 +449,11 @@ The log is re-executed each time its tag variable updates.
 <button onClick() { count++ }>Log</button>
 ```
 
-This logs `Current count: 0` on both server and client and again whenever `count` changes.
+これにより、サーバーとクライアントの両方で`Current count: 0`がログに記録され、`count`が変更されるたびに再度記録されます。
 
 ## `<debug>`
 
-The `<debug>` tag injects a [`debugger` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger) within the template that will be executed once the tag renders.
+`<debug>`タグは、タグがレンダリングされたときに実行される[`debugger`ステートメント](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger)をテンプレート内に挿入します。
 
 ```marko
 export interface Input {
@@ -462,10 +462,10 @@ export interface Input {
 
 <const/{ stuff } = input>
 
-<debug/> // Can be useful to inspect render-scoped variables with a debugger.
+<debug/> // デバッガでレンダースコープの変数を検査するのに役立ちます。
 ```
 
-If a `value=` attribute is included, the debugger will be executed whenever it changes.
+`value=`属性が含まれている場合、デバッガは変更されるたびに実行されます。
 
 ```marko
 export interface Input {
@@ -476,11 +476,11 @@ export interface Input {
 <debug=[input.firstName, input.lastName]>
 ```
 
-This debugger executes on the initial render and whenever `input.firstName` or `input.lastName` changes.
+このデバッガは、初期レンダリング時と`input.firstName`または`input.lastName`が変更されたときに実行されます。
 
 ## `<await>`
 
-The `<await>` tag unwraps the promise in its [`value=` attribute](./language.md#shorthand-value) and exposes it through a [tag parameter](./language.md#tag-parameters).
+`<await>`タグは、その[`value=`属性](./language.md#shorthand-value)内のPromiseをアンラップし、[タグパラメータ](./language.md#tag-parameters)を通じて公開します。
 
 ```marko
 <await|user|=getUser()>
@@ -489,7 +489,7 @@ The `<await>` tag unwraps the promise in its [`value=` attribute](./language.md#
 </await>
 ```
 
-If this tag has a [`<try>`](#try) ancestor with a [`@placeholder`](#placeholder), the placeholder content is shown while the promise is pending.
+このタグに[`@placeholder`](#placeholder)を持つ[`<try>`](#try)祖先がある場合、Promiseが保留中の間、プレースホルダーコンテンツが表示されます。
 
 ```marko
 <try>
@@ -511,11 +511,11 @@ If this tag has a [`<try>`](#try) ancestor with a [`@placeholder`](#placeholder)
 
 ## `<try>`
 
-The `<try>` tag is used for catching runtime errors and managing asynchronous boundaries. It has two optional [attribute tags](./language.md#attribute-tags): `@catch` and `@placeholder`.
+`<try>`タグは、実行時エラーをキャッチし、非同期境界を管理するために使用されます。2つのオプションの[属性タグ](./language.md#attribute-tags)があります: `@catch`と`@placeholder`。
 
 ### `@catch`
 
-When a runtime error occurs in the [content](./language.md#tag-content) of the `<try>` or its `@placeholder` attribute tag, the content is replaced with the content of the `@catch` attribute tag. The thrown `error` is made available as the [tag parameter](./language.md#tag-parameters) of the `@catch`.
+`<try>`の[コンテンツ](./language.md#tag-content)またはその`@placeholder`属性タグで実行時エラーが発生すると、コンテンツは`@catch`属性タグのコンテンツに置き換えられます。スローされた`error`は、`@catch`の[タグパラメータ](./language.md#tag-parameters)として利用可能になります。
 
 ```marko
 <try>
@@ -530,17 +530,17 @@ When a runtime error occurs in the [content](./language.md#tag-content) of the `
 
 ### `@placeholder`
 
-The [content](./language.md#tag-content) of the `@placeholder` [attribute tag](./language.md#attribute-tags) will be displayed while an [`<await>` tag](#await) is pending inside of the content of the `<try>`.
+`@placeholder` [属性タグ](./language.md#attribute-tags)の[コンテンツ](./language.md#tag-content)は、`<try>`のコンテンツ内で[`<await>`タグ](#await)が保留中の間、表示されます。
 
 ## `<html-comment>`
 
-By default, [html comments](./language.md#Comments) are stripped from the output. The `<html-comment>` tag is used to output a literal `<!-- comment -->`.
+デフォルトでは、[HTMLコメント](./language.md#Comments)は出力から除外されます。`<html-comment>`タグは、リテラル`<!-- comment -->`を出力するために使用されます。
 
 ```marko
 <html-comment>Hello, view source</html-comment>
 ```
 
-This tag also exposes a [tag variable](./language.md#tag-variables) which contains a getter to the reference of the [comment node](https://developer.mozilla.org/en-US/docs/Web/API/Comment) in the DOM.
+このタグは、DOM内の[コメントノード](https://developer.mozilla.org/en-US/docs/Web/API/Comment)への参照のゲッターを含む[タグ変数](./language.md#tag-variables)も公開します。
 
 ```marko
 <html-comment/commentNode/>
@@ -552,20 +552,20 @@ This tag also exposes a [tag variable](./language.md#tag-variables) which contai
 
 ## `<html-script>` & `<html-style>`
 
-The [`<script>`](./native-tag.md#script) and [`<style>`](./native-tag.md#style) tags are enhanced to enable best practices and help developers avoid common footguns.
+[`<script>`](./native-tag.md#script)および[`<style>`](./native-tag.md#style)タグは、ベストプラクティスを可能にし、開発者が一般的な落とし穴を避けるのを助けるために拡張されています。
 
-Though not typically needed, vanilla versions of these tags may be written via the `<html-script>` and `<html-style>` tags respectively.
+通常は必要ありませんが、これらのタグのバニラバージョンは、それぞれ`<html-script>`および`<html-style>`タグを介して記述できます。
 
 > [!CAUTION]
-> The `<html-*>` tags are only used for specialized use cases, and should _almost never_ be used over [`<script>`](./native-tag.md#script) or [`<style>`](./native-tag.md#style).
+> `<html-*>`タグは特殊なユースケースにのみ使用され、[`<script>`](./native-tag.md#script)または[`<style>`](./native-tag.md#style)の代わりに使用されることは_ほとんどありません_。
 
 ```marko
-// Literally written out as a `<script>` html tag.
+// 文字通り`<script>` HTMLタグとして書き出されます。
 <html-script type="importmap">
   { "imports": { "square": "./module/shapes/square.js" } }
 </html-script>
 
-// Literally written out as a `<style>` html tag.
+// 文字通り`<style>` HTMLタグとして書き出されます。
 <html-style>
   @import url('https://fonts.googleapis.com/css2?family=Ubuntu&display=swap');
 </html-style>

--- a/docs/reference/custom-tag.md
+++ b/docs/reference/custom-tag.md
@@ -1,23 +1,23 @@
-# Custom Tag Discovery
+# カスタムタグの検出
 
-Custom Tags in Marko allow for reusing markup across the application.
+Markoのカスタムタグは、アプリケーション全体でマークアップを再利用することを可能にします。
 
-## Priority
+## 優先順位
 
-When you use a `<Tag>` in Marko it is resolved in the following order:
+Markoで`<Tag>`を使用する場合、以下の順序で解決されます:
 
-- [Custom Tag Discovery](#custom-tag-discovery)
-  - [Priority](#priority)
-  - [Local Variable Custom Tags](#local-variable-custom-tags)
-  - [Relative Custom Tags](#relative-custom-tags)
-  - [Installed Custom Tags](#installed-custom-tags)
-  - [Supporting Files](#supporting-files)
+- [カスタムタグの検出](#カスタムタグの検出)
+  - [優先順位](#優先順位)
+  - [ローカル変数カスタムタグ](#ローカル変数カスタムタグ)
+  - [相対カスタムタグ](#相対カスタムタグ)
+  - [インストール済みカスタムタグ](#インストール済みカスタムタグ)
+  - [サポートファイル](#サポートファイル)
 
-## Local Variable Custom Tags
+## ローカル変数カスタムタグ
 
-If a tag name starts with an uppercase letter, Marko first checks for a local variable with the same name.
+タグ名が大文字で始まる場合、Markoはまず同じ名前のローカル変数を確認します。
 
-This is useful for importing custom tags that can't be [discovered automatically](#relative-custom-tags).
+これは、[自動的に検出](#相対カスタムタグ)できないカスタムタグをインポートする際に便利です。
 
 ```marko
 import MyTag from "./my-tag.marko"
@@ -25,7 +25,7 @@ import MyTag from "./my-tag.marko"
 <MyTag/>
 ```
 
-or when using the [`<define>` tag](./core-tag.md#define)
+または、[`<define>`タグ](./core-tag.md#define)を使用する場合:
 
 ```marko
 <define/MyTag|input: { name: string }| foo=1>
@@ -37,7 +37,7 @@ or when using the [`<define>` tag](./core-tag.md#define)
 ```
 
 > [!NOTE]
-> If you need to reference a local variable that is _not_ `PascalCase`, you can do so using a [dynamic tag](./language.md#dynamic-tags).
+> `PascalCase`では_ない_ローカル変数を参照する必要がある場合は、[動的タグ](./language.md#dynamic-tags)を使用できます。
 >
 > ```marko
 > import { camelCaseTag } from "somewhere"
@@ -45,15 +45,15 @@ or when using the [`<define>` tag](./core-tag.md#define)
 > <${camelCaseTag} />
 > ```
 
-## Relative Custom Tags
+## 相対カスタムタグ
 
-If Marko did not resolve a [local variable tag name](#local-variable-custom-tags) it checks the file system. From the current file, it looks recursively upward for:
+Markoが[ローカル変数タグ名](#ローカル変数カスタムタグ)を解決できなかった場合、ファイルシステムをチェックします。現在のファイルから、以下を再帰的に上方向へ探します:
 
 - `tags/TAG_NAME.marko`
 - `tags/TAG_NAME/index.marko`
 - `tags/TAG_NAME/TAG_NAME.marko`
 
-Let's take a look at an example directory structure to understand this better:
+これをよりよく理解するために、ディレクトリ構造の例を見てみましょう:
 
 ```
 tags/
@@ -70,25 +70,25 @@ pages/
         page.marko
 ```
 
-The file `pages/home/page.marko` can resolve:
+ファイル`pages/home/page.marko`は以下を解決できます:
 
 - `<app-header>`
 - `<app-footer>`
 - `<home-banner>`
 
-And the file `pages/about/page.marko` can resolve:
+そして、ファイル`pages/about/page.marko`は以下を解決できます:
 
 - `<app-header>`
 - `<app-footer>`
 - `<team-members>`
 
-The `home` page can't resolve `<team-members>` and the `about` page can't resolve `<home-banner>`. By using nested `tag/` directories, we've scoped our page-specific tags to their respective pages.
+`home`ページは`<team-members>`を解決できず、`about`ページは`<home-banner>`を解決できません。ネストされた`tag/`ディレクトリを使用することで、ページ固有のタグをそれぞれのページにスコープしています。
 
-## Installed Custom Tags
+## インストール済みカスタムタグ
 
-If no Local Variable or Relative Custom Tag is found, Marko checks installed tag libraries in your `node_modules`.
+ローカル変数または相対カスタムタグが見つからない場合、Markoは`node_modules`内のインストール済みタグライブラリをチェックします。
 
-Packages that provide Marko Custom Tags must include a `marko.json` at the root which tells Marko where the exported tags are.
+Markoカスタムタグを提供するパッケージは、ルートに`marko.json`を含める必要があり、これがエクスポートされたタグの場所をMarkoに伝えます。
 
 ```json
 /* marko.json */
@@ -97,19 +97,19 @@ Packages that provide Marko Custom Tags must include a `marko.json` at the root 
 }
 ```
 
-This example file tells Marko to expose all Custom Tags directly under the `dist/tags/` directory to the application using your package.
+この例のファイルは、パッケージを使用するアプリケーションに対して、`dist/tags/`ディレクトリ直下のすべてのカスタムタグを公開するようMarkoに指示します。
 
 > [!TIP]
-> Often a tag library will have "private tags" and "exported tags". A common way to achieve this is to have a `tags/` folder _within_ the exported `tags/` folder 🤯.
+> タグライブラリには「プライベートタグ」と「エクスポートされたタグ」があることがよくあります。これを実現する一般的な方法は、エクスポートされた`tags/`フォルダの_内部_に`tags/`フォルダを配置することです🤯。
 >
-> For example, when exporting `dist/tags`, `dist/tags/tags/` could contain private components only available _within_ the library.
+> 例えば、`dist/tags`をエクスポートする場合、`dist/tags/tags/`にはライブラリ_内部_でのみ利用可能なプライベートコンポーネントを含めることができます。
 
 > [!CAUTION]
-> If two packages export the tag name, Marko will choose the one it finds first. To prevent collisions, tag libraries are encouraged to prefix all exported tag names, e.g. `ebay-`. If you must use tags with conflicting names, you can import by path to disambiguate.
+> 2つのパッケージが同じタグ名をエクスポートする場合、Markoは最初に見つけたものを選択します。衝突を防ぐために、タグライブラリはすべてのエクスポートされたタグ名にプレフィックスを付けることが推奨されます（例: `ebay-`）。競合する名前のタグを使用する必要がある場合は、パスでインポートして曖昧さを解消できます。
 
-## Supporting Files
+## サポートファイル
 
-Marko discovers [`style`](./styling.md) and `marko-tag.json` files adjacent to the `.marko` file.
+Markoは、`.marko`ファイルに隣接する[`style`](./styling.md)および`marko-tag.json`ファイルを検出します。
 
 ```
 foo.marko
@@ -117,9 +117,9 @@ foo.style.css
 foo.marko-tag.json
 ```
 
-Here, the `<foo>` tag has associated styles and metadata.
+ここでは、`<foo>`タグに関連するスタイルとメタデータがあります。
 
-When the file is named `index.marko` the prefix is optional.
+ファイル名が`index.marko`の場合、プレフィックスはオプションです。
 
 ```
 tags/
@@ -131,9 +131,9 @@ tags/
     marko-tag.json
 ```
 
-Here, the `<bar>` tag has an associated `style.css` and the `<baz>` tag has an associated `marko-tag.json`.
+ここでは、`<bar>`タグに関連する`style.css`があり、`<baz>`タグに関連する`marko-tag.json`があります。
 
-For `style` files any extension may be used allowing for CSS preprocessors.
+`style`ファイルには任意の拡張子を使用でき、CSSプリプロセッサが利用できます。
 
 ```
 tags/

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -1,10 +1,10 @@
-# Language Reference
+# 言語リファレンス
 
-Marko is a superset of [well-formed](https://en.wikipedia.org/wiki/Well-formed_document) HTML.
+Markoは、[整形式](https://en.wikipedia.org/wiki/Well-formed_document) HTMLのスーパーセットです。
 
-The language makes HTML more strict while extending it with control flow and reactive data bindings. It does this by meshing JavaScript syntax features with HTML and introducing a few new syntaxes of its own. Most HTML is valid Marko but there are some important deviations.
+この言語は、制御フローとリアクティブデータバインディングでHTMLを拡張しながら、HTMLをより厳密にします。これは、JavaScript構文機能をHTMLとメッシュし、独自のいくつかの新しい構文を導入することで実現します。ほとんどのHTMLは有効なMarkoですが、いくつかの重要な相違点があります。
 
-## Syntax Legend
+## 構文凡例
 
 <div class="code-block">
 <pre class="html html-ts"><code><a href="#statements">import "...";</a>
@@ -19,55 +19,55 @@ The language makes HTML more strict while extending it with control flow and rea
 </div>
 
 > [!NOTE]
-> Jump to the section for a syntax by clicking on it.
-> The legend is not comprehensive, for more see:
+> 構文をクリックすることで、そのセクションにジャンプできます。
+> 凡例は包括的ではありません。詳細については、以下を参照してください:
 >
-> - [`<${dynamic}/>` tag](#dynamic-tags)
-> - [Attributes](#attributes) for various attribute shorthands
-> - [Tag Arguments](#tag-arguments) as an alternative to attributes
-> - [Concise Mode](./concise-syntax.md)
+> - [`<${dynamic}/>`タグ](#dynamic-tags)
+> - さまざまな属性省略記法については[属性](#attributes)
+> - 属性の代替としての[タグ引数](#tag-arguments)
+> - [簡潔モード](./concise-syntax.md)
 
-## Template Variables
+## テンプレート変数
 
-Within Marko templates a few variables are automatically made available.
+Markoテンプレート内では、いくつかの変数が自動的に利用可能になります。
 
 ### `input`
 
-A JavaScript object globally available in every template that gives access to the [attributes](#attributes) it was provided from a [custom tag](./custom-tag.md) or the data passed in through the [top level api](./template.md).
+すべてのテンプレートでグローバルに利用可能なJavaScriptオブジェクトで、[カスタムタグ](./custom-tag.md)から提供された[属性](#attributes)または[トップレベルAPI](./template.md)を通じて渡されたデータへのアクセスを提供します。
 
 ### `$signal`
 
-An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) is available in all JavaScript statements, expressions, and blocks in a `.marko` file.
+[`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)は、`.marko`ファイル内のすべてのJavaScriptステートメント、式、およびブロックで利用できます。
 
-It is aborted when
+これは以下の場合に中止されます
 
-1. The expression is invalidated
-2. The template or [tag content](#tag-content) is removed from the DOM
+1. 式が無効化されたとき
+2. テンプレートまたは[タグコンテンツ](#tag-content)がDOMから削除されたとき
 
-This is primarily to handle cleaning up side effects.
+これは主に副作用のクリーンアップを処理するためのものです。
 
 > [!TIP]
-> Many built-in APIs like [`addEventListener()`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal) include the option to pass a signal for cleanup.
+> [`addEventListener()`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal)などの多くの組み込みAPIには、クリーンアップのためにシグナルを渡すオプションが含まれています。
 >
 > ```marko
 > <script>
 >   document.addEventListener("resize", () => {
->     // this function will be automatically cleaned up
+>     // この関数は自動的にクリーンアップされます
 >   }, { signal: $signal })
 > </script>
 > ```
 
 ### `$global`
 
-Gives access the ["render globals"](./template.md#inputglobal) provided through the [top level api](./template.md).
+[トップレベルAPI](./template.md)を通じて提供される[「レンダーグローバル」](./template.md#inputglobal)へのアクセスを提供します。
 
-## Statements
+## ステートメント
 
-Marko supports a few module scoped top level statements.
+Markoは、モジュールスコープのトップレベルステートメントをいくつかサポートしています。
 
 ### `import`
 
-JavaScript [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) statements are allowed at the root of the template.
+JavaScriptの[`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)ステートメントは、テンプレートのルートで使用できます。
 
 ```marko
 import sum from "sum"
@@ -76,11 +76,11 @@ import sum from "sum"
 ```
 
 > [!NOTE]
-> This syntax is a shorthand for [`static import`](#static). For server and client specific imports, you can use [`server` and `client`](#server-and-client) statements.
+> この構文は[`static import`](#static)の省略形です。サーバーとクライアント固有のインポートについては、[`server`と`client`](#server-and-client)ステートメントを使用できます。
 
-#### Tag `import` shorthand
+#### タグ`import`省略記法
 
-[Custom tags](./custom-tag.md) may be referenced using angle brackets in the `from` of the import, which will use Marko's [custom tag discovery logic](./custom-tag.md).
+[カスタムタグ](./custom-tag.md)は、インポートの`from`で山括弧を使用して参照でき、Markoの[カスタムタグ検出ロジック](./custom-tag.md)が使用されます。
 
 ```marko
 import MyTag from "<my-tag>"
@@ -90,7 +90,7 @@ import MyTag from "<my-tag>"
 
 ### `export`
 
-JavaScript [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) statements are allowed at the root of the template.
+JavaScriptの[`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)ステートメントは、テンプレートのルートで使用できます。
 
 ```marko
 export function getAnswer() {
@@ -102,7 +102,7 @@ export function getAnswer() {
 
 ### `static`
 
-Statements prefixed with `static` allow running JavaScript expressions in module scope. The statements will run when the template loaded on the server and in the browser.
+`static`を接頭辞に持つステートメントは、モジュールスコープでJavaScript式を実行できます。このステートメントは、テンプレートがサーバーとブラウザで読み込まれたときに実行されます。
 
 ```marko
 static const answer = 41;
@@ -113,7 +113,7 @@ static function getAnswer() {
 <div data-answer=getAnswer()></div>
 ```
 
-All valid javascript statements are allowed, including functions, declarations, conditions, and blocks.
+関数、宣言、条件、ブロックを含む、すべての有効なJavaScriptステートメントが使用できます。
 
 ```marko
 static {
@@ -123,9 +123,9 @@ static {
 }
 ```
 
-### `server` and `client`
+### `server`と`client`
 
-As an alternative to [`static`](#static), statements prefixed with `server` or `client` allow arbitrary module scoped JavaScript expressions that are exclusively executed when the template is loaded in a specific environment (the server or the browser).
+[`static`](#static)の代わりに、`server`または`client`を接頭辞に持つステートメントを使用すると、テンプレートが特定の環境（サーバーまたはブラウザ）で読み込まれたときにのみ実行される、任意のモジュールスコープのJavaScript式を記述できます。
 
 ```marko
 server console.log("on the server")
@@ -133,7 +133,7 @@ server console.log("on the server")
 client console.log("in the browser")
 ```
 
-All valid javascript statements are allowed, including functions, declarations, conditions, and blocks.
+関数、宣言、条件、ブロックを含む、すべての有効なJavaScriptステートメントが使用できます。
 
 ```marko
 server {
@@ -150,36 +150,36 @@ server {
 ```
 
 > [!TIP]
-> The [`import`](#import) statement is really a shortcut for `static import`. This can be leveraged with `server` and `client` if you want a module to only be imported on one platform
+> [`import`](#import)ステートメントは実際には`static import`のショートカットです。モジュールを1つのプラットフォームでのみインポートしたい場合は、`server`と`client`でこれを活用できます
 >
 > ```marko
 > server import "./init-db"
 > client import "bootstrap"
 > ```
 
-## Tags
+## タグ
 
-Marko supports all native HTML/SVG/whatever tags and attributes. In addition to these, a set of useful [core tags](./core-tags.md) are provided. Each project may have its own [custom tags](./custom-tag.md), and third-party tags may be included through `node_modules`.
+Markoは、すべてのネイティブHTML/SVG/その他のタグと属性をサポートしています。これらに加えて、便利な[コアタグ](./core-tags.md)のセットが提供されています。各プロジェクトには独自の[カスタムタグ](./custom-tag.md)があり、サードパーティのタグは`node_modules`を通じて含めることができます。
 
-All of these types of tags use the same syntax:
+これらすべてのタイプのタグは同じ構文を使用します：
 
 ```marko
 <my-tag/>
 ```
 
-`.marko` files are [automatically discovered](./custom-tag.md#custom-tag-discovery) as [custom tags](./custom-tag.md) (no need for `import`).
+`.marko`ファイルは[カスタムタグ](./custom-tag.md)として[自動的に検出](./custom-tag.md#custom-tag-discovery)されます（`import`は不要です）。
 
-All tags can be [self closed](https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags) when there is no [content](#tag-content). This means `<div/>` is valid, unlike in HTML. Additionally [`void` tags](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) like `<input>` and `<br>` can be [self closed](https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags).
+すべてのタグは、[コンテンツ](#tag-content)がない場合、[自己閉じタグ](https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags)にできます。これは、HTMLとは異なり、`<div/>`が有効であることを意味します。さらに、`<input>`や`<br>`のような[`void`タグ](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)も[自己閉じタグ](https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags)にできます。
 
-In all closing tags, the tag name may be omitted.
+すべての閉じタグでは、タグ名を省略できます。
 
 ```marko
 <div>Hello World</>
 ```
 
-## Attributes
+## 属性
 
-Attribute values are JavaScript expressions:
+属性値はJavaScript式です：
 
 ```marko
 <my-tag str="Hello"></my-tag>
@@ -189,28 +189,28 @@ Attribute values are JavaScript expressions:
 <my-tag fn=function myFn(param1) { console.log("hi") }></my-tag>
 ```
 
-Almost all valid JavaScript expressions can be written as the attribute value.
-Even with `<my-tag str="Hello">` the `"Hello"` string is a JavaScript string literal and not an html attribute string.
+ほぼすべての有効なJavaScript式を属性値として記述できます。
+`<my-tag str="Hello">`の場合でも、`"Hello"`文字列はJavaScript文字列リテラルであり、HTML属性文字列ではありません。
 
-Attributes can be thought of as JavaScript objects in Marko which are passed to a tag.
+属性は、Markoではタグに渡されるJavaScriptオブジェクトと考えることができます。
 
 > [!CAUTION]
-> Values cannot contain an unenclosed `>` since it is ambiguous. These expressions must use parentheses:
+> 値には、括弧で囲まれていない`>`を含めることはできません（曖昧になるため）。これらの式は括弧を使用する必要があります：
 >
 > ```marko
 > <my-tag value=(1 > 2)></my-tag>
 > ```
 
-### Skipped Attributes
+### スキップされる属性
 
-If an attribute value is `null`, `undefined` or `false` it will not be written to the html.
+属性値が`null`、`undefined`、または`false`の場合、HTMLに書き込まれません。
 
 > [!NOTE]
-> Not _all_ [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) values are skipped. `0`, `NaN`, and `""` will still be written.
+> _すべての_[falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)値がスキップされるわけではありません。`0`、`NaN`、`""`は引き続き書き込まれます。
 
-### Boolean Attributes
+### 真偽値属性
 
-[HTML boolean attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) become JavaScript booleans.
+[HTMLの真偽値属性](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML)はJavaScriptの真偽値になります。
 
 ```marko
 <input type="checkbox" checked>
@@ -219,54 +219,54 @@ If an attribute value is `null`, `undefined` or `false` it will not be written t
 
 > [!IMPORTANT]
 >
-> [ARIA enumerated attributes](https://developer.mozilla.org/en-US/docs/Glossary/Enumerated#aria_enumerated_attributes) use strings instead of booleans, so make sure to pass a string.
+> [ARIA列挙属性](https://developer.mozilla.org/en-US/docs/Glossary/Enumerated#aria_enumerated_attributes)は真偽値の代わりに文字列を使用するため、必ず文字列を渡してください。
 >
 > ```marko
-> // ❌ WRONG: Don't do this
+> // ❌ 間違い：これはしないでください
 > <button aria-pressed=isPressed />
 > // outputs <button aria-pressed=""/>
 > ```
 >
 > ```marko
-> // 👍 Correct use of aria attributes
+> // 👍 正しいaria属性の使用
 > <button aria-pressed=isPressed && "true" />
 > // outputs <button aria-pressed="true"/>
 > ```
 
-### Spread Attributes
+### スプレッド属性
 
-Attributes may be dynamically included with the [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals) syntax.
+属性は、[スプレッド](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals)構文を使用して動的に含めることができます。
 
 ```marko
 <my-tag ...input foo="bar"/>
 ```
 
-In this case `<my-tag>` would receive the attributes as an object like `{ ...input, foo: "bar" }`.
+この場合、`<my-tag>`は`{ ...input, foo: "bar" }`のようなオブジェクトとして属性を受け取ります。
 
-Attributes are merged from left to right, with later spreads overriding earlier ones if there are conflicts.
+属性は左から右にマージされ、競合がある場合は後のスプレッドが前のものを上書きします。
 
 > [!NOTE]
-> The value after the `...` (like [in JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals)) can be any valid JavaScript expression. This means it can be used to leverage shorthand property names:
+> `...`の後の値は（[JavaScriptと同様に](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals)）任意の有効なJavaScript式を使用できます。つまり、省略記法のプロパティ名を活用できます：
 >
 > ```marko
 > <my-tag ...{ property }/>
 > ```
 
-### Shorthand Methods
+### メソッド省略記法
 
-[Method definitions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) allow for a concise way to pass functions as attributes, such as event handlers.
+[メソッド定義](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)を使用すると、イベントハンドラなどの関数を属性として渡す簡潔な方法が提供されます。
 
 ```marko
 <button onClick(e) { console.log(e.target) }>Click Me</button>
 ```
 
-### Shorthand Change Handlers (Two-Way Binding)
+### 変更ハンドラ省略記法（双方向バインディング）
 
-The change handler shorthand (`:=`) provides both a value for an attribute and a change handler with the attribute's name suffixed by "Change".
+変更ハンドラ省略記法（`:=`）は、属性の値と、属性名に「Change」をサフィックスとして付けた変更ハンドラの両方を提供します。
 
-The value must be an [Identifier](https://developer.mozilla.org/en-US/docs/Glossary/Identifier) or a [Property Accessor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors).
+値は[識別子](https://developer.mozilla.org/en-US/docs/Glossary/Identifier)または[プロパティアクセサ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors)である必要があります。
 
-For [Identifiers](https://developer.mozilla.org/en-US/docs/Glossary/Identifier), the change handler desugars to a function with an assignment.
+[識別子](https://developer.mozilla.org/en-US/docs/Glossary/Identifier)の場合、変更ハンドラは代入を伴う関数に展開されます。
 
 ```marko
 <counter value:=count/>
@@ -276,7 +276,7 @@ For [Identifiers](https://developer.mozilla.org/en-US/docs/Glossary/Identifier),
 <counter value=count valueChange(newCount) { count = newCount }/>
 ```
 
-For [Property Accessors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors), the change handler desugars to a member expression with a `Change` suffix.
+[プロパティアクセサ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors)の場合、変更ハンドラは`Change`サフィックスを持つメンバー式に展開されます。
 
 ```marko
 <counter value:=input.count/>
@@ -286,9 +286,9 @@ For [Property Accessors](https://developer.mozilla.org/en-US/docs/Web/JavaScript
 <counter value=input.count valueChange=input.countChange/>
 ```
 
-### Shorthand `class` and `id`
+### `class`と`id`の省略記法
 
-[Emmet style](https://docs.emmet.io/abbreviations/syntax/#id-and-class) `class` and `id` attribute shorthands are supported.
+[Emmetスタイル](https://docs.emmet.io/abbreviations/syntax/#id-and-class)の`class`と`id`属性の省略記法がサポートされています。
 
 ```marko no-format
 <div#foo.bar.baz/>
@@ -299,15 +299,15 @@ For [Property Accessors](https://developer.mozilla.org/en-US/docs/Web/JavaScript
 ```
 
 > [!TIP]
-> Interpolations are supported within a dynamic class/id.
+> 動的なclass/id内で補間がサポートされています。
 >
 > ```marko no-format
 > <div.icon-${iconName}/>
 > ```
 
-### Shorthand `value`
+### `value`の省略記法
 
-It is common for a tag to use a single input property; therefore Marko allows a shorthand for passing an attribute named `value`. If the attribute name is omitted at the beginning of a tag, it will be passed as `value`.
+タグが単一の入力プロパティを使用することは一般的です。そのため、Markoは`value`という名前の属性を渡すための省略記法を提供しています。タグの先頭で属性名を省略すると、`value`として渡されます。
 
 ```marko
 <my-tag=1/>
@@ -317,7 +317,7 @@ It is common for a tag to use a single input property; therefore Marko allows a 
 <my-tag value=1/>
 ```
 
-The [method shorthand](#shorthand-methods) can be combined with the value attribute to give us the _value method shorthand_.
+[メソッド省略記法](#shorthand-methods)は、value属性と組み合わせることができ、_valueメソッド省略記法_を提供します。
 
 ```marko
 <my-tag() {
@@ -333,30 +333,30 @@ The [method shorthand](#shorthand-methods) can be combined with the value attrib
 // Received by the child as { value() { ... } }
 ```
 
-### Attribute Termination
+### 属性の終端
 
-Attributes can be terminated with a comma. This is useful in [concise mode](./concise-syntax.md#attributes-on-multiple-lines).
+属性はカンマで終端できます。これは[簡潔モード](./concise-syntax.md#attributes-on-multiple-lines)で便利です。
 
 ```marko
 <my-tag a=1, b=2/>
 ```
 
 > [!CAUTION]
-> Sequence expressions with [comma operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) must be wrapped in parentheses
+> [カンマ演算子](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator)を使用したシーケンス式は括弧で囲む必要があります
 >
 > ```marko
 > <my-tag a=(console.log(foo), foo)/>
 > ```
 
-## Tag Content
+## タグコンテンツ
 
-Markup within the body of a tag is made available as the `content` property of its [`input`](#input).
+タグの本体内のマークアップは、[`input`](#input)の`content`プロパティとして利用可能になります。
 
 ```marko
 <my-tag>Content</my-tag>
 ```
 
-The implementation of `<my-tag>` above can write out the content by passing its `input.content` to a [dynamic tag](#dynamic-tags):
+上記の`<my-tag>`の実装は、`input.content`を[動的タグ](#dynamic-tags)に渡すことでコンテンツを書き出すことができます：
 
 ```marko
 export interface Input {
@@ -368,9 +368,9 @@ export interface Input {
 </div>
 ```
 
-### Dynamic Text
+### 動的テキスト
 
-Dynamic text content can be `${interpolated}` in the tag content. This uses the same syntax as [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in JavaScript.
+動的テキストコンテンツは、タグコンテンツ内で`${補間}`できます。これはJavaScriptの[テンプレートリテラル](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)と同じ構文を使用します。
 
 ```marko
 export interface Input {
@@ -383,11 +383,11 @@ export interface Input {
 ```
 
 > [!NOTE]
-> The interpolated value is automatically escaped to avoid [XSS](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XSS).
+> 補間された値は、[XSS](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XSS)を回避するために自動的にエスケープされます。
 
-## Attribute Tags
+## 属性タグ
 
-Tags prefixed with an `@` are not rendered, but instead passed alongside attributes in [`input`](./language.md#input). Attribute tags allow for passing named or repeated [content](#tag-content) as additional attributes.
+`@`で始まるタグはレンダリングされず、代わりに[`input`](./language.md#input)の属性と一緒に渡されます。属性タグは、名前付きまたは繰り返しの[コンテンツ](#tag-content)を追加の属性として渡すことができます。
 
 ```marko
 <my-layout title="Welcome">
@@ -399,9 +399,9 @@ Tags prefixed with an `@` are not rendered, but instead passed alongside attribu
 </my-layout>
 ```
 
-Here, `@header` is available to `<my-layout>` as `input.header`. The `class` attribute from `@header` is in `input.header.class` and its content is in `input.header.content`.
+ここで、`@header`は`<my-layout>`に`input.header`として利用可能です。`@header`の`class`属性は`input.header.class`に、そのコンテンツは`input.header.content`にあります。
 
-The full [input](./language.md#input) object provided to `<my-tag>` in this example would look like:
+この例で`<my-tag>`に提供される完全な[input](./language.md#input)オブジェクトは次のようになります：
 
 ```js
 // a representation of `input` received by `my-layout.marko` (from the previous code snippet)
@@ -415,7 +415,7 @@ The full [input](./language.md#input) object provided to `<my-tag>` in this exam
 }
 ```
 
-The implementation of `my-layout.marko` might look like
+`my-layout.marko`の実装は次のようになります
 
 ```marko
 export interface Input {
@@ -455,11 +455,11 @@ export interface Input {
 ```
 
 > [!NOTE]
-> Control flow tags ([`<if>`](./core-tag.md#if--else) and [`<for>`](./core-tag.md#for)) cannot contain attribute tags themselves, and instead are used for [dynamically creating attribute tags](#conditional-attribute-tags).
+> 制御フロータグ（[`<if>`](./core-tag.md#if--else)と[`<for>`](./core-tag.md#for)）自体は属性タグを含めることができず、代わりに[属性タグを動的に作成](#conditional-attribute-tags)するために使用されます。
 
-### Nested Attribute tags
+### ネストされた属性タグ
 
-Attribute tags may be nested in other attribute tags.
+属性タグは他の属性タグ内にネストできます。
 
 ```marko
 <my-tag>
@@ -469,7 +469,7 @@ Attribute tags may be nested in other attribute tags.
 </>
 ```
 
-Would provide the following as input
+これは次のような入力を提供します
 
 ```js
 {
@@ -480,9 +480,9 @@ Would provide the following as input
 }
 ```
 
-### Repeated Attribute Tags
+### 繰り返し属性タグ
 
-When multiple attribute tags share a name, all instances may be consumed using the [iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol).
+複数の属性タグが名前を共有する場合、すべてのインスタンスは[イテラブルプロトコル](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)を使用して消費できます。
 
 ```marko
 <my-menu>
@@ -496,7 +496,7 @@ When multiple attribute tags share a name, all instances may be consumed using t
 </my-menu>
 ```
 
-This example uses two `<@item>` tags, but `<my-menu>` receives only a single `item` attribute.
+この例では2つの`<@item>`タグを使用していますが、`<my-menu>`は単一の`item`属性のみを受け取ります。
 
 ```js
 {
@@ -514,7 +514,7 @@ This example uses two `<@item>` tags, but `<my-menu>` receives only a single `it
 }
 ```
 
-The other `<@item>` tags are reached through the iterator. The most common way to do so is with a [for tag](./core-tag.md#for) or one of JavaScript's [syntaxes for iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#syntaxes_expecting_iterables).
+他の`<@item>`タグはイテレータを通じてアクセスされます。最も一般的な方法は、[forタグ](./core-tag.md#for)またはJavaScriptの[イテラブルの構文](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#syntaxes_expecting_iterables)のいずれかを使用することです。
 
 ```marko
 /* my-menu.marko */
@@ -531,10 +531,10 @@ export interface Input {
 </for>
 ```
 
-Attribute tags are generally singular by name, even when repeated. Prefer singular property names when consuming repeated attribute tags (for example, iterate `input.item` rather than `input.items`).
+属性タグは、繰り返される場合でも、一般的に名前は単数形です。繰り返し属性タグを消費する場合は、単数形のプロパティ名を使用してください（例：`input.items`ではなく`input.item`を反復処理します）。
 
 > [!TIP]
-> If you need repeated attribute tags as a list, it is a common pattern to spread into an array with a [`<const>` tag](./core-tag.md#const)
+> 繰り返し属性タグをリストとして必要とする場合、[`<const>`タグ](./core-tag.md#const)を使用して配列にスプレッドするのが一般的なパターンです
 >
 > ```marko
 > export interface Input {
@@ -546,9 +546,9 @@ Attribute tags are generally singular by name, even when repeated. Prefer singul
 > <div>${items.length}</div>
 > ```
 
-### Conditional Attribute Tags
+### 条件付き属性タグ
 
-Attribute tags are generally provided directly to their immediate parent. The exception to this is control flow tags ([`<if>`](./core-tag.md#if--else) and [`<for>`](./core-tag.md#for)), which are used to dynamically apply attribute tags.
+属性タグは通常、直接の親に直接提供されます。これの例外は制御フロータグ（[`<if>`](./core-tag.md#if--else)と[`<for>`](./core-tag.md#for)）で、これらは属性タグを動的に適用するために使用されます。
 
 ```marko
 <my-message>
@@ -561,7 +561,7 @@ Attribute tags are generally provided directly to their immediate parent. The ex
 </my-message>
 ```
 
-In this case, the `@title` received by `<my-message>` depends on `welcome`.
+この場合、`<my-message>`が受け取る`@title`は`welcome`に依存します。
 
 ```marko
 <my-select>
@@ -573,16 +573,16 @@ In this case, the `@title` received by `<my-message>` depends on `welcome`.
 </my-select>
 ```
 
-Here, `<my-select>` unconditionally receives the first `@option`, and also all of the `@option` tags applied by the `<for>` loop.
+ここでは、`<my-select>`は最初の`@option`を無条件に受け取り、`<for>`ループによって適用されるすべての`@option`タグも受け取ります。
 
 > [!NOTE]
-> You can't mix [attribute tags](#attribute-tags) with default [content](#tag-content) while inside a [control flow tag](./core-tag.md#if--else).
+> [制御フロータグ](./core-tag.md#if--else)内では、[属性タグ](#attribute-tags)をデフォルトの[コンテンツ](#tag-content)と混在させることはできません。
 
-## Tag Variables
+## タグ変数
 
-Tag variables expose a value from a tag to be used within a template (from a custom tag, the variable is taken from its [`<return>`](./core-tag.md#return)). These variables are not _quite_ like JavaScript variables, as they are used to power [Marko's compiled reactivity](./reactivity.md).
+タグ変数は、テンプレート内で使用するためにタグから値を公開します（カスタムタグからは、変数はその[`<return>`](./core-tag.md#return)から取得されます）。これらの変数は、[Markoのコンパイル済みリアクティビティ](./reactivity.md)を強化するために使用されるため、JavaScript変数とは_まったく_同じではありません。
 
-Tag Variables use a `/` followed by a valid JavaScript [identifier](https://developer.mozilla.org/en-US/docs/Glossary/Identifier) or [destructure assignment pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) after the tag name.
+タグ変数は、タグ名の後に`/`と、有効なJavaScript[識別子](https://developer.mozilla.org/en-US/docs/Glossary/Identifier)または[分割代入パターン](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)を続けて使用します。
 
 ```marko
 <my-tag/foo/>
@@ -592,7 +592,7 @@ Tag Variables use a `/` followed by a valid JavaScript [identifier](https://deve
 <div>`my-other-tag` returned an object containing ${bar} and ${baz}</div>
 ```
 
-Native tags have an implicitly returned tag variable that contains a reference to the element.
+ネイティブタグには、要素への参照を含む暗黙的に返されるタグ変数があります。
 
 ```marko
 <div/myDiv/>
@@ -602,13 +602,13 @@ Native tags have an implicitly returned tag variable that contains a reference t
 </script>
 ```
 
-In this case `myDiv` will be a variable which can be called to get the `myDiv` element in the browser.
+この場合、`myDiv`はブラウザで`myDiv`要素を取得するために呼び出すことができる変数になります。
 
-Using the [core `<return>` tag](./core-tag.md#return), any custom tag can return a value into it's parents scope as a tag variable.
+[コア`<return>`タグ](./core-tag.md#return)を使用すると、任意のカスタムタグがタグ変数として親スコープに値を返すことができます。
 
-### Scope
+### スコープ
 
-Tag variables are automatically [hoisted](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) and can be accessed anywhere in the template except for in [module statements](#statements). This means that it is possible to read tag variables from anywhere in the tree.
+タグ変数は自動的に[ホイスト](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting)され、[モジュールステートメント](#statements)を除くテンプレート内のどこからでもアクセスできます。つまり、ツリー内のどこからでもタグ変数を読み取ることができます。
 
 ```marko
 <form>
@@ -621,9 +621,9 @@ Tag variables are automatically [hoisted](https://developer.mozilla.org/en-US/do
 </script>
 ```
 
-## Tag Parameters
+## タグパラメータ
 
-While rendering [content](#tag-content), child may pass information _back_ to its parent using tag parameters.
+[コンテンツ](#tag-content)をレンダリングする間、子はタグパラメータを使用して親に情報を_返す_ことができます。
 
 ```marko
 /* child.marko */
@@ -643,16 +643,16 @@ export interface Input {
 </child>
 ```
 
-This example results in the following HTML:
+この例は次のHTMLを生成します：
 
 ```html
 <div>Rendered with 1337 as the `number=` attribute</div>
 ```
 
-The `|parameters|` are enclosed in pipes after a tag name, and act functionally like [JavaScript function parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#function_parameters) within which the first parameter is an object containing all attributes passed from the child component.
+`|parameters|`はタグ名の後にパイプで囲まれており、機能的には[JavaScript関数パラメータ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#function_parameters)のように動作します。最初のパラメータは子コンポーネントから渡されたすべての属性を含むオブジェクトです。
 
 > [!TIP]
-> Parameters include all features of the [JavaScript function parameters syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#function_parameters), so feel free to destructure.
+> パラメータには[JavaScript関数パラメータ構文](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#function_parameters)のすべての機能が含まれているため、自由に分割できます。
 >
 > ```marko
 > <child|{ number }|>
@@ -660,9 +660,9 @@ The `|parameters|` are enclosed in pipes after a tag name, and act functionally 
 > </child>
 > ```
 
-### Tag Arguments
+### タグ引数
 
-Multiple [tag parameters](#tag-parameters) may be provided to the content by using the Tag Arguments syntax, which uses the JavaScript `(...args)` syntax after the tag name.
+複数の[タグパラメータ](#tag-parameters)は、タグ名の後にJavaScriptの`(...args)`構文を使用するタグ引数構文を使用してコンテンツに提供できます。
 
 ```marko
 export interface Input {
@@ -672,7 +672,7 @@ export interface Input {
 <${input.content}(1, 2, 3)/>
 ```
 
-This example passes three arguments back to its parent.
+この例は、3つの引数を親に返します。
 
 ```marko
 <my-tag|a, b, c|>
@@ -686,7 +686,7 @@ This example passes three arguments back to its parent.
 ```
 
 > [!WARNING]
-> Tag content may use attributes _or_ arguments, but not both at once.
+> タグコンテンツは属性_または_引数を使用できますが、両方を同時に使用することはできません。
 >
 > ```marko
 > <my-tag a=1 b=2 c=3 />
@@ -694,17 +694,17 @@ This example passes three arguments back to its parent.
 > <my-tag({ a: 1, b: 2, c: 3 })/>
 > ```
 
-### Scope
+### スコープ
 
-Tag parameters are scoped to the [tag content](#tag-content) only.
-This means you cannot access the tag parameters outside the body of the tag.
+タグパラメータは[タグコンテンツ](#tag-content)のみにスコープされます。
+これは、タグの本体の外側ではタグパラメータにアクセスできないことを意味します。
 
 > [!CAUTION]
-> Tag parameters cannot be accessed by [attribute tags](#attribute-tags) since they are evaluated as attributes.
+> タグパラメータは属性として評価されるため、[属性タグ](#attribute-tags)からアクセスすることはできません。
 
-## Comments
+## コメント
 
-Both [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Comments) and [JavaScript](https://developer.mozilla.org/en-US/docs/Web/API/Comment) comments are supported.
+[HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Comments)と[JavaScript](https://developer.mozilla.org/en-US/docs/Web/API/Comment)の両方のコメントがサポートされています。
 
 ```marko
 <div>
@@ -715,17 +715,17 @@ Both [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Comments) and [Jav
 ```
 
 > [!NOTE]
-> Comments are ignored completely. To include a literal HTML comment in the output, use the [`<html-comment>` core tag](./core-tag.md#html-comment).
+> コメントは完全に無視されます。出力にリテラルHTMLコメントを含めるには、[`<html-comment>`コアタグ](./core-tag.md#html-comment)を使用してください。
 
-## Dynamic Tags
+## 動的タグ
 
-In place of the tag name, an `${interpolation}` may be used to dynamically output a [native tag](./native-tag.md), [custom tag](./custom-tag.md), or [tag content](#tag-content).
+タグ名の代わりに、`${補間}`を使用して[ネイティブタグ](./native-tag.md)、[カスタムタグ](./custom-tag.md)、または[タグコンテンツ](#tag-content)を動的に出力できます。
 
-With a dynamic tag the closing tag should be `</>`, or if there is no [content](#tag-content) the tag may be self-closed.
+動的タグの場合、閉じタグは`</>`にする必要があります。または、[コンテンツ](#tag-content)がない場合は、タグを自己閉じにすることができます。
 
-### Dynamic Native Tags
+### 動的ネイティブタグ
 
-When the value of the dynamic tag name is a string,
+動的タグ名の値が文字列の場合、
 
 ```marko
 export interface Input {
@@ -736,7 +736,7 @@ export interface Input {
 <${"h" + input.headingSize}>Hello!</>
 ```
 
-### Dynamic Custom Tags
+### 動的カスタムタグ
 
 ```marko
 // Dynamically output a custom tag.
@@ -746,14 +746,14 @@ import MyTagB from "<my-tag-b>"
 ```
 
 > [!CAUTION]
-> Strings will _always_ render native tags. When rendering a custom tag, you must have a reference to it. The following is _not_ equivalent to the above example, since Marko would output a native HTML element (as if you called `document.createElement("my-tag-a")`).
+> 文字列は_常に_ネイティブタグをレンダリングします。カスタムタグをレンダリングする場合は、それへの参照が必要です。次の例は上記の例と_同等ではありません_。MarkoはネイティブHTML要素を出力します（`document.createElement("my-tag-a")`を呼び出した場合と同様）。
 >
 > ```marko
 > <${Math.random() > 0.5 ? "my-tag-a" : "my-tag-b"}/>
 > ```
 
 > [!NOTE]
-> If an object is provided with a `content` property, the `content` value will become the dynamic tag name. This is how the [define](./core-tag.md#define) tag works under the hood 🤯.
+> `content`プロパティを持つオブジェクトが提供されると、`content`値が動的タグ名になります。これは[define](./core-tag.md#define)タグが内部でどのように動作するかです🤯。
 >
 > ```marko
 > <define/message>
@@ -762,11 +762,11 @@ import MyTagB from "<my-tag-b>"
 > <${message}/>
 > ```
 >
-> Although in this case you should prefer a [PascalCase](#pascalcase-variables) `<Message>` tag instead.
+> ただし、この場合は代わりに[PascalCase](#pascalcase-variables)の`<Message>`タグを使用することをお勧めします。
 
-### Conditional Parent Tags
+### 条件付き親タグ
 
-When a dynamic tag name is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) it will output the tag's [content](#tag-content) only. This is useful for conditional parenting and fallback content.
+動的タグ名が[falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)の場合、タグの[コンテンツ](#tag-content)のみを出力します。これは、条件付き親とフォールバックコンテンツに便利です。
 
 ```marko
 export interface Input {
@@ -777,9 +777,9 @@ export interface Input {
 <${input.href && "a"} href=input.href>Hello World</>
 ```
 
-### PascalCase Variables
+### PascalCase変数
 
-Local variable names that start with an upper case letter (`PascalCase`) can also be used as tag names without the explicit dynamic tag syntax. This is useful for referencing an imported custom tag or with the [`<define>` tag](./core-tag.md#define).
+大文字で始まるローカル変数名（`PascalCase`）は、明示的な動的タグ構文なしでタグ名として使用することもできます。これは、インポートされたカスタムタグを参照する場合や[`<define>`タグ](./core-tag.md#define)を使用する場合に便利です。
 
 ```marko
 import MyTag from "./my-tag.marko"
@@ -787,7 +787,7 @@ import MyTag from "./my-tag.marko"
 <MyTag/>
 ```
 
-This is equivalent to
+これは次と同等です
 
 ```marko
 import MyTag from "./my-tag.marko"

--- a/docs/reference/native-tag.md
+++ b/docs/reference/native-tag.md
@@ -1,10 +1,10 @@
-# Native Tags
+# ネイティブタグ
 
-Native tags are the [built-in HTML elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements). In Marko they behave like standard HTML with a few ergonomic enhancements.
+ネイティブタグは、[組み込みHTML要素](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements)です。Markoでは、いくつかの人間工学的な機能強化を備えた標準HTMLのように動作します。
 
-## Element References
+## 要素参照
 
-All native tags expose a [Tag Variable](./language.md#tag-variables) that provides a getter to the reference of the DOM node.
+すべてのネイティブタグは、DOMノードへの参照のゲッターを提供する[タグ変数](./language.md#tag-variables)を公開します。
 
 ```marko
 <div/ref/>
@@ -15,26 +15,26 @@ All native tags expose a [Tag Variable](./language.md#tag-variables) that provid
 ```
 
 > [!CAUTION]
-> The node reference is only available in the browser. Attempting to access a DOM node from the server will result in an error.
+> ノード参照はブラウザでのみ利用できます。サーバーからDOMノードにアクセスしようとするとエラーになります。
 
-## Enhanced Attributes
+## 拡張属性
 
 ### `class=`
 
-In addition to strings, Marko supports passing arrays and objects to the `class=` attribute.
+文字列に加えて、Markoは`class=`属性に配列とオブジェクトを渡すことをサポートしています。
 
 ```marko
-<!-- String -->
+<!-- 文字列 -->
 <div class="a c"/>
 
-<!-- Object -->
+<!-- オブジェクト -->
 <div class={ a: true, b: false, c: true }/>
 
-<!-- Array -->
+<!-- 配列 -->
 <div class=["a", null, { c: true }]/>
 ```
 
-All examples above result in the same HTML:
+上記のすべての例は、同じHTMLになります:
 
 ```html
 <div class="a c"></div>
@@ -42,30 +42,30 @@ All examples above result in the same HTML:
 
 ### `style=`
 
-In addition to strings, Marko supports passing arrays and objects to the `style=` attribute.
+文字列に加えて、Markoは`style=`属性に配列とオブジェクトを渡すことをサポートしています。
 
 ```marko
-<!-- String -->
+<!-- 文字列 -->
 <div style="display:block;margin-right:16px"/>
 
-<!-- Object -->
+<!-- オブジェクト -->
 <div style={ display: "block", color: false, "margin-right": 16 }/>
 
-<!-- Array -->
+<!-- 配列 -->
 <div style=["display:block", null, { "margin-right": 16 }]/>
 ```
 
-All examples above result in the same HTML:
+上記のすべての例は、同じHTMLになります:
 
 ```html
 <div style="display:block;margin-right:16px;"></div>
 ```
 
-### Event Handlers
+### イベントハンドラ
 
-Attributes on native tags that begin with `on` followed by `-` or a capital letter are attached as [event handlers](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).
+`on`で始まり、その後に`-`または大文字が続くネイティブタグの属性は、[イベントハンドラ](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)として添付されます。
 
-When the attribute starts with `on-` the event name casing is preserved, otherwise the event name is all lowercased.
+属性が`on-`で始まる場合、イベント名の大文字小文字は保持されます。それ以外の場合、イベント名はすべて小文字になります。
 
 - `onDblClick` → `dblclick`
 - `on-DblClick` → `DblClick`
@@ -75,7 +75,7 @@ When the attribute starts with `on-` the event name casing is preserved, otherwi
   Say Hi
 </button>
 
-// equivalent to
+// これと同等
 
 <button on-click() { alert("Hi!") }>
   Say Hi
@@ -83,9 +83,9 @@ When the attribute starts with `on-` the event name casing is preserved, otherwi
 ```
 
 > [!NOTE]
-> Event handlers are typically written using the [method shorthand](./language.md#shorthand-methods) for readability.
+> イベントハンドラは、可読性のために通常、[メソッド省略記法](./language.md#shorthand-methods)を使用して記述されます。
 
-The value for the attribute must be either a function or a [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value, allowing for conditional event handlers:
+属性の値は、関数または[falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)値のいずれかである必要があり、条件付きイベントハンドラを可能にします:
 
 ```marko
 <let/clicked=false>
@@ -98,56 +98,56 @@ The value for the attribute must be either a function or a [falsy](https://devel
 ```
 
 > [!TIP]
-> Since native events are all lowercase, the `onCamelCase` event naming can help with readability of multi-word events:
+> ネイティブイベントはすべて小文字であるため、`onCamelCase`イベント命名は、複数語のイベントの可読性を向上させるのに役立ちます:
 >
 > ```marko
 > <canvas onContentVisibilityAutoStateChange() {  }/>
 > ```
 >
-> Some [custom elements](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements) may emit non lowercase event names, in which case (pun intended 😏) you should use `on-` which preserves the casing.
+> 一部の[カスタム要素](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements)は、小文字でないイベント名を発行する場合があります。その場合（ダジャレです😏）、大文字小文字を保持する`on-`を使用する必要があります。
 
 > [!CAUTION]
-> Even though Marko _does_ support [native HTML inline event handler attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#event_handler_attributes), it's recommended to avoid them since they're detached from Marko's reactivity system and may lead to [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) / [XSS](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting) issues.
+> Markoは[ネイティブHTMLインラインイベントハンドラ属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#event_handler_attributes)を_サポート_していますが、Markoのリアクティビティシステムから切り離されており、[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) / [XSS](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting)の問題につながる可能性があるため、避けることをお勧めします。
 >
 > ```marko
 > <button onclick="this.innerHTML++">0</button>
 > ```
 
-### Tags with Enhanced `value` Attributes
+### 拡張された`value`属性を持つタグ
 
-The HTML `<input>` tag has a `value=` attribute that reflects the state of the `<input>`. Marko adds this attribute to a few other tags that hold internal state.
+HTML `<input>`タグには、`<input>`の状態を反映する`value=`属性があります。Markoは、内部状態を保持する他のいくつかのタグにこの属性を追加します。
 
-#### `<input type="radio">` and `<input type="checkbox">`
+#### `<input type="radio">`と`<input type="checkbox">`
 
-Radio and checkbox inputs support a `checkedValue=` attribute. When this attribute matches the input's `value=` attribute, it will be `checked`.
+ラジオとチェックボックスの入力は、`checkedValue=`属性をサポートします。この属性が入力の`value=`属性と一致すると、`checked`になります。
 
-`checkedValue=` may be set to a string, in which case only one value will match (for use with `type="radio"`), or an array of strings, in which case multiple values may match (for use with `type="checkbox"`).
+`checkedValue=`は文字列に設定でき、この場合、1つの値のみが一致します（`type="radio"`で使用）。または文字列の配列に設定でき、この場合、複数の値が一致する可能性があります（`type="checkbox"`で使用）。
 
 #### `<select>`
 
-The `<select>` tag is unique in that its state is internally synchronized with the `<option>` tags in its body. Marko exposes this state via the `value=` attribute.
+`<select>`タグは、その状態がボディ内の`<option>`タグと内部的に同期されるという点で独特です。Markoは、`value=`属性を介してこの状態を公開します。
 
-`value=` may be set to a string in which case it mirrors the `<select>`'s `.value` property - the value of the selected `<option>`. It may also be set to an array of strings in which case multiple `<option>`s may be selected (for use with`<select multiple>`).
+`value=`は文字列に設定でき、この場合、`<select>`の`.value`プロパティ（選択された`<option>`の値）をミラーリングします。文字列の配列にも設定でき、この場合、複数の`<option>`を選択できます（`<select multiple>`で使用）。
 
 #### `<textarea>`
 
-In HTML, `<textarea>` holds its value inside its body. In Marko, this state can also be held in the `value=` attribute, which is useful for the textarea change handler.
+HTMLでは、`<textarea>`はその値をボディ内に保持します。Markoでは、この状態は`value=`属性にも保持でき、これはtextareaの変更ハンドラに役立ちます。
 
-### Change Handlers
+### 変更ハンドラ
 
-Some native tags in Marko have additional attributes that make them **controllable**. These attributes end with `Change` and are designed to work with the [bind shorthand](./language.md#shorthand-change-handlers-two-way-binding).
+Markoの一部のネイティブタグには、それらを**制御可能**にする追加の属性があります。これらの属性は`Change`で終わり、[バインド省略記法](./language.md#shorthand-change-handlers-two-way-binding)と連携するように設計されています。
 
-For DOM elements that maintain internal state separate from an associated attribute, Marko uses "uncontrolled" attributes by default, meaning it only sets the attribute value and not the internal value.
+関連する属性とは別の内部状態を維持するDOM要素の場合、Markoはデフォルトで「非制御」属性を使用します。つまり、属性値のみを設定し、内部値は設定しません。
 
 ```marko
 <input value="hello">
 ```
 
-Above is among the simplest of examples, but interestingly its behavior is different across frameworks in subtle ways.
+上記は最も単純な例の1つですが、興味深いことに、フレームワーク間で微妙に異なる動作をします。
 
-In some frameworks, like React, this would be a "read-only" `<input>`. Marko takes a different approach, allowing the input's state to be managed natively by the browser.
+Reactなどの一部のフレームワークでは、これは「読み取り専用」の`<input>`になります。Markoは異なるアプローチを取り、ブラウザによってネイティブに入力の状態を管理できるようにします。
 
-Adding state introduces some nuances in behavior.
+状態を追加すると、動作にいくつかのニュアンスが導入されます。
 
 ```marko
 <let/message="hello">
@@ -159,14 +159,14 @@ Adding state introduces some nuances in behavior.
 <button onClick() { message = "goodbye" }>Click Me</>
 ```
 
-In this example, typing in the `<input>` and then clicking the `<button>` might not behave as expected. The `<div>` text updates only when the button is clicked, and the `<input>` doesn't reflect the new "goodbye" value.
+この例では、`<input>`に入力してから`<button>`をクリックしても、期待どおりに動作しない可能性があります。`<div>`のテキストはボタンがクリックされたときにのみ更新され、`<input>`は新しい「goodbye」値を反映しません。
 
-This occurs because there are two separate states, which update independently:
+これは、独立して更新される2つの別々の状態があるために発生します:
 
-1. The Marko-managed state in `<let/message>`
-2. The internal state of the `<input>` value
+1. `<let/message>`のMarko管理状態
+2. `<input>`値の内部状態
 
-To synchronize these two states and their updates, Marko includes a special `valueChange` attribute on `<input>`.
+これら2つの状態とその更新を同期するために、Markoは`<input>`に特別な`valueChange`属性を含めています。
 
 ```marko
 <let/message = "hello">
@@ -178,17 +178,17 @@ To synchronize these two states and their updates, Marko includes a special `val
 <button onClick() { message = "goodbye" }>Click Me</>
 ```
 
-The `valueChange` attribute transforms the behavior:
+`valueChange`属性は動作を変換します:
 
-- Typing in the `<input>` updates both the `<input>` and the `<div>`
-- Clicking the `<button>` updates both the `<input>` and the `<div>`
+- `<input>`への入力は、`<input>`と`<div>`の両方を更新します
+- `<button>`のクリックは、`<input>`と`<div>`の両方を更新します
 
-There is now only one state! This synchronization occurs because `valueChange`:
+これで状態は1つだけになりました! この同期は、`valueChange`が次のことを行うため発生します:
 
-1. Captures internal `<input>` changes
-2. Updates the `message` variable, which then updates the `value=` attribute
+1. 内部`<input>`の変更をキャプチャ
+2. `message`変数を更新し、次に`value=`属性を更新
 
-The `valueChange` function is called whenever the `<input>` would normally update, allowing a parent component to synchronize its state with the input's internal state.
+`valueChange`関数は、`<input>`が通常更新されるたびに呼び出され、親コンポーネントがその状態を入力の内部状態と同期できるようにします。
 
 ```marko
 <let/message = "hello">
@@ -200,9 +200,9 @@ The `valueChange` function is called whenever the `<input>` would normally updat
 <button onClick() { message = "goodbye" }>Click Me</>
 ```
 
-In this example, there is a single state _and_ updates from both sources are handled. Typing in the `<input>` and clicking the `<button>` cause changes to both the `<div>` and the `<input>` itself. Everything is in sync!
+この例では、単一の状態があり、_かつ_両方のソースからの更新が処理されます。`<input>`への入力と`<button>`のクリックは、`<div>`と`<input>`自体の両方に変更を引き起こします。すべてが同期しています!
 
-Marko has [a shorthand](./language.md#shorthand-change-handlers-two-way-binding) for simple reflective change handlers like this, allowing the example to be simplified to:
+Markoには、このような単純な反射的変更ハンドラのための[省略記法](./language.md#shorthand-change-handlers-two-way-binding)があり、例を次のように簡略化できます:
 
 ```marko
 <let/message="Hello">
@@ -214,9 +214,9 @@ Marko has [a shorthand](./language.md#shorthand-change-handlers-two-way-binding)
 <button onClick() { message = "Goodbye" }>Click Me</>
 ```
 
-With this shorthand all that is needed to go from "uncontrolled" to "controlled" for the `value` attribute was to swap from `value=` to `value:=`.
+この省略記法では、`value`属性を「非制御」から「制御」に変更するために必要なのは、`value=`から`value:=`に切り替えることだけです。
 
-For cases besides the most simple, manual `valueChange` handlers are required.
+最も単純なケース以外では、手動の`valueChange`ハンドラが必要です。
 
 ```marko
 <let/message = "hello">
@@ -228,17 +228,17 @@ For cases besides the most simple, manual `valueChange` handlers are required.
 <button onClick() { message = "goodbye" }>Click Me</>
 ```
 
-All changes to this `<input>` are intercepted _and manipulated_. In this example, all UPPERCASE characters are automatically converted to lowercase. This pattern is useful for [input masking](https://css-tricks.com/input-masking/) and more - and it's built in!
+この`<input>`へのすべての変更は、傍受され_操作されます_。この例では、すべての大文字が自動的に小文字に変換されます。このパターンは、[入力マスキング](https://css-tricks.com/input-masking/)などに役立ち、組み込まれています!
 
 ```marko
-// uncontrolled - The browser owns the state
+// 非制御 - ブラウザが状態を所有
 <input value="hello">
 
-// controlled - The `inputValue` tag variable owns the state
+// 制御 - `inputValue`タグ変数が状態を所有
 <let/inputValue="hello">
 <input value:=inputValue>
 
-// controlled - Modifications to `<input>` are transformed
+// 制御 - `<input>`への変更が変換される
 <let/creditCardNumber="5555 5555 555">
 <input
   value=creditCardNumber
@@ -250,9 +250,9 @@ All changes to this `<input>` are intercepted _and manipulated_. In this example
 
 #### `<input>` (`valueChange=`, `checkedChange=`, `checkedValueChange=`)
 
-The `<input>` tag has 3 change handlers, which are each related to an input type.
+`<input>`タグには、それぞれ入力タイプに関連する3つの変更ハンドラがあります。
 
-The `value=` attribute may be controlled with `valueChange=`
+`value=`属性は`valueChange=`で制御できます
 
 ```marko
 <let/text="">
@@ -261,19 +261,19 @@ The `value=` attribute may be controlled with `valueChange=`
 ```
 
 > [!CAUTION]
-> The value of `<input>` is _always_ a string, so numbers need to be casted.
+> `<input>`の値は_常に_文字列であるため、数値はキャストする必要があります。
 >
 > ```marko
 > <let/number=0>
 >
-> // ❌ (INCORRECT) this will set number to a string when updated
+> // ❌ (不正解) これは更新時にnumberを文字列に設定します
 > <input type="number" value:=number>
 >
-> // ✅ cast the string value to a number during the change handler
+> // ✅ 変更ハンドラ中に文字列値を数値にキャストします
 > <input type="number" value=number valueChange(value) { number = +value }>
 > ```
 
-The `checked=` attribute may be controlled with `checkedChange=`
+`checked=`属性は`checkedChange=`で制御できます
 
 ```marko
 <let/checked=false>
@@ -281,7 +281,7 @@ The `checked=` attribute may be controlled with `checkedChange=`
 <input type="checkbox" checked=checked checkedChange(value) { checked = value }>
 ```
 
-The [added `checkedValue=` attribute](#input-typeradio-and-input-typecheckbox) also has a change handler.
+[追加された`checkedValue=`属性](#input-typeradio-and-input-typecheckbox)にも変更ハンドラがあります。
 
 ```marko
 <let/checked="foo">
@@ -290,7 +290,7 @@ The [added `checkedValue=` attribute](#input-typeradio-and-input-typecheckbox) a
 
 #### `<select>` (`valueChange=`)
 
-Traditionally, the value of a `<select>` is controlled via the `selected=` attribute in its `<option>` tags. Marko adds an additional way to control the `<select>` using [a new `value=` attribute](#select), which is also controllable with a `Change` handler.
+従来、`<select>`の値は、その`<option>`タグの`selected=`属性を介して制御されます。Markoは、[新しい`value=`属性](#select)を使用して`<select>`を制御する追加の方法を追加しており、これも`Change`ハンドラで制御できます。
 
 ```marko
 <let/selected="en">
@@ -303,7 +303,7 @@ Traditionally, the value of a `<select>` is controlled via the `selected=` attri
 
 #### `<textarea>` (`valueChange=`)
 
-The `<textarea>` tag has a change handler for [Marko's added `value=` attribute](#textarea).
+`<textarea>`タグには、[Markoが追加した`value=`属性](#textarea)の変更ハンドラがあります。
 
 ```marko
 <let/text="">
@@ -312,7 +312,7 @@ The `<textarea>` tag has a change handler for [Marko's added `value=` attribute]
 
 #### `<details>` (`openChange=`)
 
-The `<details>` tag has a change handler for its `open=` attribute.
+`<details>`タグには、その`open=`属性の変更ハンドラがあります。
 
 ```marko
 <let/open=false>
@@ -325,7 +325,7 @@ The `<details>` tag has a change handler for its `open=` attribute.
 
 #### `<dialog>` (`openChange=`)
 
-The `<dialog>` tag has a change handler for its `open=` attribute.
+`<dialog>`タグには、その`open=`属性の変更ハンドラがあります。
 
 ```marko
 <let/open=false>
@@ -337,17 +337,17 @@ The `<dialog>` tag has a change handler for its `open=` attribute.
 ```
 
 > [!Warning]
-> The `open` attribute of the `<dialog>` tag can be used to control a non-modal dialog. However if you need a modal dialog, you should use [the `.showModal()` method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal) directly. Calling this method will _not_ cause `openChange` to fire as the HTML `<dialog>` only fires an event on `close`.
+> `<dialog>`タグの`open`属性は、非モーダルダイアログを制御するために使用できます。ただし、モーダルダイアログが必要な場合は、[`.showModal()`メソッド](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)を直接使用する必要があります。このメソッドを呼び出しても、HTML `<dialog>`は`close`時にのみイベントを発火するため、`openChange`は発火_しません_。
 
-## Enhanced Tags
+## 拡張タグ
 
-Some native tags have special meaning in Marko, and don't behave exactly like their HTML counterpart.
+一部のネイティブタグはMarkoで特別な意味を持ち、HTMLの対応するものとまったく同じように動作しません。
 
 ### `<script>`
 
-Marko's [`<script>` tag](./core-tag.md#script) is used for browser effects.
+Markoの[`<script>`タグ](./core-tag.md#script)は、ブラウザエフェクトに使用されます。
 
-A native HTML `<script>` may be included with `<html-script>`.
+ネイティブHTML `<script>`は、`<html-script>`で含めることができます。
 
 ```marko
 <html-script type="application/json">
@@ -357,12 +357,12 @@ A native HTML `<script>` may be included with `<html-script>`.
 
 ### `<style>`
 
-Marko's [`<style>` tag](./core-tag.md#style) generates `.css` files.
+Markoの[`<style>`タグ](./core-tag.md#style)は、`.css`ファイルを生成します。
 
-Though almost never recommended, a native HTML `<style>` may be included with `<html-style>`.
+ほとんど推奨されませんが、ネイティブHTML `<style>`は`<html-style>`で含めることができます。
 
 ### `<!-- comment -->`
 
-By default, Marko strips [comments](./language.md#comments) from the output.
+デフォルトでは、Markoは出力から[コメント](./language.md#comments)を除外します。
 
-A native HTML `<!-- comment -->` may be included with [`<html-comment>`](./core-tag.md#html-comment)
+ネイティブHTML `<!-- comment -->`は、[`<html-comment>`](./core-tag.md#html-comment)で含めることができます

--- a/docs/reference/reactivity.md
+++ b/docs/reference/reactivity.md
@@ -1,22 +1,22 @@
-# Reactivity Reference
+# リアクティビティリファレンス
 
-Marko's goal is to make it easy to represent performant experiences with rich client interactions. This is enabled through its **reactivity system**. The reactive system is how Marko determines what needs to update and when.
+Markoの目標は、豊富なクライアントインタラクションを持つパフォーマンスの高いエクスペリエンスを簡単に表現できるようにすることです。これは、その**リアクティビティシステム**を通じて実現されます。リアクティブシステムは、Markoが何をいつ更新する必要があるかを決定する方法です。
 
-The core of Marko's reactive system is [the `<let>` tag](./core-tag.md#let).
+Markoのリアクティブシステムの核心は、[`<let>`タグ](./core-tag.md#let)です。
 
-## Reactive Variables
+## リアクティブ変数
 
-In Marko, [Tag Variables](./language.md#tag-variables), [Tag Parameters](./language.md#tag-parameters), and [`input`](./language.md#input) are all reactive. This means they are tracked by the Marko compiler and when these values are caused to update any dependent [render expressions](#render-expressions) are also updated.
+Markoでは、[タグ変数](./language.md#tag-variables)、[タグパラメータ](./language.md#tag-parameters)、および[`input`](./language.md#input)はすべてリアクティブです。これは、Markoコンパイラによって追跡され、これらの値が更新されると、依存する[レンダリング式](#render-expressions)も更新されることを意味します。
 
-## Render Expressions
+## レンダリング式
 
-Any expression within a `.marko` template that references a [reactive variable](#reactive-variables) is considered reactive and will be updated alongside that variable.
+`.marko`テンプレート内で[リアクティブ変数](#reactive-variables)を参照する式はすべて、リアクティブと見なされ、その変数とともに更新されます。
 
-These reactive expressions may exist throughout the template in [attributes](./language.md#attributes), [dynamic text](./language.md#dynamic-text), [dynamic tag names](./language.md#dynamic-tags), and [script content](./core-tag.md#script).
+これらのリアクティブ式は、テンプレート全体の[属性](./language.md#attributes)、[動的テキスト](./language.md#dynamic-text)、[動的タグ名](./language.md#dynamic-tags)、および[スクリプトコンテンツ](./core-tag.md#script)に存在する可能性があります。
 
 > [!NOTE]
-> All JavaScript expressions withing the Marko template may be reactive with the exception of
-> [static statements](./language.md#static) (including [`import`](./language.md#import), [`export`](./language.md#export), [`static`](./language.md#static), [`server` and `client`](./language.md#server-and-client)) which are evaluated _once_ when the template is loaded.
+> Markoテンプレート内のすべてのJavaScript式はリアクティブになる可能性がありますが、例外として
+> [staticステートメント](./language.md#static)（[`import`](./language.md#import)、[`export`](./language.md#export)、[`static`](./language.md#static)、[`server`と`client`](./language.md#server-and-client)を含む）があり、これらはテンプレートがロードされたときに_一度_評価されます。
 
 ```marko
 <let/count=0>
@@ -26,22 +26,22 @@ These reactive expressions may exist throughout the template in [attributes](./l
 </button>
 ```
 
-Here, a `count` Tag Variable is mutated by a button click. Because the text content of the button references `count`, it is automatically be kept in sync with the new value.
+ここでは、`count`タグ変数がボタンクリックによって変更されます。ボタンのテキストコンテンツが`count`を参照しているため、新しい値と自動的に同期されます。
 
 > [!CAUTION]
-> In some cases Marko may cause some expressions to evaluate together. This is why [render expressions](#render-expressions) should be pure.
+> 場合によっては、Markoがいくつかの式を一緒に評価させることがあります。これが、[レンダリング式](#render-expressions)が純粋であるべき理由です。
 
 > [!TIP]
-> Marko is a **compiled language**, and its reactive graph is discovered at compile time instead of during runtime. This is in contrast with many of the other leading approaches, such as [Signals in SolidJS](https://docs.solidjs.com/advanced-concepts/fine-grained-reactivity) and [Hooks in React](https://react.dev/reference/react/hooks).
+> Markoは**コンパイル言語**であり、そのリアクティブグラフは実行時ではなくコンパイル時に発見されます。これは、[SolidJSのSignals](https://docs.solidjs.com/advanced-concepts/fine-grained-reactivity)や[ReactのHooks](https://react.dev/reference/react/hooks)など、他の多くの主要なアプローチとは対照的です。
 
-## Scheduling Updates
+## 更新のスケジューリング
 
-Marko automatically batches work to ensure optimal performance. Any time a [reactive variable](#reactive-variables) is changed, its update is queued to ensure that multiple changes will be applied efficiently together.
+Markoは、最適なパフォーマンスを確保するために作業を自動的にバッチ処理します。[リアクティブ変数](#reactive-variables)が変更されるたびに、その更新がキューに入れられ、複数の変更が一緒に効率的に適用されることが保証されます。
 
-This update queue is typically scheduled after a [microtask](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide).
+この更新キューは、通常、[マイクロタスク](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide)の後にスケジュールされます。
 
-If additional updates are scheduled after the queue is consumed but _before the update is painted_, they are deferred until the next frame. This accomplishes a few things:
+キューが消費された後、_更新がペイントされる前_に追加の更新がスケジュールされた場合、それらは次のフレームまで延期されます。これにより、いくつかのことが達成されます:
 
-- Content ready to display to the user is not blocked.
-- It is not possible to lock up the application in an infinite update loop.
-- The update loop can be used to power animations (although CSS [Animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) & [Transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition)/ JS [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API) are preferred in most cases).
+- ユーザーに表示する準備ができたコンテンツがブロックされません。
+- 無限の更新ループでアプリケーションをロックアップすることはできません。
+- 更新ループを使用してアニメーションを駆動できます（ただし、ほとんどの場合、CSS [Animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation)と[Transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/transition)/ JS [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)が推奨されます）。

--- a/docs/reference/template.md
+++ b/docs/reference/template.md
@@ -1,31 +1,31 @@
-# Template API Reference
+# テンプレートAPIリファレンス
 
-All `.marko` files expose the same API on their [default export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#using_the_default_export).
-These methods are used to generate an HTML string on the server, and to modify the [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) in the browser.
+すべての`.marko`ファイルは、その[デフォルトエクスポート](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#using_the_default_export)で同じAPIを公開します。
+これらのメソッドは、サーバー上でHTML文字列を生成し、ブラウザで[DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)を変更するために使用されます。
 
 ## `Template.render(input)`
 
-| Parameter | Default | Details                                                                                                                 |
-| :-------- | :------ | :---------------------------------------------------------------------------------------------------------------------- |
-| `input`   | `{}`    | The [`input` object](./language.md#input) for the template. May also include [`$global`](#inputglobal) for global state |
+| パラメータ | デフォルト | 詳細                                                                                                                   |
+| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------- |
+| `input`   | `{}`    | テンプレートの[`input`オブジェクト](./language.md#input)。グローバル状態用の[`$global`](#inputglobal)も含めることができます |
 
-For use on the **server**, the `.render()` API on a Marko template provides an object containing a variety of ways to generate an HTML string. Its first parameter becomes the [`input`](./language.md#input) available within the template.
+**サーバー**で使用する場合、Markoテンプレートの`.render()` APIは、HTML文字列を生成するさまざまな方法を含むオブジェクトを提供します。最初のパラメータは、テンプレート内で利用可能な[`input`](./language.md#input)になります。
 
-### Async Iterator
+### 非同期イテレータ
 
-The render result contains an [async iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), which allows consumption through a [`for await` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of).
+レンダリング結果には[非同期イテレータ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)が含まれており、[`for await`ステートメント](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)を通じて消費できます。
 
 ```js
 import Template from "./template.marko";
 
 for await (const chunk of Template.render({})) {
-  // send the html chunk somewhere.
+  // HTMLチャンクをどこかに送信します。
 }
 ```
 
-### Pipe
+### パイプ
 
-The `.pipe()` method in the render result object sends an HTML string into a [NodeJS `stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable).
+レンダリング結果オブジェクトの`.pipe()`メソッドは、HTML文字列を[NodeJS `stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable)に送信します。
 
 ```js
 import Template from "./template.marko";
@@ -33,7 +33,7 @@ import http from "node:http";
 
 http
   .createServer((req, res) => {
-    // Stream rendered html into the server response.
+    // レンダリングされたHTMLをサーバーレスポンスにストリーミングします。
     Template.render({}).pipe(res);
   })
   .listen(3000);
@@ -41,7 +41,7 @@ http
 
 ### ReadableStream
 
-The `.toReadable()` method in the render result object returns a [WHATWG ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream). This can be used in environments that support web apis, eg in a web worker.
+レンダリング結果オブジェクトの`.toReadable()`メソッドは、[WHATWG ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)を返します。これは、Webワーカーなど、Web APIをサポートする環境で使用できます。
 
 ```js
 const webHTMLResponse = new Response(Template.render({}).toReadable(), {
@@ -51,90 +51,90 @@ const webHTMLResponse = new Response(Template.render({}).toReadable(), {
 
 ### Thenable
 
-The render result is a [thenable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables), so the `.then()`, `.catch()` or `.finally()` methods return a `Promise<string>` that resolves with a buffered HTML string. This may be handled implicitly with the [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) keyword.
+レンダリング結果は[thenable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables)であるため、`.then()`、`.catch()`または`.finally()`メソッドは、バッファリングされたHTML文字列で解決される`Promise<string>`を返します。これは、[`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)キーワードで暗黙的に処理できます。
 
 ```js
 const html = await Template.render({});
 ```
 
 > [!NOTE]
-> By using thenable and `await`, you are opting out of Marko's streaming capabilities.
+> thenableと`await`を使用することで、Markoのストリーミング機能をオプトアウトすることになります。
 
 #### toString
 
-The result implements a `toString()` that returns the buffered `html` synchronously if possible.
+結果は、可能であればバッファリングされた`html`を同期的に返す`toString()`を実装しています。
 
 ```js
 const html = Template.render({}).toString();
 ```
 
 > [!CAUTION]
-> If there is any async behavior (i.e. an [`<await>` tag](./core-tag.md#await)) this method will throw.
+> 非同期動作（つまり、[`<await>`タグ](./core-tag.md#await)）がある場合、このメソッドはスローします。
 
 ## `Template.mount(input, node, position?)`
 
-| Parameter  | Default       | Details                                                                                                                                                                                       |
-| :--------- | :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `input`    | `{}`          | The [`input` object](./language.md#input) for the template. May also include [`$global`](#inputglobal) for global state                                                                       |
-| `node`     | `undefined`   | A reference to the DOM node where the template will be rendered                                                                                                                               |
-| `position` | `"beforeend"` | Location to render the template, relative to `node`. Value follows the [Element.insertAdjacentHTML API](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML#position) |
+| パラメータ  | デフォルト     | 詳細                                                                                                                                                                                          |
+| :--------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `input`    | `{}`          | テンプレートの[`input`オブジェクト](./language.md#input)。グローバル状態用の[`$global`](#inputglobal)も含めることができます                                                                      |
+| `node`     | `undefined`   | テンプレートがレンダリングされるDOMノードへの参照                                                                                                                                                |
+| `position` | `"beforeend"` | `node`に対するテンプレートをレンダリングする場所。値は[Element.insertAdjacentHTML API](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML#position)に従います |
 
-For use in the **browser/client**, The `.mount()` API on a Marko template builds up a [reactive](./reactivity.md) DOM and inserts it at the specified `node` and `position`. The `input` argument becomes the [`input`](./language.md#input) available within the template.
+**ブラウザ/クライアント**で使用する場合、Markoテンプレートの`.mount()` APIは、[リアクティブ](./reactivity.md)なDOMを構築し、指定された`node`と`position`に挿入します。`input`引数は、テンプレート内で利用可能な[`input`](./language.md#input)になります。
 
 ```js
-template.mount({}, document.body); // append to the body.
+template.mount({}, document.body); // bodyに追加します。
 ```
 
-Or with a `position` override
+または、`position`をオーバーライドして
 
 ```js
-template.mount({}, document.body, "afterbegin"); // prepended to the body
+template.mount({}, document.body, "afterbegin"); // bodyの先頭に追加します
 ```
 
 > [!NOTE]
-> Valid values for `position` are based on [`insertAdjacentHTML()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML#position):
+> `position`の有効な値は、[`insertAdjacentHTML()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML#position)に基づいています:
 >
-> - `"beforebegin"`: Before the element.
-> - `"afterbegin"`: Just inside the element, before its first child.
-> - `"beforeend"`: Just inside the element, after its last child.
-> - `"afterend"`: After the element.
+> - `"beforebegin"`: 要素の前
+> - `"afterbegin"`: 要素の内側、最初の子の前
+> - `"beforeend"`: 要素の内側、最後の子の後
+> - `"afterend"`: 要素の後
 >
-> which, if the element is this `<p>`, can be visualized as
+> 要素がこの`<p>`の場合、次のように視覚化できます
 >
 > ```html
 > <!-- "beforebegin" -->
 > <p>
 >   <!-- "afterbegin" -->
 >   existing body content
->   <!-- "beforeend" (default) -->
+>   <!-- "beforeend" (デフォルト) -->
 > </p>
 > <!-- "afterend" -->
 > ```
 
-### Render Result
+### レンダリング結果
 
-The [`.mount()` API](#templatemountinput-node-position) returns an object with helpers used update and destroy the instance of the template and DOM that was built.
+[`.mount()` API](#templatemountinput-node-position)は、構築されたテンプレートとDOMのインスタンスを更新および破棄するために使用されるヘルパーを含むオブジェクトを返します。
 
 ```js
 const instance = template.mount({ name: "foo" }, document.body);
 ```
 
 > [!Warning]
-> This API is **not** the recommended way to update/destroy Marko templates. It is primarily intended to be used in exclusively client rendered environments and/or while testing. Instead the [reactive system](./reactivity.md) should be used.
+> このAPIは、Markoテンプレートを更新/破棄するための推奨される方法では**ありません**。主に、クライアント専用でレンダリングされる環境やテスト中に使用することを目的としています。代わりに、[リアクティブシステム](./reactivity.md)を使用する必要があります。
 
 #### instance.update(input)
 
-The `.update()` method allows providing new [`input`](./language.md#input) to the instance of the template with a reactive update.
+`.update()`メソッドは、テンプレートのインスタンスに新しい[`input`](./language.md#input)をリアクティブ更新で提供できます。
 
 ```js
 instance.update({ name: "bar" });
 ```
 
-This update to the `input` is applied synchronously.
+この`input`への更新は同期的に適用されます。
 
 #### instance.destroy()
 
-The `.destroy()` method causes every [`$signal`](./language.md#signal) to be aborted and runs cleanup for the instance.
+`.destroy()`メソッドは、すべての[`$signal`](./language.md#signal)を中止させ、インスタンスのクリーンアップを実行します。
 
 ```js
 instance.destroy();
@@ -142,32 +142,32 @@ instance.destroy();
 
 ## `input.$global`
 
-When a template is rendered via the [`render`](#templaterenderinput) or [`mount`](#templatemountinput-node-position) APIs, the `input` object may specify a `$global` property which will be stripped off and used as [`$global`](./language.md#global) within all rendered `.marko` templates.
+テンプレートが[`render`](#templaterenderinput)または[`mount`](#templatemountinput-node-position) APIを介してレンダリングされる場合、`input`オブジェクトは`$global`プロパティを指定でき、これは削除され、レンダリングされたすべての`.marko`テンプレート内で[`$global`](./language.md#global)として使用されます。
 
-Some properties on the `$global` are picked up by Marko itself and have predefined functionality.
+`$global`のいくつかのプロパティは、Marko自体によって取得され、事前定義された機能を持っています。
 
 ### `$global.signal`
 
 > <code>[AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | undefined</code>
 
-When `signal` is included in `$global`, Marko will listen to it and automatically clean up any pending async rendering activity when it is aborted.
+`signal`が`$global`に含まれている場合、Markoはそれをリッスンし、中止されたときに保留中の非同期レンダリングアクティビティを自動的にクリーンアップします。
 
-This is used to, for example, prevent continued rendering after an incoming request is aborted.
+これは、たとえば、受信リクエストが中止された後の継続的なレンダリングを防ぐために使用されます。
 
 ### `$global.cspNonce`
 
 > `string | undefined`
 
-This value should be a string that represents a valid [csp nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce). Marko will automatically set this value as the `nonce` on all assets (`<script>`, `<style>`, etc) rendered by the template.
+この値は、有効な[csp nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)を表す文字列である必要があります。Markoは、テンプレートによってレンダリングされたすべてのアセット（`<script>`、`<style>`など）の`nonce`としてこの値を自動的に設定します。
 
 ### `$global.renderId`
 
 > `string | undefined`
 
-The `runtimeId` is used to isolate runtimes when there are multiple copies on the same page, and is generally not necessary as `@marko/vite` and `@marko/webpack` plugins will automatically provide one based off of the project level `package.json` name.
+`runtimeId`は、同じページに複数のコピーがある場合にランタイムを分離するために使用され、一般的には必要ありません。`@marko/vite`および`@marko/webpack`プラグインが、プロジェクトレベルの`package.json`名に基づいて自動的に提供します。
 
 ### `$global.runtimeId`
 
 > `string | undefined`
 
-The `renderId` is used to isolate distinct server renders (using the same runtime) and is not automatically set. This value should be set such that all server rendered segments of `html` have a unique `renderId` string to avoid conflicts. This is particularly useful for solutions such as [micro-frame](https://github.com/marko-js/micro-frame).
+`renderId`は、異なるサーバーレンダリング（同じランタイムを使用）を分離するために使用され、自動的には設定されません。この値は、`html`のすべてのサーバーレンダリングセグメントが競合を避けるために一意の`renderId`文字列を持つように設定する必要があります。これは、[micro-frame](https://github.com/marko-js/micro-frame)などのソリューションに特に役立ちます。

--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -1,12 +1,12 @@
 # TypeScript
 
-Marko’s TypeScript support offers in-editor error checking, makes refactoring less scary, verifies that data matches expectations, and even helps with API design.
+MarkoのTypeScriptサポートは、エディタ内でのエラーチェック、リファクタリングの不安軽減、データが期待通りであることの検証、さらにはAPI設計の支援を提供します。
 
-## Enabling TypeScript in your Marko project
+## MarkoプロジェクトでTypeScriptを有効にする
 
-There are two (non-exclusive) ways to add TypeScript to a Marko project:
+Markoプロジェクトに TypeScript を追加するには、2つの（排他的でない）方法があります:
 
-- **For sites and web apps**, [a `tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) at the project root is the only requirement:
+- **サイトやWebアプリの場合**、プロジェクトルートに[`tsconfig.json`ファイル](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)を置くだけです:
 
   ```
   src/
@@ -14,7 +14,7 @@ There are two (non-exclusive) ways to add TypeScript to a Marko project:
   tsconfig.json
   ```
 
-- **For [packages of Marko tags](https://markojs.com/docs/custom-tags/#publishing-tags-to-npm)**, the `"script-lang"` attribute must be set to `"ts"` in [the `marko.json`](./marko-json.md):
+- **[Markoタグのパッケージ](https://markojs.com/docs/custom-tags/#publishing-tags-to-npm)の場合**、[`marko.json`](./marko-json.md)内で`"script-lang"`属性を`"ts"`に設定する必要があります:
 
   ```json
   /* marko.json */
@@ -23,22 +23,22 @@ There are two (non-exclusive) ways to add TypeScript to a Marko project:
   }
   ```
 
-  This will automatically expose type-checking and autocomplete for the published tags.
+  これにより、公開されたタグの型チェックとオートコンプリートが自動的に公開されます。
 
 > [!TIP]
-> You can also use the `script-lang` method for sites and apps.
+> サイトやアプリでも`script-lang`メソッドを使用できます。
 >
-> Marko will crawl up the directory looking for a `marko.json` with `script-lang` defined.
+> Markoは、`script-lang`が定義された`marko.json`を探してディレクトリを上方向にクロールします。
 >
-> This helps when incrementally migrating to TypeScript allowing folders to opt-in or opt-out of strict type checking.
+> これは、TypeScriptに段階的に移行する際に、フォルダごとに厳密な型チェックをオプトインまたはオプトアウトできるため役立ちます。
 
-## Typing `input`
+## `input`の型付け
 
-A `.marko` file will use any exported `Input` type for [that file’s `input` object](./language.md#input).
+`.marko`ファイルは、[そのファイルの`input`オブジェクト](./language.md#input)に対してエクスポートされた`Input`型を使用します。
 
-This can be `export type Input` or `export interface Input`.
+これは`export type Input`または`export interface Input`にできます。
 
-### Example
+### 例
 
 ```marko
 /* PriceField.marko */
@@ -53,7 +53,7 @@ export interface Input {
 </label>
 ```
 
-Since it is exported, `Input` may be accessed from other `.marko` and `.ts` files:
+エクスポートされているため、`Input`は他の`.marko`および`.ts`ファイルからアクセスできます:
 
 ```marko
 import { Input as PriceInput } from "<PriceField>";
@@ -69,9 +69,9 @@ export interface Input extends PriceInput {
 };
 ```
 
-### Generic `Input`
+### ジェネリック`Input`
 
-[Generic Types and Type Parameters](https://www.typescriptlang.org/docs/handbook/2/generics.html) on `Input` are recognized throughout the entire `.marko` template (excluding [static statements](./language.md#static)).
+`Input`の[ジェネリック型と型パラメータ](https://www.typescriptlang.org/docs/handbook/2/generics.html)は、`.marko`テンプレート全体で認識されます（[staticステートメント](./language.md#static)を除く）。
 
 ```marko
 export interface Input<T> {
@@ -80,14 +80,14 @@ export interface Input<T> {
 }
 
 static function staticFn() {
-  // can NOT use `T` here
+  // ここでは`T`を使用できません
 }
 
 <const/instanceFn(val: T) {
-  // can use `T` here
+  // ここでは`T`を使用できます
 }/>
 
-// can use `as T` here
+// ここでは`as T`を使用できます
 <select onInput(evt) { input.onSelect(options[evt.target.value] as T) }>
   <for|value, i| of=input.options>
     <option value=i>${value}</option>
@@ -95,49 +95,49 @@ static function staticFn() {
 </select>
 ```
 
-## Built-in Marko Types
+## 組み込みMarko型
 
-Marko exposes common [type definitions](https://github.com/marko-js/marko/blob/main/packages/marko/index.d.ts) through the `Marko` [TypeScript namespace](https://www.typescriptlang.org/docs/handbook/namespaces.html):
+Markoは、`Marko` [TypeScript名前空間](https://www.typescriptlang.org/docs/handbook/namespaces.html)を通じて一般的な[型定義](https://github.com/marko-js/marko/blob/main/packages/marko/index.d.ts)を公開しています:
 
 - **`Marko.Template<Input, Return>`**
-  - The type of a `.marko` file
+  - `.marko`ファイルの型
   - `typeof import("./template.marko")`
 - **`Marko.TemplateInput<Input>`**
-  - The object accepted by the render methods of a template. It includes the template's `Input` and `$global` values.
+  - テンプレートのrenderメソッドが受け入れるオブジェクト。テンプレートの`Input`と`$global`値を含みます。
 - **`Marko.Body<Params, Return>`**
-  - Used to type [tag content](./language.md#tag-content)
+  - [タグコンテンツ](./language.md#tag-content)を型付けするために使用されます
 - **`Marko.Renderable`**
-  - All values accepted by the [`<${dynamic}/>` tag](./language.md#dynamic-tags)
+  - [`<${dynamic}/>`タグ](./language.md#dynamic-tags)が受け入れるすべての値
   - `string | Marko.Template | Marko.Body | { content: Marko.Body}`
 - **`Marko.Global`**
-  - The type of [the `$global` object](./language.md#global)
+  - [`$global`オブジェクト](./language.md#global)の型
 - **`Marko.RenderResult`**
-  - The result of [rendering a Marko template](./template.md#templaterenderinput)
+  - [Markoテンプレートのレンダリング](./template.md#templaterenderinput)の結果
   - `ReturnType<template.renderSync>`
   - `Awaited<ReturnType<template.render>>`
 - **`Marko.NativeTags`**
-  - `Marko.NativeTags`: An object containing all [native tags](./native-tag.md) and their types
-- **`Marko.Input<TagName>`** and **`Marko.Return<TagName>`**
-  - Helpers to extract the input and return types from native tags (when a string is passed) or custom tags.
-- **`Marko.BodyParameters<Body>`** and **`Marko.BodyReturnType<Body>`**
-  - Helper to extract the parameters and return types from a `Marko.Body`
+  - `Marko.NativeTags`: すべての[ネイティブタグ](./native-tag.md)とその型を含むオブジェクト
+- **`Marko.Input<TagName>`**と**`Marko.Return<TagName>`**
+  - ネイティブタグ（文字列が渡された場合）またはカスタムタグから入力と戻り値の型を抽出するヘルパー
+- **`Marko.BodyParameters<Body>`**と**`Marko.BodyReturnType<Body>`**
+  - `Marko.Body`からパラメータと戻り値の型を抽出するヘルパー
 - **`Marko.AttrTag<T>`**
-  - Used to represent types for [attributes tags](./language.md#attribute-tags)
-  - A single attribute tag, with a `[Symbol.iterator]` to consume any repeated tags
+  - [属性タグ](./language.md#attribute-tags)の型を表すために使用されます
+  - 繰り返しタグを消費するための`[Symbol.iterator]`を持つ単一の属性タグ
 
-### Deprecated
+### 非推奨
 
 - **`Marko.Component<Input, State>`**
-  - The base class for a [class component](https://markojs.com/v5/docs/class-components/#class-components)
+  - [クラスコンポーネント](https://markojs.com/v5/docs/class-components/#class-components)の基底クラス
 - **`Marko.Out`**
-  - The render context with methods like `write`, `beginAsync`, etc.
+  - `write`、`beginAsync`などのメソッドを持つレンダーコンテキスト
   - `ReturnType<template.render>`
 - **`Marko.Emitter`**
-  - `EventEmitter` from `@types/node`
+  - `@types/node`の`EventEmitter`
 
-### Typing `content`
+### `content`の型付け
 
-A commonly used type from the `Marko` namespace is `Marko.Body` which can be used to type the [content](./language.md#tag-content) in `input.content`:
+`Marko`名前空間からよく使用される型は`Marko.Body`で、`input.content`の[コンテンツ](./language.md#tag-content)を型付けするために使用できます:
 
 ```marko
 /* child.marko */
@@ -146,7 +146,7 @@ export interface Input {
 }
 ```
 
-Here, all of the following are acceptable:
+ここでは、以下のすべてが許容されます:
 
 ```marko
 /* index.marko */
@@ -157,7 +157,7 @@ Here, all of the following are acceptable:
 </child>
 ```
 
-Passing other values (including components) causes a type error:
+他の値（コンポーネントを含む）を渡すと型エラーが発生します:
 
 ```marko
 /* index.marko */
@@ -165,9 +165,9 @@ import OtherTag from "<other-tag>";
 <child content=OtherTag/>
 ```
 
-#### Typing Tag Parameters
+#### タグパラメータの型付け
 
-Tag parameters are provided to the `content` by the child tag. For this reason, `Marko.Body` allows typing of its parameters:
+タグパラメータは、子タグによって`content`に提供されます。このため、`Marko.Body`はそのパラメータの型付けを可能にします:
 
 ```marko
 /* for-by-two.marko */
@@ -188,9 +188,9 @@ export interface Input {
 </for-by-two>
 ```
 
-### Typing Attribute Tags
+### 属性タグの型付け
 
-All attribute tags are typed as iterable with a `[Symbol.iterator]`, regardless of intent. This means all attribute tag inputs must be wrapped in `Marko.AttrTag`.
+すべての属性タグは、意図に関係なく`[Symbol.iterator]`を持つイテラブルとして型付けされます。これは、すべての属性タグ入力が`Marko.AttrTag`でラップされる必要があることを意味します。
 
 ```marko
 /* my-select.marko */
@@ -205,9 +205,9 @@ export interface Input {
 </select>
 ```
 
-### Extending native tag types within a Marko tag
+### Markoタグ内でネイティブタグ型を拡張する
 
-The types for native tags are accessed via the global `Marko.Input` type. Here's an example of a component that extends the `button` html tag:
+ネイティブタグの型は、グローバル`Marko.Input`型を介してアクセスされます。以下は、`button` HTMLタグを拡張するコンポーネントの例です:
 
 ```marko
 /* color-button.marko */
@@ -223,7 +223,7 @@ $ const { color, ...attrs } = input;
 </button>
 ```
 
-### Registering a new native tag (e.g. for custom elements)
+### 新しいネイティブタグの登録（例: カスタム要素用）
 
 ```ts
 interface MyCustomElementAttributes {
@@ -233,42 +233,42 @@ interface MyCustomElementAttributes {
 declare global {
   namespace Marko {
     interface NativeTags {
-      // By adding this entry, you can now use `my-custom-element` as a native html tag.
+      // このエントリを追加することで、`my-custom-element`をネイティブHTMLタグとして使用できるようになります。
       "my-custom-element": MyCustomElementAttributes;
     }
   }
 }
 ```
 
-### Registering new "global" HTML Attributes
+### 新しい「グローバル」HTML属性の登録
 
 ```ts
 declare global {
   namespace Marko {
     interface HTMLAttributes {
-      "my-non-standard-attribute"?: string; // Adds this attribute as available on all HTML tags.
+      "my-non-standard-attribute"?: string; // この属性をすべてのHTMLタグで利用可能として追加します。
     }
   }
 }
 ```
 
-### Registering CSS Properties (eg for custom properties)
+### CSSプロパティの登録（例: カスタムプロパティ用）
 
 ```ts
 declare global {
   namespace Marko {
     namespace CSS {
       interface Properties {
-        "--foo"?: string; // adds a support for a custom `--foo` css property.
+        "--foo"?: string; // カスタム`--foo` CSSプロパティのサポートを追加します。
       }
     }
   }
 }
 ```
 
-## TypeScript Syntax in `.marko`
+## `.marko`でのTypeScript構文
 
-Any JavaScript expression in Marko can also be written as a TypeScript expression.
+MarkoのすべてのJavaScript式は、TypeScript式としても記述できます。
 
 ```marko
 <my-tag foo=1 as any>
@@ -276,7 +276,7 @@ Any JavaScript expression in Marko can also be written as a TypeScript expressio
 </my-tag>
 ```
 
-### Tag Type Parameters
+### タグ型パラメータ
 
 ```marko
 <child <T>|value: T|>
@@ -284,7 +284,7 @@ Any JavaScript expression in Marko can also be written as a TypeScript expressio
 </child>
 ```
 
-### Tag Type Arguments
+### タグ型引数
 
 ```marko
 /* components/child.marko */
@@ -295,19 +295,19 @@ export interface Input<T> {
 
 ```marko
 /* index.marko */
-// number would be inferred in this case, but we can be explicit
+// この場合numberは推論されますが、明示的にすることもできます
 <child<number> value=1 />
 ```
 
-### Method Shorthand Type Parameters
+### メソッド省略記法の型パラメータ
 
 ```marko
 <child process<T>() { /* ... */ } />
 ```
 
-### Attribute Type Assertions
+### 属性の型アサーション
 
-The types of attribute values can _usually_ be inferred. When needed, you can assert values to be more specific with [TypeScript’s `as` keyword](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions):
+属性値の型は_通常_推論できます。必要に応じて、[TypeScriptの`as`キーワード](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions)を使用して、値をより具体的にアサートできます:
 
 ```marko
 <some-component
@@ -316,21 +316,21 @@ The types of attribute values can _usually_ be inferred. When needed, you can as
 />
 ```
 
-## JSDoc Support
+## JSDocサポート
 
-For existing projects that want to incrementally add type safety, adding full TypeScript support is a big leap. This is why Marko also includes full support for [incremental typing via JSDoc](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html).
+型安全性を段階的に追加したい既存のプロジェクトにとって、完全なTypeScriptサポートの追加は大きな飛躍です。このため、Markoは[JSDocによる段階的な型付け](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html)の完全なサポートも含んでいます。
 
-### Setup
+### セットアップ
 
-You can enable type checking in an existing `.marko` file by adding a `// @ts-check` comment at the top:
+既存の`.marko`ファイルで型チェックを有効にするには、先頭に`// @ts-check`コメントを追加します:
 
 ```js
 // @ts-check
 ```
 
-If you want to enable type checking for all Marko & JavaScript files in a JavaScript project, you can switch to using a [`jsconfig.json`](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#using-tsconfigjson-or-jsconfigjson). You can skip checking some files by adding a `// @ts-nocheck` comment to files.
+JavaScriptプロジェクトのすべてのMarkoおよびJavaScriptファイルで型チェックを有効にしたい場合は、[`jsconfig.json`](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#using-tsconfigjson-or-jsconfigjson)の使用に切り替えることができます。ファイルに`// @ts-nocheck`コメントを追加することで、一部のファイルのチェックをスキップできます。
 
-Once that has been enabled, you can start by typing the input with JSDoc. Here's an example component with typed `input`:
+有効になったら、JSDocで入力を型付けすることから始めることができます。以下は、型付けされた`input`を持つコンポーネントの例です:
 
 ```marko
 // @ts-check
@@ -345,13 +345,13 @@ Once that has been enabled, you can start by typing the input with JSDoc. Here's
 <div>${firstName} ${lastName}</div>
 ```
 
-## CI Type Checking
+## CI型チェック
 
-For type checking Marko files outside of your editor there is the [`@marko/type-check` cli](https://github.com/marko-js/language-server/tree/main/packages/type-check). See the CLI documentation for more information.
+エディタの外でMarkoファイルを型チェックするには、[`@marko/type-check` CLI](https://github.com/marko-js/language-server/tree/main/packages/type-check)があります。詳細については、CLIドキュメントを参照してください。
 
-## Profiling Performance
+## パフォーマンスプロファイリング
 
-The [`--generateTrace`](https://www.typescriptlang.org/tsconfig/#generateTrace) flag can be used to determine the parts of a codebase which are using the most resources during type checking.
+[`--generateTrace`](https://www.typescriptlang.org/tsconfig/#generateTrace)フラグを使用して、型チェック中に最もリソースを使用しているコードベースの部分を特定できます。
 
 ```sh
 mtc --generateTrace TRACE_DIR

--- a/docs/tutorial/components-and-reactivity.md
+++ b/docs/tutorial/components-and-reactivity.md
@@ -1,22 +1,22 @@
-# Components and Reactivity
+# コンポーネントとリアクティビティ
 
 > [!TLDR]
 >
-> We build a simple example which introduces tag variables, conditionals, and components
+> タグ変数、条件分岐、コンポーネントを紹介する簡単な例を構築します
 
-In this tutorial, we're going to build an app for converting temperature between fahrenheit and celsius.
+このチュートリアルでは、華氏と摂氏の間で温度を変換するアプリを構築します。
 
-## Introducing a Tag
+## タグの導入
 
-As with many user interfaces, our first step is to gather input from the user. We can do so with HTML's `<input>` tag:
+多くのユーザーインターフェースと同様に、最初のステップはユーザーから入力を収集することです。HTMLの`<input>`タグを使用してこれを行うことができます：
 
 ```marko
 <input type="number">
 ```
 
-## Adding State
+## 状態の追加
 
-Of course, right now we aren't keeping track of the value that this input contains. To do this, we need to introduce state. In Marko, the most common way to do this is with [tag variables](../reference/language.md#tag-variables). Here, we will use [Marko's `<let>` tag](../reference/core-tag.md#let):
+もちろん、現時点ではこの入力に含まれる値を追跡していません。これを行うには、状態を導入する必要があります。Markoでは、これを行う最も一般的な方法は[タグ変数](../reference/language.md#tag-variables)を使用することです。ここでは、[Markoの`<let>`タグ](../reference/core-tag.md#let)を使用します：
 
 ```marko
 <let/degF=80>
@@ -25,9 +25,9 @@ Of course, right now we aren't keeping track of the value that this input contai
 <div>It's ${degF}°F</div>
 ```
 
-## Syncing State
+## 状態の同期
 
-Now the `<input>` has an initial value, but we still aren't keeping track of it when it changes. One way to do this is by listening for [the `input` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event) with an [event handler](../reference/native-tag.md#event-handlers):
+これで`<input>`に初期値が設定されましたが、変更時にそれを追跡していません。これを行う1つの方法は、[イベントハンドラ](../reference/native-tag.md#event-handlers)で[`input`イベント](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)をリッスンすることです：
 
 ```marko
 <let/degF=80>
@@ -38,14 +38,14 @@ Now the `<input>` has an initial value, but we still aren't keeping track of it 
 <div>It's ${degF}°F</div>
 ```
 
-Aha! Now we have a [reactive variable](../reference/reactivity.md) that keeps track of our value for degrees (in fahrenheit). Let's convert it to celsius!
+これで、度数（華氏）の値を追跡する[リアクティブ変数](../reference/reactivity.md)ができました。摂氏に変換しましょう！
 
 > [!NOTE]
-> For more control over the `<input>` value, we could have used Marko's [controllable](../reference/native-tag.md#change-handlers) pattern.
+> `<input>`の値をより細かく制御するには、Markoの[controllable](../reference/native-tag.md#change-handlers)パターンを使用できます。
 
-## Adding Computed Values
+## 計算値の追加
 
-To do this, we can use a `<const>` tag:
+これを行うには、`<const>`タグを使用できます：
 
 ```marko
 <let/degF=80>
@@ -59,9 +59,9 @@ To do this, we can use a `<const>` tag:
 </div>
 ```
 
-## Using Conditionals
+## 条件分岐の使用
 
-Now that we have a reactive variable, let's see what else we can do! Maybe some notes about the temperature, using [conditional tags](../reference/core-tag.md#if--else)?
+リアクティブ変数ができたので、他に何ができるか見てみましょう！[条件タグ](../reference/core-tag.md#if--else)を使用して、温度に関するメモを追加してみましょうか？
 
 ```marko
 <let/degF=80>
@@ -85,9 +85,9 @@ Now that we have a reactive variable, let's see what else we can do! Maybe some 
 </else>
 ```
 
-## Adding Styles and Visualization
+## スタイルとビジュアライゼーションの追加
 
-Or what about a temperature gauge, with some fancy CSS?
+または、派手なCSSを使った温度計はどうでしょうか？
 
 ```marko
 <let/degF=80>
@@ -127,9 +127,9 @@ Or what about a temperature gauge, with some fancy CSS?
 </style>
 ```
 
-## Creating Reusable Components
+## 再利用可能なコンポーネントの作成
 
-Actually, this is getting a little bit too complex to all put in one place. Maybe we should pull that temperature gauge out into a component:
+実際、これは1つの場所にまとめるには少し複雑すぎます。温度計をコンポーネントに抽出しましょう：
 
 ```marko
 /* index.marko */
@@ -186,21 +186,21 @@ Actually, this is getting a little bit too complex to all put in one place. Mayb
 ```
 
 > [!IMPORTANT]
-> Make sure your `<gauge>` component file is in a `tags/` directory! Marko [auto-discovers](../reference/custom-tag.md#custom-tag-discovery) custom tags based on directory structure.
+> `<gauge>`コンポーネントファイルが`tags/`ディレクトリにあることを確認してください！Markoはディレクトリ構造に基づいてカスタムタグを[自動検出](../reference/custom-tag.md#custom-tag-discovery)します。
 
 <!-- markdownlint-disable MD026 allow exclamation point -->
 
-## Your Turn!
+## あなたの番！
 
-That's all we're going to build for now, but feel free to add more! Here are some ideas:
+今回構築するのはここまでですが、自由に追加してください！以下にいくつかのアイデアを示します：
 
-- How about a new temperature unit? Maybe Kelvin or [Delisle](https://en.wikipedia.org/wiki/Delisle_scale)?
-- Most of the world actually uses celsius 😅, maybe users should be able to pick which unit to start with
-- What about wind chill? Apparently there are [standard formulas](https://en.wikipedia.org/wiki/Wind_chill) if "wind velocity" is known
-- Converting between temperatures is cool, but this system _could_ be generalized. What if it converted between weights, volumes, or distances?
-- Anything else! The opportunities are limitless!
+- 新しい温度単位はどうでしょうか？ケルビンや[ドリール度](https://en.wikipedia.org/wiki/Delisle_scale)などは？
+- 世界のほとんどの地域では実際に摂氏を使用しています😅、おそらくユーザーは開始する単位を選択できるべきです
+- 体感温度はどうでしょうか？「風速」がわかっていれば、[標準的な公式](https://en.wikipedia.org/wiki/Wind_chill)があるようです
+- 温度間の変換はクールですが、このシステムは_汎用化_できます。重量、容量、距離の間で変換するとしたら？
+- その他何でも！可能性は無限大です！
 
-## Next Steps
+## 次のステップ
 
-- [Nested Reactivity](../explanation/nested-reactivity.md)
-- [Language Reference](../reference/language.md)
+- [ネストされたリアクティビティ](../explanation/nested-reactivity.md)
+- [言語リファレンス](../reference/language.md)

--- a/docs/tutorial/fundamentals.md
+++ b/docs/tutorial/fundamentals.md
@@ -1,14 +1,14 @@
-# Marko Fundamentals
+# Markoの基礎
 
 > [!TLDR]
 >
-> Marko builds on top of HTML, enabling components and JavaScript-based interpolation
+> MarkoはHTMLをベースに構築されており、コンポーネントとJavaScriptベースの補間を可能にします
 
-Marko is designed to feel familiar if you know HTML, while making it easy to build dynamic, interactive websites. Let's walk through the core concepts.
+Markoは、HTMLを知っていれば親しみやすく感じられるように設計されており、動的でインタラクティブなウェブサイトを簡単に構築できます。コアコンセプトを見ていきましょう。
 
-## Templates are HTML
+## テンプレートはHTML
 
-Nearly any valid HTML is also valid Marko code. We can start with regular HTML and gradually add features as needed.
+ほぼすべての有効なHTMLは、有効なMarkoコードでもあります。通常のHTMLから始めて、必要に応じて徐々に機能を追加できます。
 
 ```marko
 <h1>My Blog</h1>
@@ -18,9 +18,9 @@ Nearly any valid HTML is also valid Marko code. We can start with regular HTML a
 </nav>
 ```
 
-## Attributes are JS
+## 属性はJS
 
-Almost all valid JavaScript expressions can be written as attribute values.
+ほぼすべての有効なJavaScript式を属性値として記述できます。
 
 ```marko
 <a href=`/user/${user.id}`>My Profile</a>
@@ -28,21 +28,21 @@ Almost all valid JavaScript expressions can be written as attribute values.
 ```
 
 > [!NOTE]
-> The Reference Docs explain [more about Attributes](../reference/language.md#attributes) including how they support [`...spreads`](../reference/language.md#spread-attributes) and [`methods()`](../reference/language.md#shorthand-methods).
+> リファレンスドキュメントでは、[`...spreads`](../reference/language.md#spread-attributes)や[`methods()`](../reference/language.md#shorthand-methods)のサポートを含む[属性の詳細](../reference/language.md#attributes)について説明しています。
 
 
-## Dynamic Content
+## 動的コンテンツ
 
-Tag content in Marko is similar to [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in JavaScript, so dynamic text can be added with [interpolated `${expressions}`](../reference/language.md#dynamic-text)
+Markoのタグコンテンツは、JavaScriptの[テンプレートリテラル](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)に似ており、[補間された`${式}`](../reference/language.md#dynamic-text)で動的なテキストを追加できます
 
 ```marko
 <p>Today is ${new Date().toDateString()}</p>
 <p>Random number: ${Math.floor(Math.random() * 100)}</p>
 ```
 
-## Components
+## コンポーネント
 
-To reuse code, we can move it into a separate file. Each `.marko` file is a component that can be used like an HTML tag.
+コードを再利用するには、別のファイルに移動できます。各`.marko`ファイルは、HTMLタグのように使用できるコンポーネントです。
 
 ```marko
 /* tags/card.marko */
@@ -53,7 +53,7 @@ To reuse code, we can move it into a separate file. Each `.marko` file is a comp
 </div>
 ```
 
-This `<card>` component can now be used anywhere in the page:
+この`<card>`コンポーネントは、ページ内のどこでも使用できます：
 
 ```marko
 <h1>Our Team</h1>
@@ -63,14 +63,14 @@ This `<card>` component can now be used anywhere in the page:
 ```
 
 > [!NOTE]
-> Components in the `tags/` directory are [automatically discovered](../reference/custom-tag.md#custom-tag-discovery). No need to `import` them.
+> `tags/`ディレクトリ内のコンポーネントは[自動的に検出](../reference/custom-tag.md#custom-tag-discovery)されます。`import`する必要はありません。
 
 > [!TIP]
-> We can also write multiple "components" in a single file using the [`<define>` tag](../reference/core-tag.md#define).
+> [`<define>`タグ](../reference/core-tag.md#define)を使用して、単一のファイルに複数の「コンポーネント」を記述することもできます。
 
-### Passing Data to Components
+### コンポーネントへのデータの受け渡し
 
-Attributes on custom components are available through a special object called [`input`](../reference/language.md#input).
+カスタムコンポーネントの属性は、[`input`](../reference/language.md#input)と呼ばれる特別なオブジェクトを通じて利用できます。
 
 ```marko
 /* card.marko */
@@ -87,7 +87,7 @@ export interface Input {
 </div>
 ```
 
-Now we can pass different data to each instance of `card`:
+これで、`card`の各インスタンスに異なるデータを渡すことができます：
 
 ```marko
 <h1>Our Team</h1>
@@ -97,11 +97,11 @@ Now we can pass different data to each instance of `card`:
 ```
 
 > [!NOTE]
-> Also check out [attribute tags](../reference/language.md#attribute-tags) which we can use to pass named content to a component
+> コンポーネントに名前付きコンテンツを渡すために使用できる[属性タグ](../reference/language.md#attribute-tags)もチェックしてください
 
-## Core Tags
+## コアタグ
 
-Marko provides many helpful [Core Tags](../reference/core-tag.md). For example, we can use [`<if>` and `<else>`](../reference/core-tag.md#if--else) to show or hide content based on conditions.
+Markoは多くの便利な[コアタグ](../reference/core-tag.md)を提供しています。たとえば、[`<if>`と`<else>`](../reference/core-tag.md#if--else)を使用して、条件に基づいてコンテンツを表示または非表示にできます。
 
 ```marko
 /* tags/product.marko */
@@ -117,7 +117,7 @@ Marko provides many helpful [Core Tags](../reference/core-tag.md). For example, 
 </div>
 ```
 
-Now we can show different states based on the product data:
+これで、製品データに基づいて異なる状態を表示できます：
 
 ```marko
 <product name="T-Shirt" price=25 stock=10/>
@@ -125,7 +125,7 @@ Now we can show different states based on the product data:
 <product name="Hat" price=15 stock=5/>
 ```
 
-And we can use the [`<for>` tag](../reference/core-tag.md#for) to display repeated content
+また、[`<for>`タグ](../reference/core-tag.md#for)を使用して繰り返しコンテンツを表示できます
 
 ```marko
 <for|product| of=productsList>
@@ -133,7 +133,7 @@ And we can use the [`<for>` tag](../reference/core-tag.md#for) to display repeat
 </for>
 ```
 
-## Next Steps
+## 次のステップ
 
-- [Components and Reactivity](./components-and-reactivity.md)
-- [Build an App](../marko-run/getting-started.md)
+- [コンポーネントとリアクティビティ](./components-and-reactivity.md)
+- [アプリの構築](../marko-run/getting-started.md)


### PR DESCRIPTION
Translate all markdown files in the docs directory to Japanese:
- explanation/ (10 files)
- guide/ (6 files)
- introduction/ (5 files)
- marko-run/ (3 files)
- reference/ (8 files)
- tutorial/ (2 files)

All code blocks, technical terms, and links are preserved in their original form. Only explanatory text has been translated to Japanese.