### PR TITLE
feat: add a format command to the playground editor

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -36,6 +36,7 @@
     "markodown",
     "markojs",
     "microtask",
+    "mlog",
     "nbsp",
     "onbeforeinput",
     "openjsf",

--- a/src/routes/playground/tags/playground/tags/editor/editor.marko
+++ b/src/routes/playground/tags/playground/tags/editor/editor.marko
@@ -1,6 +1,8 @@
-client import { EditorView } from "@codemirror/view";
+client import { EditorView, keymap } from "@codemirror/view";
 client import { EditorState } from "@codemirror/state";
 client import extensions, { update } from "app/util/codemirror";
+client import { formatCode } from "app/util/format";
+import { faPaintbrush } from "@fortawesome/free-solid-svg-icons";
 import type { File } from "app/util/workspace";
 import * as styles from "./editor.styles.module.scss";
 export interface Input {
@@ -19,8 +21,24 @@ let/file=files[selected]
     files = files.toSpliced(selected, 1, newValue);
   }
 
+// Bridges the format button (markup) to the editor's lifecycle; set on mount.
+let/doFormat=(() => {})
+
 tabs files:=files selected:=selected
-div.shiki/$editor id=styles.editor
+div class=styles.editorWrap
+  div.shiki/$editor id=styles.editor
+  button
+    ,type="button"
+    ,title="Format (Shift+Alt+F)"
+    ,class=styles.action
+    ,onClick() {
+      doFormat();
+    }
+    fa-icon=faPaintbrush
+    html-script --
+      ${
+        `if(navigator.platform.startsWith("Mac"))document.currentScript.parentElement.title="Format (⇧⌘F)"`
+      };
 
 lifecycle<{
   editor?: EditorView;
@@ -28,6 +46,7 @@ lifecycle<{
   currentPath?: string;
   change?: boolean;
   set(content: string): void;
+  format(): void;
   stateFor(f: File | undefined): EditorState;
 }>
   ,set(content) {
@@ -36,10 +55,51 @@ lifecycle<{
       file = { ...file, content };
     }
   }
+  ,format() {
+    const view = this.editor;
+    if (!view || !file) return;
+    const content = view.state.doc.toString();
+    const cursorOffset = view.state.selection.main.head;
+    const pending = formatCode(content, cursorOffset, ext(file.path));
+    if (!pending) return;
+    void pending
+      .then((result) => {
+        // Skip if the doc changed while formatting, or is already formatted.
+        if (
+          result.formatted === content ||
+          view.state.doc.toString() !== content
+        ) {
+          return;
+        }
+        view.dispatch({
+          changes: { from: 0, to: content.length, insert: result.formatted },
+          selection: {
+            anchor: Math.min(result.cursorOffset, result.formatted.length),
+          },
+        });
+      })
+      .catch(() => {
+        // Ignore formatting errors (e.g. the file currently has a syntax error).
+      });
+  }
   ,stateFor(f) {
     return EditorState.create({
       doc: f?.content,
-      extensions: [this.listener, ...extensions],
+      extensions: [
+        this.listener,
+        keymap.of([
+          {
+            // Alt+letter is a dead key on macOS, so use Cmd there instead.
+            key: "Shift-Alt-f",
+            mac: "Shift-Cmd-f",
+            run: () => {
+              this.format();
+              return true;
+            },
+          },
+        ]),
+        ...extensions,
+      ],
     });
   }
   ,onMount() {
@@ -54,6 +114,7 @@ lifecycle<{
       state: this.stateFor(file),
       parent: $editor(),
     });
+    doFormat = () => this.format();
     if (file) {
       update(this.editor, file.content, ext(file.path));
     }

--- a/src/routes/playground/tags/playground/tags/editor/editor.styles.module.scss
+++ b/src/routes/playground/tags/playground/tags/editor/editor.styles.module.scss
@@ -1,6 +1,43 @@
+.editorWrap {
+  position: relative;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
 #editor {
   overflow: hidden;
   flex: 1;
+}
+
+// Floating action button pinned to the top-right of the pane (also used,
+// with matching styles, for the result pane's copy-code button).
+.action {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.5rem;
+  border: none;
+  border-radius: 0.4rem;
+  background-color: var(--color-gray-dim);
+  cursor: pointer;
+  opacity: 0.65;
+  transition: opacity 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+    background-color: var(--color-gray-alt-dim);
+  }
+
+  svg {
+    height: 1lh;
+    fill: var(--color-blue);
+  }
 }
 
 :global {

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -136,20 +136,6 @@ div class=styles.result
       label class=styles.checkbox
         -- Debug
         input type="checkbox" checked:=debug
-    if=outputType !== "preview"
-      button
-        ,type="button"
-        ,class=styles.controlButton
-        ,title=(codeCopied ? "Copied!" : "Copy code")
-        ,onClick() {
-          navigator.clipboard?.writeText(compiledCode || "").catch(() => {});
-          codeCopied = true;
-        }
-        fa-icon=(codeCopied ? faCheck : faCopy)
-          ,class=codeCopied && styles.copied
-          ,onAnimationEnd() {
-            codeCopied = false;
-          }
     span class=styles.version -- v${markoVersion}
 
   div class=styles.output
@@ -185,6 +171,20 @@ div class=styles.result
       script -- update($signal, $frame(), files, !debug);
 
     a class=styles.markoLogo href="https://markojs.com" title="Built with Marko"
+    if=outputType !== "preview"
+      button
+        ,type="button"
+        ,title=(codeCopied ? "Copied!" : "Copy code")
+        ,class=styles.action
+        ,onClick() {
+          navigator.clipboard?.writeText(compiledCode || "").catch(() => {});
+          codeCopied = true;
+        }
+        fa-icon=(codeCopied ? faCheck : faCopy)
+          ,class=codeCopied && styles.copied
+          ,onAnimationEnd() {
+            codeCopied = false;
+          }
   div class=styles.console
     div class=styles.consoleBar
       button

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -72,7 +72,9 @@
   position: relative;
   display: flex;
   flex: 1;
-  overflow-y: auto;
+  // The compiled-code view scrolls internally (see #compiled) so the pane
+  // itself stays put -- this keeps the absolute copy button pinned top-right.
+  overflow: hidden;
 
   :global(.fullscreen) & {
     visibility: visible;
@@ -131,17 +133,27 @@
   }
 }
 
-.controlButton {
+// Floating action button pinned to the top-right of the output pane;
+// matches the editor pane's format button (see editor.styles).
+.action {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  z-index: 5;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.75rem;
+  padding: 0.4rem 0.5rem;
   border: none;
-  border-radius: 0;
+  border-radius: 0.4rem;
   background-color: var(--color-gray-dim);
   cursor: pointer;
+  opacity: 0.65;
+  transition: opacity 0.15s ease;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
     background-color: var(--color-gray-alt-dim);
   }
 
@@ -188,6 +200,7 @@
   display: flex;
   flex: 1;
   max-width: 100%;
+  overflow: auto;
 
   > :global(.shiki) {
     flex: 1;

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -1,0 +1,34 @@
+import { formatWithCursor } from "prettier/standalone";
+import prettierBabel from "prettier/plugins/babel";
+import prettierEstree from "prettier/plugins/estree";
+import prettierCSS from "prettier/plugins/postcss";
+import * as prettierMarko from "prettier-plugin-marko";
+
+function optionsFor(ext: string) {
+  switch (ext) {
+    case "marko":
+      // Marko embeds js/ts/css, so include those plugins for the embedded code.
+      return {
+        parser: "marko",
+        plugins: [prettierMarko, prettierBabel, prettierEstree, prettierCSS],
+      };
+    case "js":
+    case "jsx":
+    case "mjs":
+    case "cjs":
+      return { parser: "babel", plugins: [prettierBabel, prettierEstree] };
+    case "ts":
+    case "tsx":
+      return { parser: "babel-ts", plugins: [prettierBabel, prettierEstree] };
+    case "json":
+      return { parser: "json", plugins: [prettierBabel, prettierEstree] };
+    case "css":
+      return { parser: "css", plugins: [prettierCSS] };
+  }
+}
+
+export function formatCode(content: string, cursorOffset: number, ext: string) {
+  const options = optionsFor(ext);
+  if (!options) return;
+  return formatWithCursor(content, { ...options, cursorOffset });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,12 +24,22 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
+    alias: [
       // marko/translator uses `node:path` which must be shimmed for browser environments.
       // The shim re-exports from path-browserify. Named exports are bound from the default
       // so they work in both Rollup (build) and Vite's SSR module runner (dev).
-      "node:path": path.resolve("./shim/path/browser.js"),
-    },
+      {
+        find: "node:path",
+        replacement: path.resolve("./shim/path/browser.js"),
+      },
+      // prettier-plugin-marko (used by the playground formatter) imports `doc` from the
+      // full, node-only prettier build; map the bare specifier to the browser standalone
+      // build. Anchored so `prettier/standalone` and `prettier/plugins/*` are untouched.
+      {
+        find: /^prettier$/,
+        replacement: "prettier/standalone",
+      },
+    ],
   },
   optimizeDeps: {
     exclude: ["@rollup/browser", "lightningcss-wasm"],


### PR DESCRIPTION
Adds a **Format** action to the playground editor: a paintbrush button pinned to the top-right of the editor pane, plus a keybinding (`Shift+Alt+F`, `⇧⌘F` on macOS where Alt is a dead key — detected like the search bar's `Cmd+K` hint).

Formatting uses Prettier — Marko via `prettier-plugin-marko` (with the js/ts/css plugins for embedded code), plus js/ts/json/css files. `formatWithCursor` keeps the caret in place; it no-ops when already formatted or if the doc changed mid-format, and ignores parse errors.

For consistency, the result pane's **Copy code** button gets the same floating style, pinned top-right of the output pane (the compiled view now scrolls internally so the button stays put).

Notes:
- `prettier-plugin-marko` imports `doc` from the full node-only `prettier`, so the bare `prettier` specifier is aliased to the browser standalone build for bundling.
- Whitelisted the `mlog` token (from the embedded-console PR) in cspell so the lint/pre-commit hook passes.

Verified by building (`npm run build`) and driving the playground in a browser: format via button + keybinding reformats Marko (including embedded JS), the copy button stays pinned while compiled code scrolls, no console errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTVVAfDsiMrDjqJoXAoh7Y)_