### PR TITLE
fix(playground): prevent format button from repeatedly adding newlines

### DIFF
--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -1,4 +1,4 @@
-import { formatWithCursor } from "prettier/standalone";
+import { format, formatWithCursor } from "prettier/standalone";
 import prettierBabel from "prettier/plugins/babel";
 import prettierEstree from "prettier/plugins/estree";
 import prettierCSS from "prettier/plugins/postcss";
@@ -30,5 +30,19 @@ function optionsFor(ext: string) {
 export function formatCode(content: string, cursorOffset: number, ext: string) {
   const options = optionsFor(ext);
   if (!options) return;
-  return formatWithCursor(content, { ...options, cursorOffset });
+  return formatStable(content, cursorOffset, options);
+}
+
+async function formatStable(
+  content: string,
+  cursorOffset: number,
+  options: NonNullable<ReturnType<typeof optionsFor>>,
+) {
+  const [withCursor, formatted] = await Promise.all([
+    formatWithCursor(content, { ...options, cursorOffset }),
+    format(content, options),
+  ]);
+  return withCursor.formatted === formatted
+    ? withCursor
+    : { formatted, cursorOffset: withCursor.cursorOffset };
 }


### PR DESCRIPTION
The playground's Format button used prettier's `formatWithCursor`, which in `prettier-plugin-marko` isn't idempotent when the cursor sits on a blank line — it re-inserts that blank line on every pass. So formatting repeatedly kept appending newlines (e.g. the counter example after adding a newline below `${count}`).

Plain `format` collapses blank lines deterministically, so it's now used as the source of truth for the text, keeping the cursor-aware result only when the two already agree. Repeated formatting now converges to the canonical output in a single pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_018edkm3QNbatCtKkfSQpuN9)_