### PR TITLE
docs: document dynamic values in the `<style>` tag

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -68,6 +68,7 @@
     "touchstart",
     "tsrx",
     "TTFB",
+    "unitless",
     "webkitdirectory",
     "webp",
     "WHATWG"

--- a/docs/guide/styling.md
+++ b/docs/guide/styling.md
@@ -75,6 +75,30 @@ You may still provide a custom file extension to enable to use of preprocessors.
 <div class=styles.fancy>Hello</div>
 ```
 
+### Dynamic Values
+
+A `<style>` tag may contain dynamic values, written as `${...}` interpolations, keeping state-driven styling next to the rest of the stylesheet.
+
+```marko
+<let/hue=200>
+
+<style>
+  .swatch {
+    /* Updates whenever `hue` changes */
+    background: hsl(${hue} 80% 50%);
+    border-radius: 4px;
+  }
+</style>
+
+<input type="range" min="0" max="360" value:parseFloat:=hue>
+<div class="swatch"/>
+```
+
+The stylesheet is still extracted and bundled once. Each interpolation compiles to a [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) whose value Marko keeps up to date as state changes.
+
+> [!NOTE]
+> Dynamic values are only supported where css expects a declaration value, and apply to elements rendered after the `<style>` tag. See the [`<style>` reference](../reference/core-tag.md#dynamic-values) for details.
+
 ## Auto-Discovered Styles
 
 Styling files adjacent a [custom tag are automatically discovered](../reference/custom-tag.md#supporting-files). These files are imported and processed the same as [inline styles](#inline-styles).

--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -387,6 +387,45 @@ If the `<style>` tag has a [Tag Variable](./language.md#tag-variables), it lever
 <div.${styles.foo} />
 ```
 
+### Dynamic Values
+
+The `<style>` tag also supports dynamic values, written as `${...}` interpolations.
+
+```marko
+<style>
+  .toast {
+    border-color: ${input.tone};
+    animation-duration: calc(${input.delay} * 1ms);
+  }
+</style>
+
+<div class="toast">Saved!</div>
+```
+
+The stylesheet itself remains fully static. The compiler replaces each interpolation with a reference to a [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) and extracts the css into the bundle as usual. At runtime a small `<style>` element is rendered in place of the tag, assigning the custom property values to the elements after it. When state referenced by an interpolation changes, only the custom property values update.
+
+> [!NOTE]
+> Dynamic values only apply to elements rendered after the `<style>` tag, so it must be placed above the content it styles. The compiler warns when renderable content precedes the tag.
+
+Dynamic values are escaped, so arbitrary user input cannot break out of the stylesheet.
+
+Because custom properties only resolve where css expects a declaration value, interpolations cannot appear in selectors, at-rule preludes, property names, or quoted strings. The compiler reports an error in these positions.
+
+A unit also cannot be written directly against an interpolation (`${size}px` would produce invalid css, since css does not re-tokenize the substituted value). Include the unit in the value itself, or multiply by one unit with `calc()`:
+
+```marko
+<style>
+  .dropzone {
+    /* The value resolves to complete css, e.g. "2px dashed teal" */
+    outline: ${input.outline};
+    /* Or multiply a unitless number by one unit */
+    outline-offset: calc(${input.offset} * 1px);
+  }
+</style>
+
+<div class="dropzone">Drop files here</div>
+```
+
 > [!TIP]
 > There are very few cases where you should be using a _real_ inline `<style>` tag but if needed you can use the fallback [`<html-style>`](#html-script--html-style) tag.
 


### PR DESCRIPTION
Documents the new `${...}` interpolation support in `<style>` tags introduced in marko-js/marko#3309.

## Changes

- **`docs/reference/core-tag.md`**: Adds a "Dynamic Values" subsection to the `<style>` reference covering:
  - Basic `${...}` interpolation syntax with an example
  - How it works under the hood (interpolations compile to CSS custom property references, the stylesheet stays static and bundled, only property values update reactively)
  - Escaping of interpolated values
  - Positional constraints (declaration values only; not selectors, at-rule preludes, property names, or quoted strings)
  - The glued-unit restriction, with the `calc()` and value-includes-unit workarounds
  - A note on placement (dynamic values only apply to elements rendered after the tag)
- **`docs/guide/styling.md`**: Adds a "Dynamic Values" section under Inline Styles with a state-driven example, cross-linking to the reference for details.
- **`cspell.json`**: Adds "unitless" to the word list.

Verified with `npm run lint` and a full `npm run build` (anchors and cross-links resolve in the rendered output).

---
_Generated by [Claude Code](https://claude.ai/code/session_0166GMLW1jVyrSnaXtu3jENH)_