### PR TITLE
Restructure newsletters into headline and bucket tiers

### DIFF
--- a/.marko-run/routes.d.ts
+++ b/.marko-run/routes.d.ts
@@ -13,6 +13,13 @@ declare module "@marko/run" {
 			"/": { verb: "get"; };
 			"/brand": { verb: "get"; };
 			"/docs": { verb: "get"; };
+			"/docs/newsletter": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter+meta.json"); };
+			"/docs/newsletter/april-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/april-2026+meta.json"); };
+			"/docs/newsletter/february-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/february-2026+meta.json"); };
+			"/docs/newsletter/january-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/january-2026+meta.json"); };
+			"/docs/newsletter/june-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/june-2026+meta.json"); };
+			"/docs/newsletter/march-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/march-2026+meta.json"); };
+			"/docs/newsletter/may-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/may-2026+meta.json"); };
 			"/docs/explanation/class-vs-tags-api": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/explanation/class-vs-tags-api+meta.json"); };
 			"/docs/explanation/controllable-components": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/explanation/controllable-components+meta.json"); };
 			"/docs/explanation/fine-grained-bundling": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/explanation/fine-grained-bundling+meta.json"); };
@@ -39,10 +46,6 @@ declare module "@marko/run" {
 			"/docs/marko-run/file-based-routing": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+meta.json"); };
 			"/docs/marko-run/getting-started": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+meta.json"); };
 			"/docs/marko-run/typescript": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+meta.json"); };
-			"/docs/newsletter/february-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/february-2026+meta.json"); };
-			"/docs/newsletter/january-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/january-2026+meta.json"); };
-			"/docs/newsletter/june-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/june-2026+meta.json"); };
-			"/docs/newsletter/may-2026": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/newsletter/may-2026+meta.json"); };
 			"/docs/reference/concise-syntax": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+meta.json"); };
 			"/docs/reference/core-tag": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+meta.json"); };
 			"/docs/reference/custom-tag": { verb: "get"; meta: typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+meta.json"); };
@@ -119,7 +122,7 @@ declare module "../src/routes/docs/newsletter/feed%2exml+handler" {
 declare module "../src/routes/docs/+middleware" {
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/docs" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/may-2026" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/docs/reference-full.md" | "/docs/newsletter/feed.xml"];
+    export type Route = Run.Routes["/docs" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/docs/reference-full.md" | "/docs/newsletter/feed.xml"];
     export type Context = Run.MultiRouteContext<Route>;
     export type Handler = Run.HandlerLike<Route>;
     export type GET = Run.HandlerLike<Route, "GET">;
@@ -156,6 +159,132 @@ declare module "../src/routes/brand/+page.marko" {
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
     export type Route = Run.Routes["/brand"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter/april-2026+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter/april-2026"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter/february-2026+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter/february-2026"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter/january-2026+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter/january-2026"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter/june-2026+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter/june-2026"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter/march-2026+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter/march-2026"];
+    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
+    export type Handler = Run.HandlerLike<Route>;
+    export type GET = Run.HandlerLike<Route, "GET">;
+    export type HEAD = Run.HandlerLike<Route, "HEAD">;
+    export type POST = Run.HandlerLike<Route, "POST">;
+    export type PUT = Run.HandlerLike<Route, "PUT">;
+    export type DELETE = Run.HandlerLike<Route, "DELETE">;
+    export type PATCH = Run.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
+    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
+    export const route: Run.HandlerTypeFn<Route>;
+  }
+}
+
+declare module "../src/routes/docs/_compiled-docs/newsletter/may-2026+page.marko" {
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = Run.Routes["/docs/newsletter/may-2026"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
     export type GET = Run.HandlerLike<Route, "GET">;
@@ -638,78 +767,6 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/typescript+page.mark
   }
 }
 
-declare module "../src/routes/docs/_compiled-docs/newsletter/february-2026+page.marko" {
-  namespace MarkoRun {
-    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/docs/newsletter/february-2026"];
-    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
-    export type Handler = Run.HandlerLike<Route>;
-    export type GET = Run.HandlerLike<Route, "GET">;
-    export type HEAD = Run.HandlerLike<Route, "HEAD">;
-    export type POST = Run.HandlerLike<Route, "POST">;
-    export type PUT = Run.HandlerLike<Route, "PUT">;
-    export type DELETE = Run.HandlerLike<Route, "DELETE">;
-    export type PATCH = Run.HandlerLike<Route, "PATCH">;
-    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
-    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
-    export const route: Run.HandlerTypeFn<Route>;
-  }
-}
-
-declare module "../src/routes/docs/_compiled-docs/newsletter/january-2026+page.marko" {
-  namespace MarkoRun {
-    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/docs/newsletter/january-2026"];
-    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
-    export type Handler = Run.HandlerLike<Route>;
-    export type GET = Run.HandlerLike<Route, "GET">;
-    export type HEAD = Run.HandlerLike<Route, "HEAD">;
-    export type POST = Run.HandlerLike<Route, "POST">;
-    export type PUT = Run.HandlerLike<Route, "PUT">;
-    export type DELETE = Run.HandlerLike<Route, "DELETE">;
-    export type PATCH = Run.HandlerLike<Route, "PATCH">;
-    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
-    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
-    export const route: Run.HandlerTypeFn<Route>;
-  }
-}
-
-declare module "../src/routes/docs/_compiled-docs/newsletter/june-2026+page.marko" {
-  namespace MarkoRun {
-    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/docs/newsletter/june-2026"];
-    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
-    export type Handler = Run.HandlerLike<Route>;
-    export type GET = Run.HandlerLike<Route, "GET">;
-    export type HEAD = Run.HandlerLike<Route, "HEAD">;
-    export type POST = Run.HandlerLike<Route, "POST">;
-    export type PUT = Run.HandlerLike<Route, "PUT">;
-    export type DELETE = Run.HandlerLike<Route, "DELETE">;
-    export type PATCH = Run.HandlerLike<Route, "PATCH">;
-    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
-    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
-    export const route: Run.HandlerTypeFn<Route>;
-  }
-}
-
-declare module "../src/routes/docs/_compiled-docs/newsletter/may-2026+page.marko" {
-  namespace MarkoRun {
-    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/docs/newsletter/may-2026"];
-    export type Context = Run.MultiRouteContext<Route> & Marko.Global;
-    export type Handler = Run.HandlerLike<Route>;
-    export type GET = Run.HandlerLike<Route, "GET">;
-    export type HEAD = Run.HandlerLike<Route, "HEAD">;
-    export type POST = Run.HandlerLike<Route, "POST">;
-    export type PUT = Run.HandlerLike<Route, "PUT">;
-    export type DELETE = Run.HandlerLike<Route, "DELETE">;
-    export type PATCH = Run.HandlerLike<Route, "PATCH">;
-    export type OPTIONS = Run.HandlerLike<Route, "OPTIONS">;
-    /** @deprecated use `((context, next) => { ... }) satisfies MarkoRun.Handler` instead */
-    export const route: Run.HandlerTypeFn<Route>;
-  }
-}
-
 declare module "../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko" {
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
@@ -948,7 +1005,7 @@ declare module "../src/routes/+layout.marko" {
   export interface Input extends Run.LayoutInput<typeof import("../src/routes/+layout.marko")> {}
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/" | "/brand" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/may-2026" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/playground"];
+    export type Route = Run.Routes["/" | "/brand" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/playground"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
     export type GET = Run.HandlerLike<Route, "GET">;
@@ -967,7 +1024,7 @@ declare module "../src/routes/docs/+layout.marko" {
   export interface Input extends Run.LayoutInput<typeof import("../src/routes/docs/+layout.marko")> {}
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = Run.Routes["/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/may-2026" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals"];
+    export type Route = Run.Routes["/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals"];
     export type Context = Run.MultiRouteContext<Route> & Marko.Global;
     export type Handler = Run.HandlerLike<Route>;
     export type GET = Run.HandlerLike<Route, "GET">;

--- a/docs/newsletter/april-2026.md
+++ b/docs/newsletter/april-2026.md
@@ -3,11 +3,11 @@
 > [!TLDR]
 >
 > - Safer escaping inside `<script>`, `<style>`, and comment tags
-> - TypeScript 6 across the language tools
 > - Vite 8 support with dev-server hot-reload fixes
-> - Smaller serialized output and faster editor parsing
+> - TSRX, an experiment in writing Marko in a JSX-like TypeScript syntax
+> - TypeScript 6 across the language tools
 
-April was a month of hardening. A security-relevant fix tightened how dynamic values are escaped inside script and style tags, the language tools moved to TypeScript 6, and the Vite integration continued onto Rolldown with Vite 8 support and a batch of dev-server fixes.
+April was a month of hardening. A security-relevant fix tightened how dynamic values are escaped inside script and style tags, the language tools moved to TypeScript 6, and the Vite integration continued onto Rolldown with Vite 8 support and a batch of dev-server fixes, while a new experimental project explored a different way to write Marko.
 
 ## Safer Escaping
 
@@ -16,41 +16,49 @@ Dynamic text interpolated into `<script>`, `<style>`, `<html-script>`, and `<htm
 > [!WARNING]
 > The contents of `<script>` and `<style>` are executed as code. Never interpolate untrusted input into them, escaping notwithstanding.
 
-## TypeScript
-
-The language tools upgraded to TypeScript 6, so `@marko/type-check`, the language server, and the VS Code extension all build and check against the new release ([language-server#480](https://github.com/marko-js/language-server/pull/480)).
-
 ## Build Tooling
 
 Marko Run added Vite 8 support ([run#186](https://github.com/marko-js/run/pull/186)), extending the Vite integration's Vite 8 work from the previous month. A batch of dev-server fixes followed: hot reloading now handles a Tags API component whose child template changes how it uses `input`, and Marko virtual files update correctly on change ([vite#260](https://github.com/marko-js/vite/pull/260), [vite#266](https://github.com/marko-js/vite/pull/266)). CommonJS dependency handling in dev SSR was iterated on across several fixes. Separately, package publishing can now target release tags other than `latest`, and Marko Run cleans special characters out of generated Rollup output filenames ([vite#255](https://github.com/marko-js/vite/pull/255), [vite#258](https://github.com/marko-js/vite/pull/258), [run#187](https://github.com/marko-js/run/pull/187)).
-
-## Performance
-
-The runtime skips serializing the signal index for the first dynamic closure, trimming the serialized output ([marko#3148](https://github.com/marko-js/marko/pull/3148)). In the editor, script parsing is now cacheable and its scope tracking simplified, which reduces repeated work as files are analyzed ([language-server#472](https://github.com/marko-js/language-server/pull/472)).
-
-## Error Handling
-
-An empty `<@catch>` now absorbs errors as intended. Previously `<@catch></@catch>` behaved as if it were absent, so asynchronous errors escaped the surrounding `<try>` instead of being caught ([marko#3158](https://github.com/marko-js/marko/pull/3158)).
-
-## Fixes
-
-- A production-build regression was corrected: module-scoped `var` declarations that can reference themselves synchronously are no longer hoisted the way `let` and `const` are ([marko#3171](https://github.com/marko-js/marko/pull/3171)).
-- Tags API dynamic tags with a mutable tag variable now serialize references to their child scope correctly ([marko#3168](https://github.com/marko-js/marko/pull/3168)).
-- Editor typings for attribute tags handle dynamic cases more accurately ([language-server#474](https://github.com/marko-js/language-server/pull/474)).
-
-## Documentation Search
-
-The documentation site replaced Algolia with a self-hosted FlexSearch index and a redesigned search dialog ([website#138](https://github.com/marko-js/website/pull/138)).
-
-## Community
-
-Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for bringing first-class Marko support to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)); its [sortability docs](https://drag-and-drop.formkit.com/#sortability) now include a Marko example.
 
 ## Experiments
 
 A new experimental project, [TSRX](https://tsrx.dev), explores writing Marko components in a JSX-like TypeScript syntax that compiles to Marko. Early work added control-flow expressions, member-expression tag names that map to dynamic tags, and looser rules for default exports ([tsrx](https://github.com/marko-js/tsrx)).
 
+## Improvements
+
+Quieter improvements landed in the language tools and on the documentation site.
+
+### TypeScript
+
+The language tools upgraded to TypeScript 6, so `@marko/type-check`, the language server, and the VS Code extension all build and check against the new release ([language-server#480](https://github.com/marko-js/language-server/pull/480)).
+
+### Performance
+
+The runtime skips serializing the signal index for the first dynamic closure, trimming the serialized output ([marko#3148](https://github.com/marko-js/marko/pull/3148)). In the editor, script parsing is now cacheable and its scope tracking simplified, which reduces repeated work as files are analyzed ([language-server#472](https://github.com/marko-js/language-server/pull/472)).
+
+### Documentation Search
+
+The documentation site replaced Algolia with a self-hosted FlexSearch index and a redesigned search dialog ([website#138](https://github.com/marko-js/website/pull/138)).
+
+## Fixes
+
+A handful of correctness fixes rounded out the month.
+
+### Error Handling
+
+An empty `<@catch>` now absorbs errors as intended. Previously `<@catch></@catch>` behaved as if it were absent, so asynchronous errors escaped the surrounding `<try>` instead of being caught ([marko#3158](https://github.com/marko-js/marko/pull/3158)).
+
+### In Brief
+
+- A production-build regression was corrected: module-scoped `var` declarations that can reference themselves synchronously are no longer hoisted the way `let` and `const` are ([marko#3171](https://github.com/marko-js/marko/pull/3171)).
+- Tags API dynamic tags with a mutable tag variable now serialize references to their child scope correctly ([marko#3168](https://github.com/marko-js/marko/pull/3168)).
+- Editor typings for attribute tags handle dynamic cases more accurately ([language-server#474](https://github.com/marko-js/language-server/pull/474)).
+
 Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).
+
+## Community
+
+Thanks to [@defunkt-dev](https://github.com/defunkt-dev) for bringing first-class Marko support to [`@formkit/drag-and-drop`](https://github.com/formkit/drag-and-drop) ([drag-and-drop#168](https://github.com/formkit/drag-and-drop/pull/168)); its [sortability docs](https://drag-and-drop.formkit.com/#sortability) now include a Marko example.
 
 ## Further Reading
 

--- a/docs/newsletter/february-2026.md
+++ b/docs/newsletter/february-2026.md
@@ -36,23 +36,25 @@ This rewrite builds on new validity APIs in the parser, including helpers for ch
 
 Numeric controllable values are now supported and normalized correctly, so a numeric `value:=` round-trips as a number rather than being coerced to a string ([marko#3098](https://github.com/marko-js/marko/pull/3098), [marko#3096](https://github.com/marko-js/marko/pull/3096)).
 
-## Performance
-
-The HTML serializer now deduplicates long strings. When a serialized value over thirty characters appears more than once, it is written a single time and referenced afterward instead of being repeated, which trims the size of the data sent to the browser for resumption on pages with repeated content ([marko#3105](https://github.com/marko-js/marko/pull/3105)).
-
 ## Compiler
 
 The compiler no longer depends on Babel modules directly. Instead it bundles a pre-patched, pre-built copy of Babel. Marko patches some Babel internals, and a change upstream had previously been able to break the compiler. Vendoring Babel decouples those upgrades, so new Babel versions can be adopted during routine dependency updates, and it removes the old patch strategy's sensitivity to load order and to multiple copies of Babel being present ([marko#3073](https://github.com/marko-js/marko/pull/3073), [marko#3071](https://github.com/marko-js/marko/pull/3071), [marko#3075](https://github.com/marko-js/marko/pull/3075)).
 
 The same effort made `browserslist` optional and firmed up the compiler's browser support, so the compiler runs in more environments, including the browser, without extra configuration ([marko#3077](https://github.com/marko-js/marko/pull/3077), [marko#3081](https://github.com/marko-js/marko/pull/3081)).
 
-## Editor Support
+## Performance
+
+The HTML serializer now deduplicates long strings. When a serialized value over thirty characters appears more than once, it is written a single time and referenced afterward instead of being repeated, which trims the size of the data sent to the browser for resumption on pages with repeated content ([marko#3105](https://github.com/marko-js/marko/pull/3105)).
+
+## Improvements
+
+Smaller features landed in the editor, Marko Run, concise mode, and the documentation.
+
+### Editor Support
 
 Attribute autocomplete grew more helpful. String attributes with common prefixes now suggest those prefixes inline, so completing `href` or `src` offers starting points like `#`, `mailto:`, `https://`, and `/` ([marko#3090](https://github.com/marko-js/marko/pull/3090)).
 
-The language server moved to the latest Marko and picked up a batch of fixes: tag-name syntax highlighting, render errors that map back to the correct tag name, accurate reading of a variable inside its own body, codegen for `const` native tags, and attribute-tag type narrowing ([language-server#460](https://github.com/marko-js/language-server/pull/460), [#450](https://github.com/marko-js/language-server/pull/450), [#452](https://github.com/marko-js/language-server/pull/452), [#454](https://github.com/marko-js/language-server/pull/454), [#456](https://github.com/marko-js/language-server/pull/456), [#458](https://github.com/marko-js/language-server/pull/458)).
-
-## Marko Run
+### Marko Run
 
 Meta data defined in [`+meta`](../marko-run/file-based-routing.md) files can carry HTTP verb specific overrides. For a meta file that exports an object, including a JSON file, top-level keys that match an uppercase HTTP method are treated as overrides. The matching override for the current request method is merged shallowly over the base values and excluded from the meta object otherwise.
 
@@ -69,7 +71,7 @@ Meta data defined in [`+meta`](../marko-run/file-based-routing.md) files can car
 
 A `GET` request sees the base `title` and `robots`, while a `POST` request sees the overridden pair ([run#183](https://github.com/marko-js/run/pull/183)).
 
-## Concise Syntax
+### Concise Syntax
 
 In [concise mode](../reference/concise-syntax.md), text inside a code fence now has its surrounding whitespace trimmed, including leading tabs, instead of preserving the leading and trailing newlines the fence used to keep.
 
@@ -82,9 +84,19 @@ div
 
 The fenced text resolves to `Hello World` with no surrounding whitespace ([htmljs-parser#199](https://github.com/marko-js/htmljs-parser/pull/199)).
 
+### Documentation
+
+A new [Supported Environments](../reference/supported-environments.md) page documents the browsers and Node versions Marko targets, giving a single place to check compatibility ([website#132](https://github.com/marko-js/website/pull/132)).
+
 ## Fixes
 
-A round of correctness fixes landed across the runtime and compiler:
+A batch of language server fixes shipped with its move to the latest Marko, alongside a round of runtime and compiler corrections.
+
+### Language Server
+
+The language server moved to the latest Marko and picked up a batch of fixes: tag-name syntax highlighting, render errors that map back to the correct tag name, accurate reading of a variable inside its own body, codegen for `const` native tags, and attribute-tag type narrowing ([language-server#460](https://github.com/marko-js/language-server/pull/460), [#450](https://github.com/marko-js/language-server/pull/450), [#452](https://github.com/marko-js/language-server/pull/452), [#454](https://github.com/marko-js/language-server/pull/454), [#456](https://github.com/marko-js/language-server/pull/456), [#458](https://github.com/marko-js/language-server/pull/458)).
+
+### In Brief
 
 - Pure signals are preserved correctly when a function is resumed ([marko#3070](https://github.com/marko-js/marko/pull/3070)).
 - Pending `<await>` closures resolve correctly ([marko#3100](https://github.com/marko-js/marko/pull/3100)).
@@ -94,10 +106,6 @@ A round of correctness fixes landed across the runtime and compiler:
 - Class API interop fixes `toJSON` placement on implicit split components ([marko#3083](https://github.com/marko-js/marko/pull/3083)).
 - Types for the `<dialog>` element and the [`<id>`](../reference/core-tag.md#id) tag are filled in ([marko#3085](https://github.com/marko-js/marko/pull/3085), [marko#3087](https://github.com/marko-js/marko/pull/3087)).
 - The Vite integration emits correct sourcemaps for the server and browser entries ([vite#244](https://github.com/marko-js/vite/pull/244)).
-
-## Browser Support
-
-A new [Supported Environments](../reference/supported-environments.md) page documents the browsers and Node versions Marko targets, giving a single place to check compatibility ([website#132](https://github.com/marko-js/website/pull/132)).
 
 Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).
 

--- a/docs/newsletter/january-2026.md
+++ b/docs/newsletter/january-2026.md
@@ -2,9 +2,9 @@
 
 > [!TLDR]
 >
-> - A large batch of compiler fixes for variable hoisting and cross-section scope analysis
-> - Correct handling of known rest and spread inputs
-> - Steadier type checking in the language server, plus pnpm project discovery
+> - A large batch of compiler fixes for variable hoisting, scope analysis, and rest inputs
+> - Steadier type checking in the language server
+> - pnpm project discovery for editor tooling
 > - Interop and controllable-input fixes for mixed Class API and Tags API apps
 
 January was a stabilization month. Rather than new syntax, the work went into the parts of the Marko 6 compiler that decide where variables live and how scopes connect, into the language server's understanding of those same scopes, and into the seams where Class API and Tags API code meet. The result is a compiler that handles more real-world templates correctly and an editor that keeps up with them.
@@ -15,51 +15,46 @@ The largest theme was variable hoisting and section analysis. A regression that 
 
 A cluster of related fixes tightened how the compiler reasons about scopes that span sections: assignments that were missing their section, declared non-nullable aliases used in a different section, the canonical signal used for closure references, and assignments to bindings that are never read ([marko#3052](https://github.com/marko-js/marko/pull/3052), [marko#3051](https://github.com/marko-js/marko/pull/3051), [marko#3048](https://github.com/marko-js/marko/pull/3048), [marko#3049](https://github.com/marko-js/marko/pull/3049)). Scriptlet variables no longer collide with compiler-generated names ([marko#3028](https://github.com/marko-js/marko/pull/3028)).
 
-## Rest and Spread
+The optimizations for known spread and rest inputs were corrected as part of the same push. A known tag with a `...rest` input reference could create a circular serialize reason and overflow the call stack, and serializing nested rest bindings is now handled correctly ([marko#3035](https://github.com/marko-js/marko/pull/3035), [marko#3040](https://github.com/marko-js/marko/pull/3040), [marko#3053](https://github.com/marko-js/marko/pull/3053)).
 
-Optimizations for known spread and rest inputs were corrected. A known tag with a `...rest` input reference could create a circular serialize reason and overflow the call stack, and serializing nested rest bindings is now handled correctly ([marko#3035](https://github.com/marko-js/marko/pull/3035), [marko#3040](https://github.com/marko-js/marko/pull/3040), [marko#3053](https://github.com/marko-js/marko/pull/3053)).
+## Improvements
 
-## Event Handlers
+A few workflow improvements landed alongside the stabilization work.
 
-Default [event handlers](../reference/native-tag.md#event-handlers) registered before a spread on a native tag now apply correctly ([marko#3036](https://github.com/marko-js/marko/pull/3036)). A separate fix resolves a serialization error when a Class API component is used from the Tags API with a handler that reads nothing from scope.
+### Editor Tooling
 
-```marko no-format
-// use tags
+The language server discovers `@marko/compiler` more reliably under pnpm. Because pnpm stores transitive dependencies in its `.pnpm` directory, the compiler was not found when it was not a direct dependency. When no compiler is found, the server now falls back to the one resolved from the installed `marko` version ([language-server#431](https://github.com/marko-js/language-server/pull/431)). The full set of supported editors lives in [Tooling Integrations](../introduction/integrations.md#editor-tooling).
 
-<my-class-api-button onClick() { console.log("no state used") }/>
-```
+### Build Integration
 
-Previously this produced a "scope is undefined" error; the stateless handler now serializes cleanly ([marko#3039](https://github.com/marko-js/marko/pull/3039)).
+The Vite integration tracks optional watch files more accurately, so changes to files that may or may not exist are picked up without over-watching ([vite#242](https://github.com/marko-js/vite/pull/242)). The compiler also allows overriding how template ids are generated, giving build tooling control over those identifiers ([marko#3061](https://github.com/marko-js/marko/pull/3061)).
 
-## Controllable Inputs
+### Playground
 
-A controllable text input driven through a spread `value` or `valueChange` now updates correctly, closing a gap in [two-way binding](../reference/language.md#shorthand-change-handlers-two-way-binding) when the controlling attributes arrive by spread rather than directly ([marko#3042](https://github.com/marko-js/marko/pull/3042)).
+The [playground](/playground) gained starter templates when adding a new tab, so a new file can begin from an example instead of an empty editor, along with a handful of smaller editor refinements ([website#129](https://github.com/marko-js/website/pull/129)).
 
-## Type Checking
+## Fixes
+
+The rest of the month's correctness work landed in the language server's type checking and at the seams between the Class API and the Tags API.
+
+### Type Checking
 
 The language server caught up with several Marko 6 scope behaviors. Tag variable hoisting aligns with the runtime, scope hoisting and attribute tag types are more accurate, and the extractor's mutation output was reworked ([language-server#433](https://github.com/marko-js/language-server/pull/433), [#435](https://github.com/marko-js/language-server/pull/435), [#442](https://github.com/marko-js/language-server/pull/442), [#444](https://github.com/marko-js/language-server/pull/444), [#437](https://github.com/marko-js/language-server/pull/437)). Identifier attribute binds in a nested scope and `define` tag variable hoisting were both fixed, along with broken type checks in recent versions ([#439](https://github.com/marko-js/language-server/pull/439), [#448](https://github.com/marko-js/language-server/pull/448)).
 
 On the runtime side, the [`<await>`](../reference/core-tag.md#await) tag types improved and the native tag types now line up between the Class API and Tags API ([marko#3055](https://github.com/marko-js/marko/pull/3055), [marko#3062](https://github.com/marko-js/marko/pull/3062)).
 
-## Editor Tooling
+### Interop
 
-The language server discovers `@marko/compiler` more reliably under pnpm. Because pnpm stores transitive dependencies in its `.pnpm` directory, the compiler was not found when it was not a direct dependency. When no compiler is found, the server now falls back to the one resolved from the installed `marko` version ([language-server#431](https://github.com/marko-js/language-server/pull/431)). The full set of supported editors lives in [Tooling Integrations](../introduction/integrations.md#editor-tooling).
+Mixed Class API and Tags API applications gained several fixes. Components initialize correctly when bundled with `lasso-marko`, dynamic native tags route through the compatibility layer as expected, and a Class API component used from the Tags API with an [event handler](../reference/native-tag.md#event-handlers) that reads nothing from scope no longer produces a "scope is undefined" error during serialization ([marko#3030](https://github.com/marko-js/marko/pull/3030), [marko#3057](https://github.com/marko-js/marko/pull/3057), [marko#3039](https://github.com/marko-js/marko/pull/3039)). Projects combining both APIs can follow [Marko 5 Interop](../guide/marko-5-interop.md) for the conventions that select each compiler.
 
-## Define Tags
+### Define Tags
 
 Rendering a [`<define>`](../reference/custom-tag.md) tag with no body content no longer errors, and a `...rest` input reference no longer produces a circular serialize reason ([marko#3034](https://github.com/marko-js/marko/pull/3034)). When every usage site is known to provide `input`, the compiler now optimizes the define tag's `input` reference ([marko#3046](https://github.com/marko-js/marko/pull/3046)).
 
-## Interop
+### In Brief
 
-Mixed Class API and Tags API applications gained two fixes. Components initialize correctly when bundled with `lasso-marko`, and dynamic native tags route through the compatibility layer as expected ([marko#3030](https://github.com/marko-js/marko/pull/3030), [marko#3057](https://github.com/marko-js/marko/pull/3057)). Projects combining both APIs can follow [Marko 5 Interop](../guide/marko-5-interop.md) for the conventions that select each compiler.
-
-## Build Integration
-
-The Vite integration tracks optional watch files more accurately, so changes to files that may or may not exist are picked up without over-watching ([vite#242](https://github.com/marko-js/vite/pull/242)). The compiler also allows overriding how template ids are generated, giving build tooling control over those identifiers ([marko#3061](https://github.com/marko-js/marko/pull/3061)).
-
-## Playground
-
-The [playground](/playground) gained starter templates when adding a new tab, so a new file can begin from an example instead of an empty editor, along with a handful of smaller editor refinements ([website#129](https://github.com/marko-js/website/pull/129)).
+- Default [event handlers](../reference/native-tag.md#event-handlers) registered before a spread on a native tag now apply correctly ([marko#3036](https://github.com/marko-js/marko/pull/3036)).
+- A controllable text input driven through a spread `value` or `valueChange` updates correctly, closing a gap in [two-way binding](../reference/language.md#shorthand-change-handlers-two-way-binding) when the controlling attributes arrive by spread rather than directly ([marko#3042](https://github.com/marko-js/marko/pull/3042)).
 
 Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).
 

--- a/docs/newsletter/june-2026.md
+++ b/docs/newsletter/june-2026.md
@@ -5,9 +5,10 @@
 > - Marko 6 is now the default `marko` on npm
 > - Native asset management with automatic lazy loading
 > - A Zed extension and a tree-sitter grammar for Marko
+> - Faster server rendering through compile-time attribute inlining
 > - Synchronous `<await>` for values that are not promises
 
-June's headline is a milestone: `marko@6` is now tagged `latest` on npm, making the Tags API the default for new installs. The rest of the month centered on the parts of Marko that developers feel every day: how assets reach the browser, how editors understand `.marko` files, and how clearly the compiler explains a mistake, alongside a large batch of resumability and interop fixes.
+June's headline is a milestone: `marko@6` is now tagged `latest` on npm, making the Tags API the default for new installs. The rest of the month centered on the parts of Marko that developers feel every day: how assets reach the browser, how editors understand `.marko` files, and how much rendering work moves to compile time, with a long tail of smaller improvements and fixes behind them.
 
 ## Latest on npm
 
@@ -34,31 +35,7 @@ The full set of triggers, including `render`, `idle`, `media`, and event-based l
 
 ## Editor Support
 
-Marko gained a tree-sitter grammar and a dedicated Zed extension, bringing syntax highlighting and structural understanding to Zed, Emacs, and the growing set of tools that rely on tree-sitter, including several LLM-based assistants ([tree-sitter](https://github.com/marko-js/tree-sitter), [zed](https://github.com/marko-js/zed)). The full list of supported editors lives in [Tooling Integrations](../introduction/integrations.md#editor-tooling).
-
-The language server moved forward on several fronts:
-
-- [CSS module support](../guide/styling.md#imported-css-modules), so scoped class names resolve and autocomplete correctly ([language-server#527](https://github.com/marko-js/language-server/pull/527)).
-- Compiler diagnostics surface as code actions, turning many errors into one-click fixes ([language-server#525](https://github.com/marko-js/language-server/pull/525)).
-- Richer completions, offering enum attribute values as snippet choices, completing tag names inside shorthand import strings, and cleaning identifiers for component auto-imports ([#528](https://github.com/marko-js/language-server/pull/528), [#531](https://github.com/marko-js/language-server/pull/531), [#530](https://github.com/marko-js/language-server/pull/530)).
-- A command to view the compiled output of a template, making the compiler's work visible from the editor ([language-server#539](https://github.com/marko-js/language-server/pull/539)), plus commands to restart or reload the server without reopening the workspace ([language-server#536](https://github.com/marko-js/language-server/pull/536)).
-
-For example, scoped class names from a CSS module now resolve and autocomplete, whether imported:
-
-```marko
-import * as styles from "./card.module.css";
-<div class=styles.card/>
-```
-
-or defined inline with a `<style>` tag variable:
-
-```marko
-<style/styles>
-  .card { padding: 1rem }
-</style>
-
-<div class=styles.card/>
-```
+Marko gained a tree-sitter grammar and a dedicated Zed extension, bringing syntax highlighting and structural understanding to Zed, Emacs, and the growing set of tools that rely on tree-sitter, including several LLM-based assistants ([tree-sitter](https://github.com/marko-js/tree-sitter), [zed](https://github.com/marko-js/zed)). The full list of supported editors lives in [Tooling Integrations](../introduction/integrations.md#editor-tooling), and a batch of language server improvements landed alongside, covered [below](#language-server).
 
 ## Performance
 
@@ -80,6 +57,8 @@ With more toggles, the compiler builds a small table of class strings up front, 
 
 Further optimizations collapse redundant signal forwarding, skip serializing the controlled type of static controllable values, and take a faster path for text-only conditionals and placeholder text. The cumulative effect is smaller payloads sent to the browser and less work to resume them. The same principles, applied at the application level, are collected in [Optimizing Performance](../explanation/optimizing-performance.md#reducing-hydration-data).
 
+Parsing sped up as well. A pair of refactors makes htmljs-parser roughly 40% faster on real-world templates: states can process multiple characters at once ([htmljs-parser#220](https://github.com/marko-js/htmljs-parser/pull/220)), and expression scanning takes a fast path for identifier characters while short-circuiting keyword scans ([htmljs-parser#223](https://github.com/marko-js/htmljs-parser/pull/223)).
+
 ## Await
 
 The [`<await>`](../reference/core-tag.md#await) tag renders synchronously when the value it receives is not a promise. An already-resolved value no longer schedules an extra asynchronous tick or a placeholder render, which removes a class of subtle ordering issues and avoids unnecessary work.
@@ -92,7 +71,20 @@ The [`<await>`](../reference/core-tag.md#await) tag renders synchronously when t
 
 When `input.cart` is not actually a promise, for example a cart already loaded on the server and passed straight through, the contents render in the same pass instead of waiting a tick. The same synchronous behavior applies when `<await>` is nested inside [`<try>`](../reference/core-tag.md#try) ([marko#3269](https://github.com/marko-js/marko/pull/3269), [marko#3271](https://github.com/marko-js/marko/pull/3271)). For the streaming side of asynchronous rendering, see [HTML Streaming](../explanation/streaming.md).
 
-## Grouped Tags
+## Improvements
+
+Beyond the headlines, a steady stream of smaller features landed across the language server, the compiler, and the playground.
+
+### Language Server
+
+The language server moved forward on several fronts:
+
+- [CSS module support](../guide/styling.md#imported-css-modules), so scoped class names resolve and autocomplete correctly, whether imported from a `.module.css` file or defined inline with a `<style>` tag variable ([language-server#527](https://github.com/marko-js/language-server/pull/527)).
+- Compiler diagnostics surface as code actions, turning many errors into one-click fixes ([language-server#525](https://github.com/marko-js/language-server/pull/525)).
+- Richer completions, offering enum attribute values as snippet choices, completing tag names inside shorthand import strings, and cleaning identifiers for component auto-imports ([#528](https://github.com/marko-js/language-server/pull/528), [#531](https://github.com/marko-js/language-server/pull/531), [#530](https://github.com/marko-js/language-server/pull/530)).
+- A command to view the compiled output of a template, making the compiler's work visible from the editor ([language-server#539](https://github.com/marko-js/language-server/pull/539)), plus commands to restart or reload the server without reopening the workspace ([language-server#536](https://github.com/marko-js/language-server/pull/536)).
+
+### Grouped Tags
 
 Custom tags can be organized one level deep inside a folder that is not itself a tag. The folder name arranges files on disk but never becomes part of the tag name, so a growing component library can be sorted by feature instead of living in a single flat directory.
 
@@ -106,17 +98,13 @@ tags/
 
 This resolves `<site-nav>`, `<bar-chart>`, and `<line-chart>`. There is no `<charts>` tag, since that folder only groups. The discovery rules are described in [Grouping Folders](../reference/custom-tag.md#grouping-folders), and the documentation now covers grouped discovery and the related `let-*` tags ([marko#3301](https://github.com/marko-js/marko/pull/3301)).
 
-## TypeScript
-
-The expression parser ends a type annotation at the function body brace, so typed methods and callbacks in `.marko` files parse correctly. The same fix landed in the tree-sitter grammar ([htmljs-parser#224](https://github.com/marko-js/htmljs-parser/pull/224), [tree-sitter#4](https://github.com/marko-js/tree-sitter/pull/4)).
-
-A pair of parser refactors makes parsing roughly 40% faster on real-world templates. States can now process multiple characters at once ([htmljs-parser#220](https://github.com/marko-js/htmljs-parser/pull/220)), and expression scanning takes a fast path for identifier characters while short-circuiting keyword scans ([htmljs-parser#223](https://github.com/marko-js/htmljs-parser/pull/223)).
+### TypeScript
 
 Editors beyond VS Code can integrate Marko's type support through the standalone [`@marko/ts-plugin`](../reference/typescript.md) package, including typed [`input`](../reference/typescript.md#typing-input) inside templates ([language-server#505](https://github.com/marko-js/language-server/pull/505)). The plugin scopes itself to Marko projects so it no longer conflicts with Vue ([language-server#532](https://github.com/marko-js/language-server/pull/532)). The supported syntax is described in [TypeScript Syntax](../reference/typescript.md#typescript-syntax-in-marko).
 
-## Clearer Errors
+### Clearer Errors
 
-A recurring theme this month was catching mistakes earlier and explaining them better. The compiler now reports clear errors for object or function literals used as native attribute values, non-function [event handlers](../reference/native-tag.md#event-handlers), invalid dynamic tag values, and invalid [`<for>`](../reference/core-tag.md#for) `by` keys. When markup uses a non-Marko attribute idiom, the error includes a suggested correction. A React-style `className`, for instance, is flagged with `class` as the intended form:
+The compiler now reports clear errors for object or function literals used as native attribute values, non-function [event handlers](../reference/native-tag.md#event-handlers), invalid dynamic tag values, and invalid [`<for>`](../reference/core-tag.md#for) `by` keys. When markup uses a non-Marko attribute idiom, the error includes a suggested correction. A React-style `className`, for instance, is flagged with `class` as the intended form:
 
 ```marko no-format
 <div className="card"/>
@@ -126,7 +114,7 @@ Two new development warnings help as well. One fires when a controlled `<select>
 
 Surfacing these problems sooner helps developers, and the coding agents working alongside them, catch mistakes earlier.
 
-## Concise Syntax
+### Concise Syntax
 
 Comments are now allowed between [line attributes](../reference/concise-syntax.md#attributes-on-multiple-lines) in concise mode, which keeps annotated markup readable ([htmljs-parser#225](https://github.com/marko-js/htmljs-parser/pull/225)).
 
@@ -138,26 +126,29 @@ button
   -- Save
 ```
 
-## Resumability
+### Playground
+
+The [playground](/playground) on markojs.com gained copy and share buttons for results, an embedded console panel, and a format command in the editor ([website#148](https://github.com/marko-js/website/pull/148), [website#149](https://github.com/marko-js/website/pull/149), [website#150](https://github.com/marko-js/website/pull/150)). A series of fixes made multi-tab editing feel right: undo history and selection are isolated per tab, editing no longer floods browser history, tab renaming behaves correctly, and the format command no longer appends stray newlines.
+
+## Fixes
+
+Correctness work this month concentrated on resuming, the Class API interop layer, and parsing.
+
+### Resumability
 
 Several resumption bugs were fixed. Resumed conditional branches are now preserved instead of being rebuilt, control-flow branches link correctly through markers on resume, and lazily-loaded branch effects run after insertion. A resumed `<for to>` range loop now serializes its key so it keeps element identity, and pending scope timing for client renders of `<await>` is more accurate. For background on how resuming differs from rehydration, see [Resumability](../explanation/why-is-marko-fast.md#resumability).
 
-## Interop
+### Interop
 
-Mixing the Class API and the Tags API grew more dependable. Class API inline scripts flush correctly across the interop layer, dynamic tags that import Tags API components route through the compatibility layer, and re-rendering an inert Class API child inside a Tags API parent no longer crashes. Self-hydrating split components work across the interop boundary. Projects combining both APIs can follow [Marko 5 Interop](../guide/marko-5-interop.md) for the directory and comment conventions that select each compiler. An ambiguous file can opt in explicitly with a comment:
+Mixing the Class API and the Tags API grew more dependable. Class API inline scripts flush correctly across the interop layer, dynamic tags that import Tags API components route through the compatibility layer, and re-rendering an inert Class API child inside a Tags API parent no longer crashes. Self-hydrating split components work across the interop boundary. Projects combining both APIs can follow [Marko 5 Interop](../guide/marko-5-interop.md) for the directory and comment conventions that select each compiler.
 
-```marko no-format
-// use tags
-<h1>Welcome ${input.name}</h1>
-```
+### Parsing
 
-## Windows
+The expression parser ends a type annotation at the function body brace, so typed methods and callbacks in `.marko` files parse correctly. The same fix landed in the tree-sitter grammar ([htmljs-parser#224](https://github.com/marko-js/htmljs-parser/pull/224), [tree-sitter#4](https://github.com/marko-js/tree-sitter/pull/4)).
+
+### Windows
 
 A round of path fixes means the language server resolves files and projects correctly on Windows ([language-server#500](https://github.com/marko-js/language-server/pull/500)).
-
-## Playground
-
-The [playground](/playground) on markojs.com gained copy and share buttons for results, an embedded console panel, and a format command in the editor ([website#148](https://github.com/marko-js/website/pull/148), [website#149](https://github.com/marko-js/website/pull/149), [website#150](https://github.com/marko-js/website/pull/150)). A series of fixes made multi-tab editing feel right: undo history and selection are isolated per tab, editing no longer floods browser history, tab renaming behaves correctly, and the format command no longer appends stray newlines.
 
 Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).
 

--- a/docs/newsletter/june-2026.md
+++ b/docs/newsletter/june-2026.md
@@ -132,7 +132,7 @@ The [playground](/playground) on markojs.com gained copy and share buttons for r
 
 ## Fixes
 
-Correctness work this month concentrated on resuming, the Class API interop layer, and parsing.
+Correctness work this month concentrated on resuming and the Class API interop layer.
 
 ### Resumability
 
@@ -142,13 +142,10 @@ Several resumption bugs were fixed. Resumed conditional branches are now preserv
 
 Mixing the Class API and the Tags API grew more dependable. Class API inline scripts flush correctly across the interop layer, dynamic tags that import Tags API components route through the compatibility layer, and re-rendering an inert Class API child inside a Tags API parent no longer crashes. Self-hydrating split components work across the interop boundary. Projects combining both APIs can follow [Marko 5 Interop](../guide/marko-5-interop.md) for the directory and comment conventions that select each compiler.
 
-### Parsing
+### In Brief
 
-The expression parser ends a type annotation at the function body brace, so typed methods and callbacks in `.marko` files parse correctly. The same fix landed in the tree-sitter grammar ([htmljs-parser#224](https://github.com/marko-js/htmljs-parser/pull/224), [tree-sitter#4](https://github.com/marko-js/tree-sitter/pull/4)).
-
-### Windows
-
-A round of path fixes means the language server resolves files and projects correctly on Windows ([language-server#500](https://github.com/marko-js/language-server/pull/500)).
+- The expression parser ends a type annotation at the function body brace, so typed methods and callbacks in `.marko` files parse correctly, with the same fix landing in the tree-sitter grammar ([htmljs-parser#224](https://github.com/marko-js/htmljs-parser/pull/224), [tree-sitter#4](https://github.com/marko-js/tree-sitter/pull/4)).
+- A round of path fixes means the language server resolves files and projects correctly on Windows ([language-server#500](https://github.com/marko-js/language-server/pull/500)).
 
 Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).
 

--- a/docs/newsletter/march-2026.md
+++ b/docs/newsletter/march-2026.md
@@ -35,27 +35,35 @@ The Vite integration gained full Rolldown support, replacing the previous esbuil
 
 Embedding a Marko app inside another page, such as a widget mounted into an existing document, works more smoothly. When a template is detected not to render `html`, `head`, or `body`, Marko now generates a unique `$global.renderId` automatically, and it cleans up scopes when the embedded DOM is removed ([marko#3124](https://github.com/marko-js/marko/pull/3124)).
 
-## Performance
+## Improvements
+
+Beyond the headlines, improvements trimmed server output and expanded type coverage.
+
+### Performance
 
 Server output got smaller. Duplicate section serialization guards are now emitted once instead of repeatedly ([marko#3141](https://github.com/marko-js/marko/pull/3141)). The list reconciliation code was rewritten with its logic inlined for a smaller bundle and additional fast paths for the common case where no items move between renders ([marko#3112](https://github.com/marko-js/marko/pull/3112)).
 
-## Concise Syntax
-
-Several concise-mode whitespace regressions were corrected. Newlines between nodes inside a concise HTML block are preserved again rather than collapsed, and trailing whitespace in those blocks is handled correctly ([htmljs-parser#216](https://github.com/marko-js/htmljs-parser/pull/216), [htmljs-parser#218](https://github.com/marko-js/htmljs-parser/pull/218)). The Tags API `<style>` translation was updated for the parser's revised text nodes, and the compiler no longer inserts a stray space between adjacent text and placeholders in a tag body ([marko#3108](https://github.com/marko-js/marko/pull/3108), [marko#3129](https://github.com/marko-js/marko/pull/3129)).
-
-## Type Definitions
+### Type Definitions
 
 Native attribute typings expanded, adding `webkitdirectory` on `<input>`, `media` on `<meta>`, and refined `<button>` attributes ([marko#3121](https://github.com/marko-js/marko/pull/3121), [marko#3137](https://github.com/marko-js/marko/pull/3137), [marko#3138](https://github.com/marko-js/marko/pull/3138)).
 
-## Interop
-
-Mixing the Class API and Tags API grew more reliable when legacy renderer APIs are involved, with dynamic tags routing correctly through the compatibility layer ([marko#3145](https://github.com/marko-js/marko/pull/3145)). A production-mode ordering bug in return-tag analysis was fixed, so intersecting state resolves in the correct order ([marko#3135](https://github.com/marko-js/marko/pull/3135)). The `@marko/express` middleware was updated for Marko 6 ([express#12](https://github.com/marko-js/express/pull/12)).
-
-## Marko Run
+### Marko Run
 
 Marko Run's file-based routing gained an interactive REPL at [marko.run/repl](https://marko.run/repl) that visualizes how a set of route files maps to matched routes ([marko.run#1](https://github.com/marko-js/marko.run/pull/1)).
 
 ## Fixes
+
+Correctness work concentrated on concise-mode whitespace and the Class API interop layer.
+
+### Concise Syntax
+
+Several concise-mode whitespace regressions were corrected. Newlines between nodes inside a concise HTML block are preserved again rather than collapsed, and trailing whitespace in those blocks is handled correctly ([htmljs-parser#216](https://github.com/marko-js/htmljs-parser/pull/216), [htmljs-parser#218](https://github.com/marko-js/htmljs-parser/pull/218)). The Tags API `<style>` translation was updated for the parser's revised text nodes, and the compiler no longer inserts a stray space between adjacent text and placeholders in a tag body ([marko#3108](https://github.com/marko-js/marko/pull/3108), [marko#3129](https://github.com/marko-js/marko/pull/3129)).
+
+### Interop
+
+Mixing the Class API and Tags API grew more reliable when legacy renderer APIs are involved, with dynamic tags routing correctly through the compatibility layer ([marko#3145](https://github.com/marko-js/marko/pull/3145)). A production-mode ordering bug in return-tag analysis was fixed, so intersecting state resolves in the correct order ([marko#3135](https://github.com/marko-js/marko/pull/3135)). The `@marko/express` middleware was updated for Marko 6 ([express#12](https://github.com/marko-js/express/pull/12)).
+
+### In Brief
 
 - Rendering no longer throws an uninitialized error when `input` is absent ([marko#3125](https://github.com/marko-js/marko/pull/3125)).
 - The compiler avoids loading Babel configuration when Babel is not installed ([marko#3118](https://github.com/marko-js/marko/pull/3118), [marko#3119](https://github.com/marko-js/marko/pull/3119)).

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -188,7 +188,6 @@ npm run build
   `grep -c 'markoAlts=' src/routes/docs/_compiled-docs/newsletter/<slug>+page.marko`
   Then confirm internal links resolved with no leftover `.md`:
   `grep -oE 'href="[^"]*\.md[^"]*"' src/routes/docs/_compiled-docs/newsletter/<slug>+page.marko` (should print nothing).
-- The build also regenerates `.marko-run/routes.d.ts`, a checked-in generated file, adding the new edition's route to the typed route map. Include the refreshed copy alongside the newsletter change so it does not go stale; never edit it by hand.
 - The build can fail nondeterministically on an unrelated doc (e.g. `docs/guide/low-level-apis` with `Cannot read properties of undefined (reading 'ast')`) because docs compile in parallel. If the newsletter page itself generated fine, rerun a clean build: `rm -rf dist && npm run build`.
 
 ## Step 9 — Confirm and hand off
@@ -206,7 +205,6 @@ Surface judgment calls to the user rather than guessing: the `Task` type for a P
 - Get numbers from the PR, with their real scope, and keep the PR's own caveats.
 - Keep implementation detail out of prose; keep compiled-output examples illustrative.
 - The TLDR renders as a run-on unless it is a real markdown list.
-- The verification build regenerates `.marko-run/routes.d.ts` with the new edition's route. Commit the refreshed file with the edition; leaving it out is how it goes stale.
 - `no-format` is the right tool for concise/anti-pattern/opt-in snippets.
 - Community content beyond first-time contributors (showcases, talks, Discord, Discussions) has no reliable API source. Ask the user rather than guessing, and drop the `## Community` heading if there is nothing to put in it.
 - Keep attributions short and credit the handle, but do not repeat the same "Thanks to X for contributing Y" template verbatim every time; work in a concrete, checkable detail (shipped in the project's docs, a live site) when one exists. Never add an affiliation, team, or motivation that is not directly confirmed.

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -188,6 +188,7 @@ npm run build
   `grep -c 'markoAlts=' src/routes/docs/_compiled-docs/newsletter/<slug>+page.marko`
   Then confirm internal links resolved with no leftover `.md`:
   `grep -oE 'href="[^"]*\.md[^"]*"' src/routes/docs/_compiled-docs/newsletter/<slug>+page.marko` (should print nothing).
+- The build also regenerates `.marko-run/routes.d.ts`, a checked-in generated file, adding the new edition's route to the typed route map. Include the refreshed copy alongside the newsletter change so it does not go stale; never edit it by hand.
 - The build can fail nondeterministically on an unrelated doc (e.g. `docs/guide/low-level-apis` with `Cannot read properties of undefined (reading 'ast')`) because docs compile in parallel. If the newsletter page itself generated fine, rerun a clean build: `rm -rf dist && npm run build`.
 
 ## Step 9 — Confirm and hand off
@@ -205,6 +206,7 @@ Surface judgment calls to the user rather than guessing: the `Task` type for a P
 - Get numbers from the PR, with their real scope, and keep the PR's own caveats.
 - Keep implementation detail out of prose; keep compiled-output examples illustrative.
 - The TLDR renders as a run-on unless it is a real markdown list.
+- The verification build regenerates `.marko-run/routes.d.ts` with the new edition's route. Commit the refreshed file with the edition; leaving it out is how it goes stale.
 - `no-format` is the right tool for concise/anti-pattern/opt-in snippets.
 - Community content beyond first-time contributors (showcases, talks, Discord, Discussions) has no reliable API source. Ask the user rather than guessing, and drop the `## Community` heading if there is nothing to put in it.
 - Keep attributions short and credit the handle, but do not repeat the same "Thanks to X for contributing Y" template verbatim every time; work in a concrete, checkable detail (shipped in the project's docs, a live site) when one exists. Never add an affiliation, team, or motivation that is not directly confirmed.

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -89,14 +89,14 @@ Create `docs/newsletter/<month>-<year>.md` (e.g. `july-2026.md`). The `markodown
 The page is tiered: the handful of items that define the month read first at full depth, and everything else stays discoverable in compact buckets behind them.
 
 - A single `# Title` H1 (its text becomes the page title).
-- A `> [!TLDR]` callout with one bullet per headline section, in the same order, then a short intro paragraph that frames the month around them. Do not start the intro with "This newsletter covers...".
+- A `> [!TLDR]` callout of three to five bullets, leading with one bullet per headline section in the same order and drawing the remainder from the highest-impact bucket themes when there are fewer headlines than that. Then a short intro paragraph that frames the month around them. Do not start the intro with "This newsletter covers...".
 - **Headlines**: zero to five flat `## ` sections directly after the intro, one per item that defines the month. Any kind of change qualifies (a feature, a milestone, a performance win, even a major fix); the bar is whether most Marko developers would care, not what kind of change it is. Each gets the full treatment: what shipped, why it matters, and usually a code example. Order them by expected developer impact. A quiet month can have no headlines, in which case the TLDR draws from the buckets below instead; never pad this tier to fill it.
 - `## Improvements` collects the rest of the shipped feature and developer-experience work as `### ` themes (editor support, error messages, playground, and so on), ordered by impact, each a paragraph or two. Open the section with a single framing sentence before the first theme. When a theme grows past a couple of paragraphs and a code example, that is a sign it belongs in the headline tier instead.
-- `## Fixes` collects correctness work. A batch with a story gets its own `### ` theme (a round of resumability fixes, an interop hardening pass); one-liners sweep into a short bullet list at the end. A fix for a feature that shipped this same month still folds into that feature's section (Step 3) rather than landing here.
+- `## Fixes` collects correctness work. A batch with a story gets its own `### ` theme (a round of resumability fixes, an interop hardening pass); one-liners sweep into a short bullet list, under a closing `### In Brief` heading when the section also has themed subsections (trailing content would otherwise read as part of the last theme), or as the section's whole body when nothing earns a theme. A fix for a feature that shipped this same month still folds into that feature's section (Step 3) rather than landing here.
 - The standing release-notes line ("Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).") closes the shipped-work portion, after `## Fixes`.
 - A `## Community` section, when Step 4 turned up content. Use `### ` subsections when it holds multiple substantial items (a showcase, a blog post, an integration); keep a single item or short shout-outs as plain prose. First-time contributor thanks sit at the end. Omit the heading entirely rather than leaving it empty.
 
-Keep paragraphs short everywhere; split dense lists into chunks.
+Keep paragraphs short everywhere; split dense lists into chunks. Omit an empty bucket rather than forcing content into it: a month of pure fixes has no `## Improvements`, and a Fixes section with nothing but prose paragraphs needs no subheadings at all.
 
 Style (see AGENTS.md, enforced by the docs lint):
 

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -86,12 +86,17 @@ Whatever the phrasing, this section is a shoutout, not a feature writeup, so ski
 
 Create `docs/newsletter/<month>-<year>.md` (e.g. `july-2026.md`). The `markodown` Vite plugin globs `docs/**/*.md` and auto-generates the route `/docs/newsletter/<slug>`, so no routing wiring is needed.
 
-Structure:
+The page is tiered: the handful of items that define the month read first at full depth, and everything else stays discoverable in compact buckets behind them.
 
 - A single `# Title` H1 (its text becomes the page title).
-- A `> [!TLDR]` callout listing the highest-impact items first, then a short intro paragraph that frames the month around them. Do not start the intro with "This newsletter covers...".
-- Flat `## ` sections, each a theme, **ordered by expected developer impact**: lead with the change most developers will notice or benefit from, and let lower-impact items (niche fixes, platform notes, internal-leaning work) fall toward the end. Keep paragraphs short; split dense lists into chunks.
-- A `## Community` section, when Step 4 turned up content, ranked by impact like any other section. A first-time contributor's fix usually sits toward the end; a notable showcase can lead if it outweighs the month's code changes. Omit the heading entirely rather than leaving it empty.
+- A `> [!TLDR]` callout with one bullet per headline section, in the same order, then a short intro paragraph that frames the month around them. Do not start the intro with "This newsletter covers...".
+- **Headlines**: zero to five flat `## ` sections directly after the intro, one per item that defines the month. Any kind of change qualifies (a feature, a milestone, a performance win, even a major fix); the bar is whether most Marko developers would care, not what kind of change it is. Each gets the full treatment: what shipped, why it matters, and usually a code example. Order them by expected developer impact. A quiet month can have no headlines, in which case the TLDR draws from the buckets below instead; never pad this tier to fill it.
+- `## Improvements` collects the rest of the shipped feature and developer-experience work as `### ` themes (editor support, error messages, playground, and so on), ordered by impact, each a paragraph or two. Open the section with a single framing sentence before the first theme. When a theme grows past a couple of paragraphs and a code example, that is a sign it belongs in the headline tier instead.
+- `## Fixes` collects correctness work. A batch with a story gets its own `### ` theme (a round of resumability fixes, an interop hardening pass); one-liners sweep into a short bullet list at the end. A fix for a feature that shipped this same month still folds into that feature's section (Step 3) rather than landing here.
+- The standing release-notes line ("Full details for every change are in the release notes of each package on [GitHub](https://github.com/marko-js).") closes the shipped-work portion, after `## Fixes`.
+- A `## Community` section, when Step 4 turned up content. Use `### ` subsections when it holds multiple substantial items (a showcase, a blog post, an integration); keep a single item or short shout-outs as plain prose. First-time contributor thanks sit at the end. Omit the heading entirely rather than leaving it empty.
+
+Keep paragraphs short everywhere; split dense lists into chunks.
 
 Style (see AGENTS.md, enforced by the docs lint):
 
@@ -110,7 +115,7 @@ Style (see AGENTS.md, enforced by the docs lint):
 
 ## Step 6 — Examples and links
 
-Add a code example to a section **only when there is a new, authoring-facing capability to show.** Do not force one onto sections about bug fixes, platform support, parser internals, or UI work, which usually read better with none.
+Add a code example to a section **only when there is a new, authoring-facing capability to show.** Headline sections usually earn one; `## Improvements` themes occasionally do; `## Fixes` and `## Community` almost never do. Do not force one onto sections about bug fixes, platform support, parser internals, or UI work, which usually read better with none.
 
 Code block rules:
 
@@ -194,7 +199,8 @@ Surface judgment calls to the user rather than guessing: the `Task` type for a P
 - Verify the nature of a change before writing it. A title can look feature-shaped when the PR is actually a bug fix; framing matters.
 - When a fix corrects a feature that shipped the same month, describe the net shipped behavior and fold the fix in as a follow-up, rather than listing both or dropping the fix.
 - Reconcile the board against the merged list every time. The board is often incomplete, and an untracked PR can be the month's lead story.
-- Order sections by expected developer impact, not by board order, PR number, or theme grouping.
+- Tier by expected developer impact, not by board order, PR number, or kind of change: headlines are the 0-5 items most developers would care about, and the same impact ordering applies within `## Improvements` and `## Fixes`.
+- Never pad the headline tier. Zero headlines is a valid shape for a quiet month; five mediocre headlines bury the one that matters.
 - Do not force examples. Sections about fixes, platform support, parser internals, or UI often read better with none.
 - Get numbers from the PR, with their real scope, and keep the PR's own caveats.
 - Keep implementation detail out of prose; keep compiled-output examples illustrative.


### PR DESCRIPTION
Reworks the newsletter into a tiered layout: 0-5 standalone headline sections up front, then `## Improvements` and `## Fixes` buckets, then `## Community`. Codifies the structure in the newsletter skill and applies it to the January-June 2026 editions.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qeLp1GuCrS17TiBKRAwkW)_