### PR TITLE
Various bug fixes

### DIFF
--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -73,6 +73,10 @@ p {
 ::selection {
   color: var(--section-color-dim-alt, var(--color-red-dim-alt));
   background-color: var(--section-color-alt, var(--color-red-alt));
+  -webkit-text-fill-color: var(
+    --section-color-dim-alt,
+    var(--color-red-dim-alt)
+  );
 }
 
 body {

--- a/src/routes/playground/tags/playground/tags/editor/tags/tabs/tabs.marko
+++ b/src/routes/playground/tags/playground/tags/editor/tags/tabs/tabs.marko
@@ -89,8 +89,8 @@ div class=styles.tabs
 
       if (filename) {
         if (!filename.includes(".")) filename += ".marko";
+        selected = tabs.length;
         tabs = [...tabs, { path: filename, content: "" }];
-        selected = tabs.length - 1;
       }
     }
     ,class=styles.add

--- a/src/styles/sticky.scss
+++ b/src/styles/sticky.scss
@@ -23,7 +23,17 @@ $pageLinksHeight: 3.5rem;
 }
 
 @mixin supported {
+  // On large screens, exclude Safari because of a rendering bug with scaleY
+  @supports (animation-timeline: scroll()) and (not (-webkit-hyphens: none)) {
+    @media (width >= 48rem) and (height >= 38rem) {
+      @content;
+    }
+  }
+
+  // On small screens, include Safari
   @supports (animation-timeline: scroll()) {
-    @content;
+    @media (width < 48rem) or (height < 38rem) {
+      @content;
+    }
   }
 }

--- a/src/util/workspace/cdn-plugin.ts
+++ b/src/util/workspace/cdn-plugin.ts
@@ -14,7 +14,10 @@ export function cdnPlugin(): Plugin {
       }
 
       if (/^[^\0.\/]/.test(id)) {
-        return { id: `https://esm.sh/${id}`, external: true };
+        return {
+          id: `https://esm.sh/${id}?bundle`,
+          external: true,
+        };
       }
     },
   };


### PR DESCRIPTION
- Add `?bundle` to `esm.sh` links for better package support, the one I found that didn't work before was `"p5"`
- Fix _crazy_ vertical stretching bug for menu on safari
  <img width="2269" height="828" alt="image" src="https://github.com/user-attachments/assets/97dfc40b-456f-4281-b913-3de65fac6f45" />
- Change tab logic so it selects latest tab, though really we should fix [the root cause](https://github.com/orgs/marko-js/projects/2/views/12?pane=issue&itemId=148774810)
- Gradients in gecko disappear on `::selection`, so I hard-coded `color`