### PR TITLE
fix: show bundled Client JS for the playground entry file

### DIFF
--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -95,9 +95,14 @@ const/compiledCode=(() => {
   if (selectedFile) {
     switch (outputType) {
       case "dom": {
-        return debug
-          ? ws.markoCompiled?.dom?.[`/tags/${selectedFile}`]?.code
-          : ws.previewModules?.[`/tags/${selectedFile}`]?.code;
+        if (debug) {
+          return ws.markoCompiled?.dom?.[`/tags/${selectedFile}`]?.code;
+        }
+        // The client entry imports the root template as `?hydrate`, so its
+        // bundled module is keyed with that suffix; child tags are bare.
+        const modules = ws.previewModules;
+        const id = `/tags/${selectedFile}`;
+        return (modules?.[id] ?? modules?.[`${id}?hydrate`])?.code;
       }
       case "html":
         return ws.markoCompiled?.html?.[`/tags/${selectedFile}`]?.code;


### PR DESCRIPTION
Continuing the playground review.

The non-debug **"Client JS"** view in the result pane looks up the bundled module by its bare path (`/tags/<file>`). But the client build imports the root template as `index.marko?hydrate`, so its module in `previewModules` is keyed `/tags/index.marko?hydrate`. Child tags are imported bare and match, but the **entry file** misses — so selecting the default `index.marko` tab and switching to "Client JS" shows an empty `/* empty */`.

The debug variant and "Server JS" both read from `markoCompiled` (keyed by bare path), which is why only this one path was affected.

Fix adds a `?hydrate`-suffixed fallback lookup. It's additive — when the bare key exists (child tags) nothing changes, and if neither key matches the result is unchanged from today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTVVAfDsiMrDjqJoXAoh7Y)_