### PR TITLE
Tighten playground preview button cluster and console bar layout

### DIFF
--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -213,37 +213,38 @@ div class=styles.result
           Stat name="css" size=(ws.stats?.style?.gzip)
           Stat name="html" size=(ws.stats?.markup?.gzip)
           let/spinning=false
-          button
-            ,title=(linkCopied ? "Copied!" : "Copy share link")
-            ,class=[styles.previewControl, styles.shareControl]
-            ,onClick() {
-              navigator.clipboard?.writeText(location.href).catch(() => {});
-              linkCopied = true;
-            }
-            fa-icon=(linkCopied ? faCheck : faLink)
-              ,class=linkCopied && styles.copied
-              ,onAnimationEnd() {
-                linkCopied = false;
+          div class=styles.previewControls
+            button
+              ,title=(linkCopied ? "Copied!" : "Copy share link")
+              ,class=[styles.previewControl, styles.shareControl]
+              ,onClick() {
+                navigator.clipboard?.writeText(location.href).catch(() => {});
+                linkCopied = true;
               }
-          button
-            ,title="Reload preview"
-            ,class=styles.previewControl
-            ,onClick() {
-              $frame().replaceWith($frame());
-              spinning = true;
-            }
-            fa-icon=faRotateRight
-              ,class=spinning && styles.spin
-              ,onAnimationEnd() {
-                spinning = false;
+              fa-icon=(linkCopied ? faCheck : faLink)
+                ,class=linkCopied && styles.copied
+                ,onAnimationEnd() {
+                  linkCopied = false;
+                }
+            button
+              ,title="Reload preview"
+              ,class=styles.previewControl
+              ,onClick() {
+                $frame().replaceWith($frame());
+                spinning = true;
               }
-          button
-            ,title=(fullscreen ? "Leave fullscreen" : "Expand to fullscreen")
-            ,class=styles.previewControl
-            ,onClick() {
-              fullscreen = !fullscreen;
-            }
-            fa-icon=(fullscreen ? faCompress : faExpand)
+              fa-icon=faRotateRight
+                ,class=spinning && styles.spin
+                ,onAnimationEnd() {
+                  spinning = false;
+                }
+            button
+              ,title=(fullscreen ? "Leave fullscreen" : "Expand to fullscreen")
+              ,class=styles.previewControl
+              ,onClick() {
+                fullscreen = !fullscreen;
+              }
+              fa-icon=(fullscreen ? faCompress : faExpand)
         else if=outputType === "previewJS"
           Stat name="size" size=(ws.stats?.script?.size)
           Stat name="gzip" size=(ws.stats?.script?.gzip)

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -197,9 +197,9 @@ div class=styles.result
         }
         fa-icon=(consoleOpen ? faChevronDown : faChevronUp)
         span -- Console
-        if=(ws.logs?.length)
+        if=ws.logs?.length
           span class=styles.consoleCount -- ${ws.logs.length}
-      if=(ws.logs?.length)
+      if=ws.logs?.length
         button
           ,type="button"
           ,title="Clear console"
@@ -255,7 +255,7 @@ div class=styles.result
           Stat name="gzip" size=(ws.stats?.style?.gzip)
     if=consoleOpen
       div class=styles.consoleBody
-        if=(ws.logs?.length)
+        if=ws.logs?.length
           for|log| of=ws.logs
             div class=styles.logEntry data-method=log.method
               span class=styles.logNs data-ns=log.ns -- ${log.ns}

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -213,7 +213,6 @@ div class=styles.result
           Stat name="js" size=(ws.stats?.script?.gzip)
           Stat name="css" size=(ws.stats?.style?.gzip)
           Stat name="html" size=(ws.stats?.markup?.gzip)
-        let/spinning=false
         button
           ,title=(linkCopied ? "Copied!" : "Copy share link")
           ,class=[styles.previewControl, styles.shareControl]
@@ -226,6 +225,7 @@ div class=styles.result
             ,onAnimationEnd() {
               linkCopied = false;
             }
+        let/spinning=false
         button
           ,title="Reload preview"
           ,class=styles.previewControl

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -60,7 +60,8 @@ define/Stat|{ name, size }: { name: string; size: number | undefined }|
   if=size !== undefined
     const/{ value, unit }=bytesToUnits(size)
     div
-      -- ${name} =${" "}
+      -- ${name}
+      span class=styles.statEquals -- =
       strong -- ${value}
       small -- ${unit}
 
@@ -196,9 +197,9 @@ div class=styles.result
         }
         fa-icon=(consoleOpen ? faChevronDown : faChevronUp)
         span -- Console
-        if=ws.logs?.length
+        if=(ws.logs?.length)
           span class=styles.consoleCount -- ${ws.logs.length}
-      if=ws.logs?.length
+      if=(ws.logs?.length)
         button
           ,type="button"
           ,title="Clear console"
@@ -207,53 +208,54 @@ div class=styles.result
             clearLogs();
           }
           fa-icon=faTrashCan
-      div class=styles.stats
-        if=outputType === "preview"
+      if=outputType === "preview"
+        div class=styles.stats
           Stat name="js" size=(ws.stats?.script?.gzip)
           Stat name="css" size=(ws.stats?.style?.gzip)
           Stat name="html" size=(ws.stats?.markup?.gzip)
-          let/spinning=false
-          div class=styles.previewControls
-            button
-              ,title=(linkCopied ? "Copied!" : "Copy share link")
-              ,class=[styles.previewControl, styles.shareControl]
-              ,onClick() {
-                navigator.clipboard?.writeText(location.href).catch(() => {});
-                linkCopied = true;
-              }
-              fa-icon=(linkCopied ? faCheck : faLink)
-                ,class=linkCopied && styles.copied
-                ,onAnimationEnd() {
-                  linkCopied = false;
-                }
-            button
-              ,title="Reload preview"
-              ,class=styles.previewControl
-              ,onClick() {
-                $frame().replaceWith($frame());
-                spinning = true;
-              }
-              fa-icon=faRotateRight
-                ,class=spinning && styles.spin
-                ,onAnimationEnd() {
-                  spinning = false;
-                }
-            button
-              ,title=(fullscreen ? "Leave fullscreen" : "Expand to fullscreen")
-              ,class=styles.previewControl
-              ,onClick() {
-                fullscreen = !fullscreen;
-              }
-              fa-icon=(fullscreen ? faCompress : faExpand)
-        else if=outputType === "previewJS"
+        let/spinning=false
+        button
+          ,title=(linkCopied ? "Copied!" : "Copy share link")
+          ,class=[styles.previewControl, styles.shareControl]
+          ,onClick() {
+            navigator.clipboard?.writeText(location.href).catch(() => {});
+            linkCopied = true;
+          }
+          fa-icon=(linkCopied ? faCheck : faLink)
+            ,class=linkCopied && styles.copied
+            ,onAnimationEnd() {
+              linkCopied = false;
+            }
+        button
+          ,title="Reload preview"
+          ,class=styles.previewControl
+          ,onClick() {
+            $frame().replaceWith($frame());
+            spinning = true;
+          }
+          fa-icon=faRotateRight
+            ,class=spinning && styles.spin
+            ,onAnimationEnd() {
+              spinning = false;
+            }
+        button
+          ,title=(fullscreen ? "Leave fullscreen" : "Expand to fullscreen")
+          ,class=styles.previewControl
+          ,onClick() {
+            fullscreen = !fullscreen;
+          }
+          fa-icon=(fullscreen ? faCompress : faExpand)
+      else if=outputType === "previewJS"
+        div class=styles.stats
           Stat name="size" size=(ws.stats?.script?.size)
           Stat name="gzip" size=(ws.stats?.script?.gzip)
-        else if=outputType === "previewCSS"
+      else if=outputType === "previewCSS"
+        div class=styles.stats
           Stat name="size" size=(ws.stats?.style?.size)
           Stat name="gzip" size=(ws.stats?.style?.gzip)
     if=consoleOpen
       div class=styles.consoleBody
-        if=ws.logs?.length
+        if=(ws.logs?.length)
           for|log| of=ws.logs
             div class=styles.logEntry data-method=log.method
               span class=styles.logNs data-ns=log.ns -- ${log.ns}

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -114,11 +114,22 @@
   font-family: "Ubuntu Mono", monospace;
 }
 
+// The preview buttons share link / reload / fullscreen) sit together in their
+// own cluster with a tighter gap than the 1rem used between stats items.
+.previewControls {
+  display: flex;
+  align-self: stretch;
+  gap: 0.25rem;
+}
+
 .previewControl {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.5rem;
+  // Square buttons: the fixed width matches the bar height (min-height: 2rem)
+  // so each one is consistent and fills the available height.
+  width: 2rem;
+  padding: 0;
   border: none;
   background: none;
   cursor: pointer;

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -108,31 +108,26 @@
 .stats {
   display: flex;
   align-items: center;
-  gap: 1rem;
   margin-left: auto;
-  padding: 0 0.5rem;
   font-family: "Ubuntu Mono", monospace;
+  gap: 0.5rem;
+  overflow-x: scroll;
+  padding-inline: 0.5rem;
 }
 
-// The preview buttons share link / reload / fullscreen) sit together in their
-// own cluster with a tighter gap than the 1rem used between stats items.
-.previewControls {
-  display: flex;
-  align-self: stretch;
-  gap: 0.25rem;
+.statEquals {
+  padding: 0.2em;
 }
 
 .previewControl {
   display: flex;
   align-items: center;
   justify-content: center;
-  // Square buttons: the fixed width matches the bar height (min-height: 2rem)
-  // so each one is consistent and fills the available height.
   width: 2rem;
   padding: 0;
   border: none;
   background: none;
-  cursor: pointer;
+  flex-shrink: 0;
 
   &:hover {
     background-color: var(--color-gray-alt-dim);
@@ -279,7 +274,7 @@
   color: inherit;
 
   svg {
-    height: 1lh;
+    height: 0.75lh;
     fill: var(--color-blue);
   }
 

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -108,12 +108,12 @@
 .stats {
   display: flex;
   align-items: center;
-  margin-left: auto;
-  font-family: "Ubuntu Mono", monospace;
   gap: 0.5rem;
+  margin-left: auto;
+  padding: 0 0.5rem;
+  font-family: "Ubuntu Mono", monospace;
   overflow-x: auto;
   scrollbar-width: thin;
-  padding-inline: 0.5rem;
 }
 
 .statEquals {

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -111,7 +111,8 @@
   margin-left: auto;
   font-family: "Ubuntu Mono", monospace;
   gap: 0.5rem;
-  overflow-x: scroll;
+  overflow-x: auto;
+  scrollbar-width: thin;
   padding-inline: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary

Cleans up the bottom bar of the playground preview output (the row with the share-link, reload, and fullscreen buttons).

- Group the share-link / reload / fullscreen buttons into a tight cluster instead of inheriting the `1rem` gap used between stats items. Each button now uses a fixed square width matching the bar height (`2rem`) instead of horizontal padding, so they fill the height with a consistent width.
- Fix the console panel on small screens: the size stats now scroll horizontally while the buttons stay pinned at a fixed width, so they no longer get pushed off on narrow viewports.
- Use `overflow-x: auto` (instead of `scroll`) with a thin scrollbar for the stats, so no scrollbar track is reserved when the stats fit.

## Testing

Verified against the dev server with headless Chromium at multiple viewport widths:

- Buttons measure a consistent `32×32` and fill the full bar height at both wide (1280px) and narrow (380px) widths.
- At 380px the stats become horizontally scrollable while the buttons stay pinned; at 1280px the stats are not scrollable, so no scrollbar track is reserved.
- `npm run lint` passes (markdownlint + cspell, 0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KU4shVPG9ZczVbR2FaEhY6)_