### PR TITLE
feat: add copy and share buttons to the playground result

### DIFF
--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -1,6 +1,9 @@
 import {
+  faCheck,
   faCompress,
+  faCopy,
   faExpand,
+  faLink,
   faRotateRight,
 } from "@fortawesome/free-solid-svg-icons";
 import type { CodeToHastOptions } from "shiki";
@@ -60,6 +63,8 @@ define/Stat|{ name, size }: { name: string; size: number | undefined }|
 
 const/selectedFile=(input.files[input.selected]?.path as string | undefined)
 let/outputType="preview"
+let/linkCopied=false
+let/codeCopied=false
 workspace/ws
 let-debounce/files=input.files
 const/showPreview=!(
@@ -127,6 +132,20 @@ div class=styles.result
       label class=styles.checkbox
         -- Debug
         input type="checkbox" checked:=debug
+    if=outputType !== "preview"
+      button
+        ,type="button"
+        ,class=styles.controlButton
+        ,title=(codeCopied ? "Copied!" : "Copy code")
+        ,onClick() {
+          navigator.clipboard?.writeText(compiledCode || "").catch(() => {});
+          codeCopied = true;
+        }
+        fa-icon=(codeCopied ? faCheck : faCopy)
+          ,class=codeCopied && styles.copied
+          ,onAnimationEnd() {
+            codeCopied = false;
+          }
     span class=styles.version -- v${markoVersion}
 
   div class=styles.output
@@ -187,6 +206,18 @@ div class=styles.result
             fullscreen = !fullscreen;
           }
           fa-icon=(fullscreen ? faCompress : faExpand)
+        button
+          ,title=(linkCopied ? "Copied!" : "Copy share link")
+          ,class=[styles.previewControl, styles.shareControl]
+          ,onClick() {
+            navigator.clipboard?.writeText(location.href).catch(() => {});
+            linkCopied = true;
+          }
+          fa-icon=(linkCopied ? faCheck : faLink)
+            ,class=linkCopied && styles.copied
+            ,onAnimationEnd() {
+              linkCopied = false;
+            }
       else if=outputType === "previewJS"
         Stat name="size" size=(ws.stats?.script?.size)
         Stat name="gzip" size=(ws.stats?.script?.gzip)

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -141,6 +141,49 @@
   }
 }
 
+.controlButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.75rem;
+  border: none;
+  border-radius: 0;
+  background-color: var(--color-gray-dim);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--color-gray-alt-dim);
+  }
+
+  svg {
+    height: 1lh;
+    fill: var(--color-blue);
+  }
+}
+
+.shareControl svg {
+  width: 1.25lh;
+}
+
+.copied {
+  animation: copied 1.5s ease;
+}
+
+@keyframes copied {
+  0% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  20% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
 .spin {
   animation: spin 0.25s ease-out;
 }


### PR DESCRIPTION
Adds two quality-of-life buttons to the playground result pane:

- **Copy share link** — sits with the reload/fullscreen preview controls and copies the current playground URL (which already encodes the files in the hash), so it shares the exact current state.
- **Copy code** — shown in the result controls for the compiled/bundled output views (Client/Server JS, Bundled JS/CSS, Rendered HTML); copies the displayed code.

Details:
- The "copied" confirmation swaps the icon to a check and pops it, resetting via `onAnimationEnd` — the same pattern the existing reload-spin button uses, so no timers.
- Clipboard calls are guarded so they no-op safely where the API is unavailable.
- The share icon has a fixed footprint so swapping to the check doesn't resize the button.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTVVAfDsiMrDjqJoXAoh7Y)_