### PR TITLE
fix: playground split-pane style binding and source map concat

### DIFF
--- a/src/routes/playground/tags/split-panes/split-panes.marko
+++ b/src/routes/playground/tags/split-panes/split-panes.marko
@@ -33,5 +33,5 @@ div/container class=styles.panes
       (e.target as HTMLButtonElement).releasePointerCapture(e.pointerId);
     }
     ,class=styles.divider
-  div ...second style=[first.style, { "flex-grow": 1 - editorSize }]
+  div ...second style=[second.style, { "flex-grow": 1 - editorSize }]
     ${second.content}

--- a/src/util/workspace/concat-sourcemaps.ts
+++ b/src/util/workspace/concat-sourcemaps.ts
@@ -52,7 +52,7 @@ export class ConcatSourceMap {
       for (let i = lines; i--; ) {
         this.sourceMap.addMapping({
           generated: {
-            line: this.line + i,
+            line: line + i,
             column: 0,
           },
           original: {
@@ -62,11 +62,6 @@ export class ConcatSourceMap {
           source,
           name: null as any,
         });
-      }
-
-      const sourceContent = sourceMap.sourcesContent?.[0];
-      if (sourceContent) {
-        this.sourceMap.setSourceContent(source, sourceContent);
       }
     }
   }


### PR DESCRIPTION
Two bug fixes found while reviewing the playground code:

- **split-panes**: the second pane applied `first.style` instead of `second.style`, silently dropping any style passed to the second pane.
- **concat-sourcemaps**: the no-sourcemap branch used the post-incremented `this.line` as the generated base line and dereferenced the (always falsy) `sourceMap` arg. Now uses the saved start line and drops the dead, crash-prone `sourceContent` lookup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTVVAfDsiMrDjqJoXAoh7Y)_