### PR TITLE
fix: don't flood browser history while editing in the playground

### DIFF
--- a/src/routes/playground/tags/hash-files.marko
+++ b/src/routes/playground/tags/hash-files.marko
@@ -13,7 +13,9 @@ lifecycle
   }
   ,onUpdate() {
     compress(JSON.stringify(value)).then((compressed) => {
-      window.location.hash = compressed;
+      // Replace the current entry instead of assigning location.hash, which
+      // would push a new history entry on every edit and flood the back button.
+      history.replaceState(history.state, "", "#" + compressed);
     });
   }
 


### PR DESCRIPTION
`hash-files.marko`'s `onUpdate` assigned `window.location.hash = compressed` on every change. Assigning a new fragment via `location.hash` pushes a **new browser-history entry**, so editing in the playground floods the back button with one entry per edit — Back then walks through every intermediate code state instead of leaving the page.

Switched to `history.replaceState(history.state, "", "#" + compressed)`, updating the fragment in place. This matches how `let-search-param.marko` already handles URL updates. The written hash value is unchanged, so share-link loading is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTVVAfDsiMrDjqJoXAoh7Y)_