### PR TITLE
Fix Open Graph banner overflow crushing the bottom stripe

### DIFF
--- a/src/util/og-banner.ts
+++ b/src/util/og-banner.ts
@@ -152,6 +152,7 @@ function frame(accent: string, content: Element[]): Element {
             style: {
               height: 14,
               width: "100%",
+              flexShrink: 0,
               backgroundImage: chevronStripe,
             },
           },
@@ -217,7 +218,7 @@ function docsBanner(
             type: "div",
             props: {
               style: {
-                fontSize: title.length > 60 ? 52 : title.length > 32 ? 64 : 84,
+                fontSize: title.length > 60 ? 52 : title.length > 22 ? 64 : 84,
                 fontWeight: 700,
                 lineHeight: 1.12,
                 letterSpacing: -1,


### PR DESCRIPTION
Titles up to 32 characters rendered at 84px, but that size only fits ~22 characters on one line, so titles like "Components and Reactivity" wrapped, overflowed the 630px canvas, and flexbox shrank the bottom chevron stripe to nothing while cramming the footer under the title. The 84px tier now cuts off at 22 characters and the stripe is `flexShrink: 0` so it can never absorb overflow. Verified by pixel-checking all 46 regenerated banners for an intact stripe and clean bottom padding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsjXpuSV2pPrYLGJUrbb6e)_