### PR TITLE
feat: add an embedded console panel to the playground

### DIFF
--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -1,15 +1,18 @@
 import {
   faCheck,
+  faChevronDown,
+  faChevronUp,
   faCompress,
   faCopy,
   faExpand,
   faLink,
   faRotateRight,
+  faTrashCan,
 } from "@fortawesome/free-solid-svg-icons";
 import type { CodeToHastOptions } from "shiki";
 import { version as markoVersion } from "marko/package.json";
 client import highlighter from "app/util/shiki";
-client import { update, type File } from "app/util/workspace";
+client import { clearLogs, update, type File } from "app/util/workspace";
 import { bytesToUnits } from "app/util/sizes";
 import { styleToClass } from "app/util/style-to-class";
 import * as styles from "./result.style.module.scss";
@@ -65,6 +68,7 @@ const/selectedFile=(input.files[input.selected]?.path as string | undefined)
 let/outputType="preview"
 let/linkCopied=false
 let/codeCopied=false
+let/consoleOpen=false
 workspace/ws
 let-debounce/files=input.files
 const/showPreview=!(
@@ -181,46 +185,77 @@ div class=styles.result
       script -- update($signal, $frame(), files, !debug);
 
     a class=styles.markoLogo href="https://markojs.com" title="Built with Marko"
-    div class=styles.stats
-      if=outputType === "preview"
-        Stat name="js" size=(ws.stats?.script?.gzip)
-        Stat name="css" size=(ws.stats?.style?.gzip)
-        Stat name="html" size=(ws.stats?.markup?.gzip)
-        let/spinning=false
+  div class=styles.console
+    div class=styles.consoleBar
+      button
+        ,type="button"
+        ,class=styles.consoleToggle
+        ,aria-expanded=(consoleOpen ? "true" : "false")
+        ,onClick() {
+          consoleOpen = !consoleOpen;
+        }
+        fa-icon=(consoleOpen ? faChevronDown : faChevronUp)
+        span -- Console
+        if=ws.logs?.length
+          span class=styles.consoleCount -- ${ws.logs.length}
+      if=ws.logs?.length
         button
-          ,title="Reload preview"
-          ,class=styles.previewControl
+          ,type="button"
+          ,title="Clear console"
+          ,class=styles.consoleClear
           ,onClick() {
-            $frame().replaceWith($frame());
-            spinning = true;
+            clearLogs();
           }
-          fa-icon=faRotateRight
-            ,class=spinning && styles.spin
-            ,onAnimationEnd() {
-              spinning = false;
+          fa-icon=faTrashCan
+      div class=styles.stats
+        if=outputType === "preview"
+          Stat name="js" size=(ws.stats?.script?.gzip)
+          Stat name="css" size=(ws.stats?.style?.gzip)
+          Stat name="html" size=(ws.stats?.markup?.gzip)
+          let/spinning=false
+          button
+            ,title=(linkCopied ? "Copied!" : "Copy share link")
+            ,class=[styles.previewControl, styles.shareControl]
+            ,onClick() {
+              navigator.clipboard?.writeText(location.href).catch(() => {});
+              linkCopied = true;
             }
-        button
-          ,title=(fullscreen ? "Leave fullscreen" : "Expand to fullscreen")
-          ,class=styles.previewControl
-          ,onClick() {
-            fullscreen = !fullscreen;
-          }
-          fa-icon=(fullscreen ? faCompress : faExpand)
-        button
-          ,title=(linkCopied ? "Copied!" : "Copy share link")
-          ,class=[styles.previewControl, styles.shareControl]
-          ,onClick() {
-            navigator.clipboard?.writeText(location.href).catch(() => {});
-            linkCopied = true;
-          }
-          fa-icon=(linkCopied ? faCheck : faLink)
-            ,class=linkCopied && styles.copied
-            ,onAnimationEnd() {
-              linkCopied = false;
+            fa-icon=(linkCopied ? faCheck : faLink)
+              ,class=linkCopied && styles.copied
+              ,onAnimationEnd() {
+                linkCopied = false;
+              }
+          button
+            ,title="Reload preview"
+            ,class=styles.previewControl
+            ,onClick() {
+              $frame().replaceWith($frame());
+              spinning = true;
             }
-      else if=outputType === "previewJS"
-        Stat name="size" size=(ws.stats?.script?.size)
-        Stat name="gzip" size=(ws.stats?.script?.gzip)
-      else if=outputType === "previewCSS"
-        Stat name="size" size=(ws.stats?.style?.size)
-        Stat name="gzip" size=(ws.stats?.style?.gzip)
+            fa-icon=faRotateRight
+              ,class=spinning && styles.spin
+              ,onAnimationEnd() {
+                spinning = false;
+              }
+          button
+            ,title=(fullscreen ? "Leave fullscreen" : "Expand to fullscreen")
+            ,class=styles.previewControl
+            ,onClick() {
+              fullscreen = !fullscreen;
+            }
+            fa-icon=(fullscreen ? faCompress : faExpand)
+        else if=outputType === "previewJS"
+          Stat name="size" size=(ws.stats?.script?.size)
+          Stat name="gzip" size=(ws.stats?.script?.gzip)
+        else if=outputType === "previewCSS"
+          Stat name="size" size=(ws.stats?.style?.size)
+          Stat name="gzip" size=(ws.stats?.style?.gzip)
+    if=consoleOpen
+      div class=styles.consoleBody
+        if=ws.logs?.length
+          for|log| of=ws.logs
+            div class=styles.logEntry data-method=log.method
+              span class=styles.logNs data-ns=log.ns -- ${log.ns}
+              span class=styles.logText -- ${log.text}
+        else
+          div class=styles.consoleEmpty -- No console output yet.

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -104,34 +104,24 @@
 }
 
 .stats {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  background-color: var(--color-gray-dim);
-  padding: 0.5rem;
-  border-top-left-radius: 0.5rem;
-  font-family: "Ubuntu Mono", monospace;
   display: flex;
+  align-items: center;
   gap: 1rem;
+  margin-left: auto;
+  padding: 0 0.5rem;
+  font-family: "Ubuntu Mono", monospace;
 }
 
 .previewControl {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid transparent;
-  height: 100%;
-  font-size: 1rem;
-  border-radius: 0;
-  background-color: var(--color-gray-dim);
-  margin: -0.5rem;
-  padding: 0.5rem;
-  &:focus-within {
-    outline: none;
-  }
+  padding: 0 0.5rem;
+  border: none;
+  background: none;
+  cursor: pointer;
 
   &:hover {
-    outline: none;
     background-color: var(--color-gray-alt-dim);
   }
 
@@ -226,6 +216,142 @@
 
 .hide {
   display: none;
+}
+
+.console {
+  display: flex;
+  flex-direction: column;
+  border-top: 2px solid var(--color-gray-alt-dim);
+  background-color: var(--color-gray-dim);
+
+  // In fullscreen, collapse to a minimal control cluster in the corner --
+  // no console toggle or log output (see below).
+  :global(.fullscreen) & {
+    visibility: visible;
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    z-index: 1000001;
+    border-top: none;
+    border-top-left-radius: 0.5rem;
+  }
+}
+
+.consoleBar {
+  display: flex;
+  align-items: stretch;
+  min-height: 2rem;
+}
+
+.consoleToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+
+  svg {
+    height: 1lh;
+    fill: var(--color-blue);
+  }
+
+  &:hover {
+    background-color: var(--color-gray-alt-dim);
+  }
+
+  :global(.fullscreen) & {
+    display: none;
+  }
+}
+
+.consoleCount {
+  background-color: var(--color-gray-alt-dim);
+  border-radius: 1rem;
+  padding: 0 0.5rem;
+  font-size: 0.8rem;
+}
+
+.consoleClear {
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+
+  svg {
+    height: 1lh;
+    fill: var(--color-blue);
+  }
+
+  &:hover {
+    background-color: var(--color-gray-alt-dim);
+  }
+
+  :global(.fullscreen) & {
+    display: none;
+  }
+}
+
+.consoleBody {
+  height: 12rem;
+  overflow-y: auto;
+  border-top: 1px solid var(--color-gray-alt-dim);
+  font-family: "Ubuntu Mono", monospace;
+  font-size: 0.85rem;
+
+  :global(.fullscreen) & {
+    display: none;
+  }
+}
+
+.consoleEmpty {
+  padding: 0.5rem;
+  opacity: 0.6;
+}
+
+.logEntry {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.15rem 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+
+  & + & {
+    border-top: 1px solid var(--color-gray-alt-dim);
+  }
+
+  &[data-method="error"] {
+    color: var(--color-red);
+  }
+
+  &[data-method="warn"] {
+    color: var(--color-yellow);
+  }
+}
+
+.logNs {
+  flex-shrink: 0;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  opacity: 0.8;
+
+  &[data-ns="server"] {
+    color: var(--color-blue);
+  }
+
+  &[data-ns="client"] {
+    color: var(--color-red);
+  }
+}
+
+.logText {
+  flex-grow: 1;
 }
 
 .markoLogo {

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -19,6 +19,11 @@ export interface File {
   path: string;
   content: string;
 }
+export interface LogEntry {
+  ns: "client" | "server";
+  method: string;
+  text: string;
+}
 export interface Workspace {
   fs: FileSystem;
   optimize: boolean;
@@ -29,6 +34,7 @@ export interface Workspace {
   buildErrors: undefined | [Error, ...Error[]];
   runtimeErrors: undefined | [Error, ...Error[]];
   server: undefined | Worker;
+  logs: LogEntry[];
   stats:
     | undefined
     | {
@@ -42,7 +48,31 @@ let workspace: Workspace | undefined;
 const encoder = new TextEncoder();
 const rootDir = "/tags/";
 const subs = new Set<(workspace: Workspace) => void>();
-const consoleInjection = (c: typeof console, ns: string, color: string) => {
+function formatLogArgs(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (typeof a === "string") return a;
+      if (a && typeof a === "object") {
+        const err = a as { stack?: unknown };
+        if (typeof err.stack === "string") return err.stack;
+        try {
+          const json = JSON.stringify(a);
+          if (json !== undefined) return json;
+        } catch {
+          // fall through to String()
+        }
+      }
+      return String(a);
+    })
+    .join(" ");
+}
+
+const consoleInjection = (
+  c: typeof console,
+  ns: string,
+  color: string,
+  sink?: (method: string, args: unknown[]) => void,
+) => {
   const label = `%c[${ns}]%c `;
   const style = `color:${color}; font-weight:bold;`;
   for (const method of [
@@ -54,12 +84,27 @@ const consoleInjection = (c: typeof console, ns: string, color: string) => {
     "trace",
   ] as (keyof typeof console)[]) {
     const f = c[method] as any;
-    c[method] = ((...args: unknown[]) =>
-      f.apply(c, [label, style, "", ...args])) as any;
+    c[method] = ((...args: unknown[]) => {
+      try {
+        sink?.(method, args);
+      } catch {
+        // ignore sink failures
+      }
+      return f.apply(c, [label, style, "", ...args]);
+    }) as any;
   }
 
   const f = c.assert as any;
-  c.assert = (cond, ...args) => f.apply(c, [cond, label, style, "", ...args]);
+  c.assert = (cond, ...args) => {
+    if (!cond) {
+      try {
+        sink?.("assert", args);
+      } catch {
+        // ignore sink failures
+      }
+    }
+    return f.apply(c, [cond, label, style, "", ...args]);
+  };
 };
 
 export function subscribe(
@@ -94,6 +139,7 @@ export async function update(
     runtimeErrors: undefined,
     stats: undefined,
     server: undefined,
+    logs: [],
   });
   for (const file of files) {
     fs.files[rootDir + file.path] = file.content;
@@ -107,7 +153,7 @@ export async function update(
           mainPlugin({
             ws,
             browser: false,
-            code: `import t from "${rootDir}index.marko";let m;onmessage=async e=>{m=e;for await(const c of t.render())if(m==e)postMessage(c);else return;m==e&&postMessage(0)}\n(${consoleInjection.toString()})(console, "server", "#00FFFF")`,
+            code: `import t from "${rootDir}index.marko";let m;onmessage=async e=>{m=e;for await(const c of t.render())if(m==e)postMessage(c);else return;m==e&&postMessage(0)}\n(${consoleInjection.toString()})(console, "server", "#00FFFF", (method, args) => postMessage({ __mlog: { method, text: (${formatLogArgs.toString()})(args) } }))`,
           }),
           markoPlugin({
             ws,
@@ -224,7 +270,9 @@ export async function update(
         async () => {
           const win = frame.contentWindow! as Window & typeof globalThis;
           if (typeof window.console === "object") {
-            consoleInjection(win.console, "client", "#c2185b");
+            consoleInjection(win.console, "client", "#c2185b", (method, args) =>
+              pushLog("client", method, formatLogArgs(args)),
+            );
           }
           win.addEventListener("error", onRuntimeError, { signal });
           win.addEventListener("unhandledrejection", onRuntimeError, {
@@ -239,11 +287,14 @@ export async function update(
           ws.runtimeErrors = undefined;
           server.onmessage = (ev) => {
             if (signal.aborted) return;
-            if (ev.data) {
-              rawHTML += ev.data;
+            const data = ev.data;
+            if (data && typeof data === "object" && "__mlog" in data) {
+              pushLog("server", data.__mlog.method, data.__mlog.text);
+            } else if (data) {
+              rawHTML += data;
               ws.previewHTML = prettyPrintHTML(rawHTML);
               emit();
-              domWriter.write(ev.data);
+              domWriter.write(data);
             } else {
               void toByteSizes(rawHTML).then((size) => {
                 ws.stats = { ...ws.stats, markup: size };
@@ -307,12 +358,28 @@ export async function update(
     }
   }
 
+  function pushLog(ns: LogEntry["ns"], method: string, text: string) {
+    if (signal.aborted) return;
+    ws.logs = [...ws.logs, { ns, method, text }];
+    emit();
+  }
+
   function emit() {
     if (!signal.aborted) {
       const copy = { ...ws };
       for (const sub of subs) {
         sub(copy);
       }
+    }
+  }
+}
+
+export function clearLogs() {
+  if (workspace) {
+    workspace.logs = [];
+    const copy = { ...workspace };
+    for (const sub of subs) {
+      sub(copy);
     }
   }
 }


### PR DESCRIPTION
The playground already intercepts client and server `console` output to label it in devtools, but nothing surfaced it in the page. This captures those logs and shows them in the result pane, and consolidates the bottom controls into a single bar.

## Capture (`workspace.ts`)
- `consoleInjection` gains an optional `sink`; the existing client/server log labeling is unchanged, but each call now also forwards `(method, args)` to a sink (wrapped in try/catch so a sink error can't break user code).
- **Client** logs are captured in the parent realm (where the iframe's `console` is already wrapped). **Server** logs are forwarded from the worker via a tagged `postMessage({ __mlog })`; the message handler distinguishes those from render chunks. A self-contained `formatLogArgs` (injected into the worker via `.toString()`, same pattern as `consoleInjection`) stringifies args with error/`stack` and circular-ref handling.
- Logs are stored immutably on `ws.logs` (reset per build); `clearLogs()` is exported for the UI.

## UI (`result.marko` + SCSS)
- The result pane's stats and the share / reload / fullscreen controls are merged into a single bottom **console bar**: `Console` toggle + count + clear on the left, stats + share/refresh/fullscreen on the right.
- A collapsible body lists log entries with per-source (`client`/`server`) and per-level (`error`/`warn`) coloring.
- In **fullscreen**, the bar collapses to a minimal bottom-right control cluster — no console toggle or log output.

## Notes
- Default-collapsed; no auto-scroll yet.
- Client logs emitted during the iframe's initial module execution (before the `load`-time console wrap) are caught on the server side but may be missed on the client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTVVAfDsiMrDjqJoXAoh7Y)_