### PR TITLE
docs: add `<show>` core tag reference

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -23,6 +23,51 @@ Expressions in the if/else chain are evaluated in order.
 </else>
 ```
 
+> [!TIP]
+> The content of an `<if>` is discarded when its condition stops matching, and rebuilt with fresh state when it matches again. To toggle the visibility of content while preserving its state, use [`<show>`](#show).
+
+## `<show>`
+
+The `<show>` tag toggles whether its [content](./language.md#tag-content) is displayed. The content is displayed when the `value=` attribute ([shorthand used below](./language.md#shorthand-value)) is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) and hidden otherwise.
+
+```marko
+<show=EXPRESSION>
+  Body
+</show>
+```
+
+Unlike [`<if>`](#if--else), the content of a `<show>` is always rendered and stays mounted. The value only controls whether the content's nodes are in the document, so state within the content, including [tag variables](./language.md#tag-variables), form values, and the DOM nodes themselves, persists across toggles.
+
+```marko
+<let/showFilters=false>
+
+<button onClick() { showFilters = !showFilters }>
+  Filters
+</button>
+
+<show=showFilters>
+  <input type="search" name="brand" placeholder="Brand">
+  <select name="condition">
+    <option>New</option>
+    <option>Used</option>
+  </select>
+</show>
+```
+
+Collapsing this filter panel keeps whatever was typed and selected, and reopening it picks up exactly where things were left. With an `<if>` in its place, the inputs would be discarded when hidden and recreated empty when displayed again.
+
+Since the content always exists exactly once, the compiler builds it directly into the surrounding template rather than splitting it into a conditional branch. This also changes what a stateful condition ships to the browser: an `<if>` whose condition can change client side must bundle its content so the branch can be rendered from scratch, but a changing `<show>` value never requires the content's template, only a small helper that moves the already rendered nodes. When the value is statically known, the tag compiles to plain markup with no runtime at all.
+
+> [!TIP]
+> Prefer `<show>` for content that toggles often, holds state worth keeping (form fields, stateful components, or an expensive-to-initialize [`<lifecycle>`](#lifecycle) widget, which mounts once and survives toggles), or is bulky markup that should not have to ship to the browser just to be toggled. Prefer [`<if>`](#if--else) when hidden content should not render at all, such as content that is costly to create, rarely revealed, or should not be present in the server rendered HTML.
+
+<!---->
+
+> [!NOTE]
+> Hidden content still renders on the server and is sent to the browser inside a wrapper element with the [`hidden` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), which allows it to resume without re-rendering. Once the value changes in the browser, hidden content is instead detached from the document entirely. Because hiding removes the content's nodes from the document rather than hiding them with CSS, transient state such as focus and text selection does not survive being hidden.
+
+The `<show>` tag requires [content](./language.md#tag-content) and accepts only the `value=` attribute. It has no `<else>` counterpart, and unlike `<if>` it cannot be used to apply [attribute tags](./language.md#attribute-tags).
+
 ## `<for>`
 
 The `<for>` control flow tag allows for writing content or applying [attribute tags](./language.md#attribute-tags) while iterating. Its [content](./language.md#tag-content) has access to information about each iteration through the [Tag Parameters](./language.md#tag-parameters).


### PR DESCRIPTION
Documents the new `<show>` core tag added in [marko-js/marko#2452476](https://github.com/marko-js/marko/commit/2452476eb39a1545440a52608e2263fadc628f59) (runtime-tags / Marko 6).

## Changes

- Adds a `## <show>` section to the Core Tags reference, placed directly after `<if>` / `<else>`. The `#show` anchor matches the URLs the compiler already emits in error messages and editor autocomplete.
- Covers the state-preserving toggle behavior (content always rendered and kept mounted; tag variables, form values, and DOM nodes persist across toggles) with a collapsible filter panel example.
- Documents the compile-time handling: the body compiles inline into the surrounding template, a resumed page never loads the body's template to toggle it, and a statically known value compiles to plain markup with no runtime.
- Adds a TIP with decision guidance between `<show>` and `<if>` in both directions, and a NOTE on server rendering of hidden content (`hidden`-attribute wrapper, detachment after the first client-side change, focus/selection not surviving being hidden).
- Adds a TIP at the end of the `<if>` / `<else>` section pointing to `<show>` when content state should survive being hidden.
- Notes the tag's constraints: requires body content, accepts only `value=`, no `<else>` counterpart, no attribute tags.

`markdownlint`, `cspell`, and `prettier --check` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gMGtwXQbXb898SF6zDx4q

---
_Generated by [Claude Code](https://claude.ai/code/session_012gMGtwXQbXb898SF6zDx4q)_