### PR TITLE
Add Community section to the newsletter

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "Fastly",
     "figcaption",
     "flexsearch",
+    "formkit",
     "fortawesome",
     "hastscript",
     "hrefs",

--- a/cspell.json
+++ b/cspell.json
@@ -60,6 +60,7 @@
     "Rolldown",
     "shiki",
     "shikijs",
+    "sortability",
     "srcset",
     "tabindex",
     "tablist",

--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
     "codegen",
     "contenteditable",
     "dblclick",
+    "defunkt",
     "Delisle",
     "desugar",
     "desugared",

--- a/docs/newsletter/april-2026.md
+++ b/docs/newsletter/april-2026.md
@@ -42,6 +42,10 @@ An empty `<@catch>` now absorbs errors as intended. Previously `<@catch></@catch
 
 The documentation site replaced Algolia with a self-hosted FlexSearch index and a redesigned search dialog ([website#138](https://github.com/marko-js/website/pull/138)).
 
+## Community
+
+FormKit's [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) library gained first-class Marko support, contributed by eBay's Marko team. The integration is a single tag built on Marko's mount, update, and destroy hooks with two-way state binding, so a Marko application can add drag-and-drop lists without a wrapper layer ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)).
+
 ## Experiments
 
 A new experimental project, [TSRX](https://tsrx.dev), explores writing Marko components in a JSX-like TypeScript syntax that compiles to Marko. Early work added control-flow expressions, member-expression tag names that map to dynamic tags, and looser rules for default exports ([tsrx](https://github.com/marko-js/tsrx)).

--- a/docs/newsletter/april-2026.md
+++ b/docs/newsletter/april-2026.md
@@ -44,7 +44,7 @@ The documentation site replaced Algolia with a self-hosted FlexSearch index and 
 
 ## Community
 
-Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for contributing first-class Marko integration to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)).
+Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for bringing first-class Marko support to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)); its [sortability docs](https://drag-and-drop.formkit.com/#sortability) now include a Marko example.
 
 ## Experiments
 

--- a/docs/newsletter/april-2026.md
+++ b/docs/newsletter/april-2026.md
@@ -44,7 +44,7 @@ The documentation site replaced Algolia with a self-hosted FlexSearch index and 
 
 ## Community
 
-FormKit's [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) library gained first-class Marko support, contributed by eBay's Marko team. The integration is a single tag built on Marko's mount, update, and destroy hooks with two-way state binding, so a Marko application can add drag-and-drop lists without a wrapper layer ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)).
+Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for contributing first-class Marko integration to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)).
 
 ## Experiments
 

--- a/docs/newsletter/june-2026.md
+++ b/docs/newsletter/june-2026.md
@@ -161,6 +161,10 @@ The [playground](/playground) on markojs.com gained copy and share buttons for r
 
 Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).
 
+## Community
+
+[Primate](https://primate.run) added full support for Marko 6, covering server rendering, hydration, client-side navigation, layouts, form validation, and i18n ([announcement](https://primate.run/blog/primate-039#marko-6)).
+
 ## Further Reading
 
 - [May 2026](may-2026.md)

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -78,6 +78,14 @@ Lists merged PRs that month whose author's association is `FIRST_TIME_CONTRIBUTO
 
 Not automatable: everything else. Showcases, conference talks, blog posts, Discord highlights, and noteworthy GitHub Discussions threads have no reliable API source, so do not guess at them or invent one to fill the section. Ask the user directly, for example: "Anything for a Community section this month, beyond new contributors? Looking for showcases, talks, Discord highlights, or shoutouts." If the user has nothing to add, drop the `## Community` section entirely rather than publishing an empty or generic one.
 
+Keep each attribution to one line: credit the handle, name the thing they contributed, and link it. This section is a shoutout, not a feature writeup, so skip the mechanism-and-benefit prose used elsewhere in the newsletter.
+
+```markdown
+Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for contributing first-class Marko integration to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)).
+```
+
+State only what the PR or the user directly confirms: the handle, what was built, and where. Do not infer or add an employer, team, or motivation that is not stated outright. When a contributor's affiliation is genuinely relevant and confirmed, it can be worth a mention, but guessing at one from a bio or username is the kind of error that erodes trust in the newsletter.
+
 ## Step 5 — Write the page
 
 Create `docs/newsletter/<month>-<year>.md` (e.g. `july-2026.md`). The `markodown` Vite plugin globs `docs/**/*.md` and auto-generates the route `/docs/newsletter/<slug>`, so no routing wiring is needed.
@@ -197,3 +205,4 @@ Surface judgment calls to the user rather than guessing: the `Task` type for a P
 - The TLDR renders as a run-on unless it is a real markdown list.
 - `no-format` is the right tool for concise/anti-pattern/opt-in snippets.
 - Community content beyond first-time contributors (showcases, talks, Discord, Discussions) has no reliable API source. Ask the user rather than guessing, and drop the `## Community` heading if there is nothing to put in it.
+- Keep attributions to one line: handle, what they contributed, where. Never add an affiliation, team, or motivation that is not directly confirmed.

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -78,11 +78,7 @@ Lists merged PRs that month whose author's association is `FIRST_TIME_CONTRIBUTO
 
 Not automatable: everything else. Showcases, conference talks, blog posts, Discord highlights, and noteworthy GitHub Discussions threads have no reliable API source, so do not guess at them or invent one to fill the section. Ask the user directly, for example: "Anything for a Community section this month, beyond new contributors? Looking for showcases, talks, Discord highlights, or shoutouts." If the user has nothing to add, drop the `## Community` section entirely rather than publishing an empty or generic one.
 
-Keep each attribution short and credit the handle, but do not force it into a single fill-in-the-blank template. "Thanks to X for contributing Y" is a fine default, yet it reads as a form letter when repeated verbatim for every entry. Where there is a concrete, checkable sign of what the contribution led to, such as the change now shipping in the project's own docs or a live site, prefer working that in over a generic thanks:
-
-```markdown
-Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for bringing first-class Marko support to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)); its [sortability docs](https://drag-and-drop.formkit.com/#sortability) now include a Marko example.
-```
+Keep each attribution short and credit the handle, but do not force it into a single fill-in-the-blank template repeated verbatim for every entry, which reads as a form letter. Where there is a concrete, checkable sign of what the contribution led to, such as the change now shipping in the project's own docs or a live site, prefer working that in over a generic thanks.
 
 Whatever the phrasing, this section is a shoutout, not a feature writeup, so skip the mechanism-and-benefit prose used elsewhere in the newsletter, and state only what the PR, a linked page, or the user directly confirms. Do not infer or add an employer, team, or motivation that is not stated outright. When a contributor's affiliation is genuinely relevant and confirmed, it can be worth a mention, but guessing at one from a bio or username is the kind of error that erodes trust in the newsletter.
 

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -64,7 +64,21 @@ From the body and that context, determine:
 - **Real magnitudes.** Pull performance numbers from the PR, never invent them. State them with their scope rather than vaguely, qualifying a percentage with what it was measured against or a benchmark multiple as measured in isolation, and keep any caveat the PR itself makes. When a PR gives no figure, describe the mechanism and the direction of the effect (smaller output, fewer allocations, less work to resume) rather than reaching for a vague percentage.
 - **The user-facing shape.** Skip implementation detail in prose. Prefer "in debug mode" over an env var name; show an illustrative compiled-output fragment, not a dump of internal helper names.
 
-## Step 4 — Write the page
+## Step 4 — Gather community content
+
+A newsletter edition can include a `## Community` section alongside the shipped-work themes, but only when there is something real to put in it. This is the one step the board and merged-PR lists cannot fully cover, so it splits into what is automatable and what is not.
+
+Automatable: first-time contributors.
+
+```bash
+node skills/newsletter/pull-board.js contributors 2026-07
+```
+
+Lists merged PRs that month whose author's association is `FIRST_TIME_CONTRIBUTOR` (first PR to that repo) or `FIRST_TIMER` (first PR anywhere on GitHub), tab-separated as `repo#number`, author, title. Every row is a reasonable candidate for a welcome or thanks mention.
+
+Not automatable: everything else. Showcases, conference talks, blog posts, Discord highlights, and noteworthy GitHub Discussions threads have no reliable API source, so do not guess at them or invent one to fill the section. Ask the user directly, for example: "Anything for a Community section this month, beyond new contributors? Looking for showcases, talks, Discord highlights, or shoutouts." If the user has nothing to add, drop the `## Community` section entirely rather than publishing an empty or generic one.
+
+## Step 5 — Write the page
 
 Create `docs/newsletter/<month>-<year>.md` (e.g. `july-2026.md`). The `markodown` Vite plugin globs `docs/**/*.md` and auto-generates the route `/docs/newsletter/<slug>`, so no routing wiring is needed.
 
@@ -73,6 +87,7 @@ Structure:
 - A single `# Title` H1 (its text becomes the page title).
 - A `> [!TLDR]` callout listing the highest-impact items first, then a short intro paragraph that frames the month around them. Do not start the intro with "This newsletter covers...".
 - Flat `## ` sections, each a theme, **ordered by expected developer impact**: lead with the change most developers will notice or benefit from, and let lower-impact items (niche fixes, platform notes, internal-leaning work) fall toward the end. Keep paragraphs short; split dense lists into chunks.
+- A `## Community` section, when Step 4 turned up content, ranked by impact like any other section. A first-time contributor's fix usually sits toward the end; a notable showcase can lead if it outweighs the month's code changes. Omit the heading entirely rather than leaving it empty.
 
 Style (see AGENTS.md, enforced by the docs lint):
 
@@ -89,7 +104,7 @@ Style (see AGENTS.md, enforced by the docs lint):
 
   (Blank `>` line, then `- ` items, no trailing periods.)
 
-## Step 5 — Examples and links
+## Step 6 — Examples and links
 
 Add a code example to a section **only when there is a new, authoring-facing capability to show.** Do not force one onto sections about bug fixes, platform support, parser internals, or UI work, which usually read better with none.
 
@@ -106,7 +121,7 @@ Links:
 - Link relevant existing docs with a relative path and the `.md` extension, e.g. `[Lazy Loading](../reference/lazy-loading.md#triggers)`. The build strips `.md` automatically. Confirm anchors against the target doc's headings (GitHub-style slugs).
 - Link the playground to `/playground` and "GitHub" to `https://github.com/marko-js`.
 
-## Step 6 — Link the new edition
+## Step 7 — Link the new edition
 
 The newsletter is wired together in three places. Update all of them when adding a month.
 
@@ -151,7 +166,7 @@ Then edit what was the newest edition to add the forward link below its existing
 
 The oldest edition links only forward, the newest links only back, and every edition in between links both ways.
 
-## Step 7 — Verify
+## Step 8 — Verify
 
 ```bash
 npx markdownlint docs/newsletter/<file>.md
@@ -166,7 +181,7 @@ npm run build
   `grep -oE 'href="[^"]*\.md[^"]*"' src/routes/docs/_compiled-docs/newsletter/<slug>+page.marko` (should print nothing).
 - The build can fail nondeterministically on an unrelated doc (e.g. `docs/guide/low-level-apis` with `Cannot read properties of undefined (reading 'ast')`) because docs compile in parallel. If the newsletter page itself generated fine, rerun a clean build: `rm -rf dist && npm run build`.
 
-## Step 8 — Confirm and hand off
+## Step 9 — Confirm and hand off
 
 Surface judgment calls to the user rather than guessing: the `Task` type for a PR with no conventional-commit prefix, an ambiguous `Epic`, which performance number to quote, and how wide the scope should be. Do not commit unless asked.
 
@@ -181,3 +196,4 @@ Surface judgment calls to the user rather than guessing: the `Task` type for a P
 - Keep implementation detail out of prose; keep compiled-output examples illustrative.
 - The TLDR renders as a run-on unless it is a real markdown list.
 - `no-format` is the right tool for concise/anti-pattern/opt-in snippets.
+- Community content beyond first-time contributors (showcases, talks, Discord, Discussions) has no reliable API source. Ask the user rather than guessing, and drop the `## Community` heading if there is nothing to put in it.

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -78,13 +78,13 @@ Lists merged PRs that month whose author's association is `FIRST_TIME_CONTRIBUTO
 
 Not automatable: everything else. Showcases, conference talks, blog posts, Discord highlights, and noteworthy GitHub Discussions threads have no reliable API source, so do not guess at them or invent one to fill the section. Ask the user directly, for example: "Anything for a Community section this month, beyond new contributors? Looking for showcases, talks, Discord highlights, or shoutouts." If the user has nothing to add, drop the `## Community` section entirely rather than publishing an empty or generic one.
 
-Keep each attribution to one line: credit the handle, name the thing they contributed, and link it. This section is a shoutout, not a feature writeup, so skip the mechanism-and-benefit prose used elsewhere in the newsletter.
+Keep each attribution short and credit the handle, but do not force it into a single fill-in-the-blank template. "Thanks to X for contributing Y" is a fine default, yet it reads as a form letter when repeated verbatim for every entry. Where there is a concrete, checkable sign of what the contribution led to, such as the change now shipping in the project's own docs or a live site, prefer working that in over a generic thanks:
 
 ```markdown
-Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for contributing first-class Marko integration to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)).
+Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for bringing first-class Marko support to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)); its [sortability docs](https://drag-and-drop.formkit.com/#sortability) now include a Marko example.
 ```
 
-State only what the PR or the user directly confirms: the handle, what was built, and where. Do not infer or add an employer, team, or motivation that is not stated outright. When a contributor's affiliation is genuinely relevant and confirmed, it can be worth a mention, but guessing at one from a bio or username is the kind of error that erodes trust in the newsletter.
+Whatever the phrasing, this section is a shoutout, not a feature writeup, so skip the mechanism-and-benefit prose used elsewhere in the newsletter, and state only what the PR, a linked page, or the user directly confirms. Do not infer or add an employer, team, or motivation that is not stated outright. When a contributor's affiliation is genuinely relevant and confirmed, it can be worth a mention, but guessing at one from a bio or username is the kind of error that erodes trust in the newsletter.
 
 ## Step 5 — Write the page
 
@@ -205,4 +205,4 @@ Surface judgment calls to the user rather than guessing: the `Task` type for a P
 - The TLDR renders as a run-on unless it is a real markdown list.
 - `no-format` is the right tool for concise/anti-pattern/opt-in snippets.
 - Community content beyond first-time contributors (showcases, talks, Discord, Discussions) has no reliable API source. Ask the user rather than guessing, and drop the `## Community` heading if there is nothing to put in it.
-- Keep attributions to one line: handle, what they contributed, where. Never add an affiliation, team, or motivation that is not directly confirmed.
+- Keep attributions short and credit the handle, but do not repeat the same "Thanks to X for contributing Y" template verbatim every time; work in a concrete, checkable detail (shipped in the project's docs, a live site) when one exists. Never add an affiliation, team, or motivation that is not directly confirmed.

--- a/skills/newsletter/pull-board.js
+++ b/skills/newsletter/pull-board.js
@@ -9,6 +9,7 @@
 //   node skills/newsletter/pull-board.js "Jul 2026"            # board items for an iteration
 //   node skills/newsletter/pull-board.js month "Jul 2026"      # same, explicit
 //   node skills/newsletter/pull-board.js merged 2026-07         # PRs merged that month (coverage cross-check)
+//   node skills/newsletter/pull-board.js contributors 2026-07   # first-time contributors that month (for Community)
 //   node skills/newsletter/pull-board.js pr language-server 527 # a PR's title, body, linked issues, changed files
 //   node skills/newsletter/pull-board.js issue marko 3167       # an issue's title and body (follow a #ref from a PR)
 //
@@ -121,7 +122,7 @@ const SEARCH_QUERY = `
     search(query: $q, type: ISSUE, first: 100, after: $cursor) {
       pageInfo { hasNextPage endCursor }
       nodes {
-        ... on PullRequest { number title repository { name } }
+        ... on PullRequest { number title repository { name } author { login } authorAssociation }
       }
     }
   }
@@ -162,15 +163,36 @@ async function pullMonth(month) {
   console.log(rows.sort().join("\n"));
 }
 
-async function pullMerged(ym) {
-  if (!/^\d{4}-\d{2}$/.test(ym ?? "")) throw new Error("Usage: pull-board.js merged <YYYY-MM>  (e.g. 2026-07)");
+async function searchMergedPRs(ym, usage) {
+  if (!/^\d{4}-\d{2}$/.test(ym ?? "")) throw new Error(usage);
   const [y, m] = ym.split("-").map(Number);
   const lastDay = String(new Date(y, m, 0).getDate()).padStart(2, "0");
   const q = `org:marko-js is:pr is:merged merged:${ym}-01..${ym}-${lastDay}`;
   const nodes = await collect(async (cursor) => (await gql(SEARCH_QUERY, { q, cursor })).search);
-  for (const pr of nodes) {
-    if (!pr?.repository) continue;
-    console.log(`${pr.repository.name}#${pr.number}\t${pr.title}`);
+  return nodes.filter((pr) => pr?.repository);
+}
+
+async function pullMerged(ym) {
+  const prs = await searchMergedPRs(ym, "Usage: pull-board.js merged <YYYY-MM>  (e.g. 2026-07)");
+  for (const pr of prs) {
+    console.log(`${pr.repository.name}#${pr.number}\t${pr.title}\t${pr.author?.login ?? "?"}\t${pr.authorAssociation}`);
+  }
+}
+
+// First-time contributors that month, for the newsletter's Community section.
+// authorAssociation FIRST_TIME_CONTRIBUTOR means their first PR to that repo;
+// FIRST_TIMER means their first PR anywhere on GitHub.
+async function pullContributors(ym) {
+  const prs = await searchMergedPRs(ym, "Usage: pull-board.js contributors <YYYY-MM>  (e.g. contributors 2026-07)");
+  const firstTime = prs.filter(
+    (pr) => pr.authorAssociation === "FIRST_TIME_CONTRIBUTOR" || pr.authorAssociation === "FIRST_TIMER",
+  );
+  if (!firstTime.length) {
+    console.log("(no first-time contributors this month)");
+    return;
+  }
+  for (const pr of firstTime) {
+    console.log(`${pr.repository.name}#${pr.number}\t${pr.author?.login ?? "unknown"}\t${pr.title}`);
   }
 }
 
@@ -209,13 +231,15 @@ const [cmd, ...args] = process.argv.slice(2);
 const command =
   cmd === "merged"
     ? () => pullMerged(args[0])
-    : cmd === "pr"
-      ? () => showPr(args[0], args[1])
-      : cmd === "issue"
-        ? () => showIssue(args[0], args[1])
-        : cmd === "month"
-          ? () => pullMonth(args[0])
-          : () => pullMonth(cmd); // default: treat the first argument as the iteration title
+    : cmd === "contributors"
+      ? () => pullContributors(args[0])
+      : cmd === "pr"
+        ? () => showPr(args[0], args[1])
+        : cmd === "issue"
+          ? () => showIssue(args[0], args[1])
+          : cmd === "month"
+            ? () => pullMonth(args[0])
+            : () => pullMonth(cmd); // default: treat the first argument as the iteration title
 
 command().catch((err) => {
   console.error(err.message);


### PR DESCRIPTION
Adds a `## Community` section to the newsletter, with skill guidance for sourcing it (automated first-time-contributor lookup, plus asking for showcases/talks/etc.) and writing concise attributions. April 2026 gets its first entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NH2WXTD2PuxUL2WoDDb5TA)_