### PR TITLE
Add GitHub Pages PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: "${{ github.repository_owner == 'marko-js' && github.event_name == 'push' }}"
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,10 +26,34 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Deploy
+      - name: Build site
+        run: npm run build
+        env:
+          REPO_GITHUB_API_TOKEN: ${{ secrets.REPO_GITHUB_API_TOKEN }}
+      # Deploy to the gh-pages branch root while preserving the previews/ directory so
+      # live PR previews survive production deploys (see preview.yml / preview-cleanup.yml).
+      - name: Deploy to gh-pages (preserving PR previews)
         run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npm run deploy
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages-deploy gh-pages
+
+          # Wipe everything except the previews/ subdirectory and git internals.
+          find /tmp/gh-pages-deploy -mindepth 1 -maxdepth 1 \
+            ! -name '.git' ! -name 'previews' \
+            -exec rm -rf {} +
+
+          # Copy the freshly-built site in (previews/ is untouched). The custom-domain
+          # CNAME ships in public/CNAME, so it lands here via the build.
+          cp -r dist/public/. /tmp/gh-pages-deploy/
+          touch /tmp/gh-pages-deploy/.nojekyll
+
+          cd /tmp/gh-pages-deploy
+          git add -A
+          git commit -m "deploy: main @ ${GITHUB_SHA}" || echo "No changes to deploy."
+          git push "https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_GITHUB_API_TOKEN: ${{ secrets.REPO_GITHUB_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             fi
             echo "Push rejected, refreshing gh-pages (attempt ${attempt})."
             git fetch origin gh-pages
-            git rebase origin/gh-pages
+            git rebase FETCH_HEAD
           done
           $pushed || { echo "Failed to push after 3 attempts."; exit 1; }
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # The gh-pages push below authenticates with an explicit token URL, and
+          # the fetch is a public read, so the checkout credential is not needed.
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -54,6 +58,19 @@ jobs:
           cd /tmp/gh-pages-deploy
           git add -A
           git commit -m "deploy: main @ ${GITHUB_SHA}" || echo "No changes to deploy."
-          git push "https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+          # Retry on non-fast-forward in case a concurrent preview deploy or cleanup
+          # writes to gh-pages first. Our commit only touches root files, so replaying
+          # it onto the latest previews/ changes rebases cleanly.
+          pushed=false
+          for attempt in 1 2 3; do
+            if git push "https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages; then
+              pushed=true
+              break
+            fi
+            echo "Push rejected, refreshing gh-pages (attempt ${attempt})."
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+          done
+          $pushed || { echo "Failed to push after 3 attempts."; exit 1; }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -40,7 +40,7 @@ jobs:
               fi
               echo "Push rejected, refreshing gh-pages (attempt ${attempt})."
               git fetch origin gh-pages
-              git rebase origin/gh-pages
+              git rebase FETCH_HEAD
             done
             $pushed || { echo "Failed to push cleanup after 3 attempts."; exit 1; }
           else

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -17,16 +17,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: gh-pages
+          # The push below uses an explicit token URL, so the checkout credential
+          # is redundant and need not be persisted.
+          persist-credentials: false
 
       - name: Remove preview directory and push
         run: |
+          set -euo pipefail
           PR=${{ github.event.pull_request.number }}
           if [ -d "previews/pr-${PR}" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git rm -rf "previews/pr-${PR}"
             git commit -m "cleanup: remove preview for pr-${PR}"
-            git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
+            REMOTE="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            # Retry on non-fast-forward in case a concurrent gh-pages write lands first.
+            pushed=false
+            for attempt in 1 2 3; do
+              if git push "$REMOTE" gh-pages; then
+                pushed=true
+                break
+              fi
+              echo "Push rejected, refreshing gh-pages (attempt ${attempt})."
+              git fetch origin gh-pages
+              git rebase origin/gh-pages
+            done
+            $pushed || { echo "Failed to push cleanup after 3 attempts."; exit 1; }
           else
             echo "No preview directory found for pr-${PR}, nothing to clean up."
           fi

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,57 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory and push
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          if [ -d "previews/pr-${PR}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "previews/pr-${PR}"
+            git commit -m "cleanup: remove preview for pr-${PR}"
+            git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
+          else
+            echo "No preview directory found for pr-${PR}, nothing to clean up."
+          fi
+
+      - name: Update preview comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('PR Preview Deployed') && !c.body.includes('_(removed)_')
+            );
+            if (existing) {
+              const struck = existing.body
+                .replace('### PR Preview Deployed', '### PR Preview Deployed _(removed)_');
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: struck,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -68,11 +68,13 @@ jobs:
       - name: Deploy to gh-pages branch (preview subdirectory)
         run: |
           set -euo pipefail
-          # gh-pages commits in its own temporary clone, so the committer identity
-          # must be passed via --user (local git config is not inherited). Retry on a
-          # non-fast-forward rejection in case a concurrent gh-pages write (another
-          # preview, the cleanup job, or the production deploy) lands first; each run
-          # re-clones the branch, so clear the cache between attempts.
+          # gh-pages commits in its own temporary clone, so set the identity globally
+          # rather than via --user (whose parser rejects the github-actions[bot]
+          # brackets). Retry on a non-fast-forward rejection in case a concurrent
+          # gh-pages write (another preview, the cleanup job, or the production deploy)
+          # lands first; each run re-clones the branch, so clear the cache between attempts.
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           pushed=false
           for attempt in 1 2 3; do
             rm -rf node_modules/.cache/gh-pages
@@ -82,7 +84,6 @@ jobs:
               --branch gh-pages \
               --nojekyll \
               --add \
-              --user "github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
               --message "preview: pr-${{ github.event.pull_request.number }} @ ${{ github.sha }}" \
               --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"; then
               pushed=true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,119 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: "preview-${{ github.head_ref }}"
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    # Secrets (and write access to gh-pages) are unavailable for forked PRs, so only
+    # deploy previews for branches pushed to this repository.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Mark existing preview comment as updating
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('PR Preview Deployed')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: existing.body.trimEnd() + ` _(deploying ${sha}...)_`,
+              });
+            }
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site (preview base URL)
+        run: npm run build
+        env:
+          BASE_URL: /previews/pr-${{ github.event.pull_request.number }}/
+          REPO_GITHUB_API_TOKEN: ${{ secrets.REPO_GITHUB_API_TOKEN }}
+
+      - name: Deploy to gh-pages branch (preview subdirectory)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npx gh-pages \
+            --dist dist/public \
+            --dest previews/pr-${{ github.event.pull_request.number }} \
+            --branch gh-pages \
+            --nojekyll \
+            --add \
+            --message "preview: pr-${{ github.event.pull_request.number }} @ ${{ github.sha }}" \
+            --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+      - name: Post preview URL to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const url = `https://markojs.com/previews/pr-${pr}/`;
+
+            // Find and update an existing bot comment, or create a new one.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find(
+              c => c.user.login === 'github-actions[bot]' && c.body.includes('PR Preview Deployed')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: existing.body
+                  .replace('### PR Preview Deployed _(removed)_', '### PR Preview Deployed')
+                  .replace(/ _\(deploying .+?\)_$/, '')
+                  .replace(/###### commit .+$/, `###### commit ${sha}`),
+              });
+            } else {
+              const body = [
+                `### PR Preview Deployed`,
+                ``,
+                `Your changes are live at [**markojs.com/previews/pr-${pr}**](${url}).`,
+                ``,
+                `###### commit ${sha}`,
+              ].join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # The deploy below authenticates with an explicit token URL, so the
+          # checkout credential is unused and best not persisted before npm ci.
+          persist-credentials: false
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -63,16 +67,31 @@ jobs:
 
       - name: Deploy to gh-pages branch (preview subdirectory)
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npx gh-pages \
-            --dist dist/public \
-            --dest previews/pr-${{ github.event.pull_request.number }} \
-            --branch gh-pages \
-            --nojekyll \
-            --add \
-            --message "preview: pr-${{ github.event.pull_request.number }} @ ${{ github.sha }}" \
-            --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          set -euo pipefail
+          # gh-pages commits in its own temporary clone, so the committer identity
+          # must be passed via --user (local git config is not inherited). Retry on a
+          # non-fast-forward rejection in case a concurrent gh-pages write (another
+          # preview, the cleanup job, or the production deploy) lands first; each run
+          # re-clones the branch, so clear the cache between attempts.
+          pushed=false
+          for attempt in 1 2 3; do
+            rm -rf node_modules/.cache/gh-pages
+            if npx gh-pages \
+              --dist dist/public \
+              --dest previews/pr-${{ github.event.pull_request.number }} \
+              --branch gh-pages \
+              --nojekyll \
+              --add \
+              --user "github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
+              --message "preview: pr-${{ github.event.pull_request.number }} @ ${{ github.sha }}" \
+              --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"; then
+              pushed=true
+              break
+            fi
+            echo "gh-pages push failed (attempt ${attempt}); retrying."
+            sleep $((attempt * 3))
+          done
+          $pushed || { echo "Failed to deploy preview after 3 attempts."; exit 1; }
 
       - name: Post preview URL to PR
         uses: actions/github-script@v7

--- a/cspell.json
+++ b/cspell.json
@@ -42,6 +42,7 @@
     "microtask",
     "mlog",
     "nbsp",
+    "noindex",
     "onbeforeinput",
     "openjsf",
     "optgroup",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     }
   },
   "scripts": {
-    "build": "marko-run build",
-    "deploy": "marko-run build && gh-pages --nojekyll -d dist/public -u \"marko-js <noreply@markojs.com>\"",
+    "build": "marko-run build && node scripts/rebase-html.mjs",
+    "deploy": "npm run build && gh-pages --nojekyll -d dist/public -u \"marko-js <noreply@markojs.com>\"",
     "dev": "marko-run",
     "format": "prettier . -w",
     "lint": "markdownlint \"docs/**/*.md\" && cspell \"**/*.{md,ts,marko}\"",

--- a/scripts/rebase-html.mjs
+++ b/scripts/rebase-html.mjs
@@ -7,8 +7,9 @@
 // can keep writing plain root-absolute paths.
 //
 // Runs only when BASE_URL points to a subdirectory (PR previews); it is a no-op for
-// the production deploy where the base is "/". Only `href`/`src`/`srcset` attribute
-// values are touched, so hydration markers and inline scripts are left byte-for-byte.
+// the production deploy where the base is "/". Only `href`/`src`/`srcset` and the
+// meta-refresh `content` redirect are touched, so hydration markers and inline
+// scripts are left byte-for-byte.
 
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/scripts/rebase-html.mjs
+++ b/scripts/rebase-html.mjs
@@ -42,13 +42,31 @@ function rebaseSrcset(value) {
     .join(", ");
 }
 
-const ATTR = /\b(href|src|srcset)=("([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/g;
+/**
+ * A meta-refresh redirect (`<meta http-equiv="refresh" content="0;url=/path">`)
+ * carries its target inside the content attribute. Server redirects (e.g. /docs)
+ * are emitted this way by the static adapter, so the url must be based too. The
+ * `<digits>;url=/` shape is unique to refresh redirects, so other content
+ * attributes (description, viewport, og:*) are left untouched.
+ */
+function rebaseMetaRefresh(value) {
+  return value.replace(
+    /^(\s*\d+\s*;\s*url=)(\/(?!\/)\S*)/i,
+    (_m, prefix, url) => prefix + rebaseUrl(url),
+  );
+}
+
+const ATTR = /\b(href|src|srcset|content)=("([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/g;
 
 function rebaseHtml(html) {
   return html.replace(ATTR, (match, name, _raw, dq, sq, unq) => {
     const value = dq ?? sq ?? unq;
     const next =
-      name === "srcset" ? rebaseSrcset(value) : rebaseUrl(value);
+      name === "srcset"
+        ? rebaseSrcset(value)
+        : name === "content"
+          ? rebaseMetaRefresh(value)
+          : rebaseUrl(value);
     if (next === value) return match;
     const quote = dq !== undefined ? '"' : sq !== undefined ? "'" : "";
     return `${name}=${quote}${next}${quote}`;

--- a/scripts/rebase-html.mjs
+++ b/scripts/rebase-html.mjs
@@ -1,0 +1,76 @@
+// Injects the deploy base path into root-absolute links in the built HTML.
+//
+// Vite's `base` already rewrites bundled assets (JS/CSS/images) and JS-internal
+// dynamic imports, but it leaves author-written root-absolute URLs (e.g. `/docs`,
+// `/fav.png`, `/assets/logo.svg`) untouched. Rather than wrapping every such link in
+// the source, this pass prefixes them automatically after the build so contributors
+// can keep writing plain root-absolute paths.
+//
+// Runs only when BASE_URL points to a subdirectory (PR previews); it is a no-op for
+// the production deploy where the base is "/". Only `href`/`src`/`srcset` attribute
+// values are touched, so hydration markers and inline scripts are left byte-for-byte.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const base = (process.env.BASE_URL || "/").replace(/\/$/, "");
+const dir = path.resolve("dist/public");
+
+if (!base) {
+  // Production deploy (BASE_URL unset or "/"): nothing to rebase.
+  process.exit(0);
+}
+
+/** Prefix a single root-absolute URL with the base, skipping anything already based. */
+function rebaseUrl(url) {
+  if (!url.startsWith("/") || url.startsWith("//")) return url; // relative/protocol-relative/external
+  if (url === base || url.startsWith(base + "/")) return url; // already based (e.g. Vite assets)
+  return base + url;
+}
+
+/** A srcset value is a comma-separated list of `url [descriptor]` candidates. */
+function rebaseSrcset(value) {
+  return value
+    .split(",")
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+      const space = trimmed.indexOf(" ");
+      return space === -1
+        ? rebaseUrl(trimmed)
+        : rebaseUrl(trimmed.slice(0, space)) + trimmed.slice(space);
+    })
+    .join(", ");
+}
+
+const ATTR = /\b(href|src|srcset)=("([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/g;
+
+function rebaseHtml(html) {
+  return html.replace(ATTR, (match, name, _raw, dq, sq, unq) => {
+    const value = dq ?? sq ?? unq;
+    const next =
+      name === "srcset" ? rebaseSrcset(value) : rebaseUrl(value);
+    if (next === value) return match;
+    const quote = dq !== undefined ? '"' : sq !== undefined ? "'" : "";
+    return `${name}=${quote}${next}${quote}`;
+  });
+}
+
+async function* htmlFiles(root) {
+  for (const entry of await fs.readdir(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) yield* htmlFiles(full);
+    else if (entry.name.endsWith(".html")) yield full;
+  }
+}
+
+let changed = 0;
+for await (const file of htmlFiles(dir)) {
+  const html = await fs.readFile(file, "utf8");
+  const next = rebaseHtml(html);
+  if (next !== html) {
+    await fs.writeFile(file, next);
+    changed++;
+  }
+}
+
+console.log(`rebase-html: prefixed root-absolute links with "${base}" in ${changed} file(s).`);

--- a/src/routes/+layout.marko
+++ b/src/routes/+layout.marko
@@ -4,6 +4,9 @@ html lang="en"
     meta charset="UTF-8"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     meta name="description" content="The Marko programming language"
+    // PR preview deploys are served from a subdirectory and must not be indexed.
+    if=(import.meta.env.BASE_URL !== "/")
+      meta name="robots" content="noindex"
     title --
       ${
         typeof ($global.meta as any).pageTitle === "string"

--- a/src/util/search-index-builder.ts
+++ b/src/util/search-index-builder.ts
@@ -25,11 +25,17 @@ export async function buildSearchIndex(docsPath: string): Promise<void> {
   const mdFiles = glob.sync("**/*.md", { cwd: docsPath });
   const blocks: SearchBlock[] = [];
 
+  // Search results are rendered on the client from this JSON, so the post-build HTML
+  // rebase pass can't reach their links. Bake the deploy base into the hrefs here
+  // instead. Matches the Vite `base` (see vite.config.ts): "/" for production,
+  // "/previews/pr-N/" for PR preview deploys.
+  const base = (process.env.BASE_URL || "/").replace(/\/$/, "");
+
   for (const file of mdFiles) {
     const raw = await fs.readFile(path.join(docsPath, file), "utf-8");
     const category = file.split("/")[0];
     const slug = file.replace(/\.md$/, "");
-    const href = `/docs/${slug}`;
+    const href = `${base}/docs/${slug}`;
     const { weight, label: categoryLabel } = CATEGORIES[category] ?? {
       weight: 25,
       label: category,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import markodown from "./src/util/markodown";
 import { patchCssModules } from "vite-css-modules";
 
 export default defineConfig({
+  // BASE_URL is set to "/previews/pr-N/" by the PR Preview workflow so the site can be
+  // served from a subdirectory on GitHub Pages. Defaults to "/" for the production deploy.
+  base: process.env.BASE_URL || "/",
   environments: {
     client: {
       define: {


### PR DESCRIPTION
Deploys a live preview of each PR to `markojs.com/previews/pr-N/` on the `gh-pages` branch and removes it when the PR closes. Production deploys preserve existing previews.

Internal links pick up the preview's base path automatically at build time (`scripts/rebase-html.mjs`), so no source links need to change. Both the rebase and the preview tooling no-op for the production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_017z2q5WLDxk9NHTkuSKaoMX

---
_Generated by [Claude Code](https://claude.ai/code/session_017z2q5WLDxk9NHTkuSKaoMX)_