### PR TITLE
docs: correct interop heuristics and document unescaped placeholders

### DIFF
--- a/docs/guide/marko-5-interop.md
+++ b/docs/guide/marko-5-interop.md
@@ -4,7 +4,7 @@
 >
 > - `marko@6` is _not_ backward compatible
 > - `marko@5` is **forward compatible**
-> - In Marko 5, heuristics determine runtime version per-tag
+> - In Marko 5, heuristics determine the runtime version per file
 
 [Marko 5](https://v5.markojs.com/) uses the [Class API](https://v5.markojs.com/docs/class-components/), and current versions use the [Tags API](../reference/language.md). Marko 6 is _not_ backwards compatible, so if `marko@6` is installed an application cannot use class components out of the box. Instead, Marko 5 is **forward compatible**. To use multiple versions of Marko together, ensure that Marko 5 is installed at the project root.
 
@@ -15,11 +15,13 @@ Marko 5 and 6 use runtimes which are **interoperable** but **distinct**. As such
 The Marko 5 compiler uses a set of heuristics to determine which runtime a template should be compiled to.
 
 > [!NOTE]
-> These rules are listed in order of precedence, so once _one_ is satisfied none of the others are checked.
+> Each `.marko` file is classified as a whole: the compiler scans the entire template and the first signal found determines the file's API. Signals from _both_ APIs in the same file cause a compile error ("Cannot mix Tags API and Class API features in the same file"), so an explicit opt-in comment cannot override conflicting syntax.
 
 ### Directory Name
 
 In Marko 5 and below custom tags were [auto-discovered](../reference/custom-tag.md#relative-custom-tags) from `/components` directories, but in Marko 6 they are discovered from `/tags`. Since `/tags` is new to Marko 6, `.marko` files under `/tags` **must** use the Tags API.
+
+There are two exceptions: files inside a `components/` directory nested within `/tags` are treated as Class API (which allows vendored Class API code to live inside a tags tree), and directories registered through a `marko.json` [`tags-dir`](https://v5.markojs.com/docs/marko-json/) are not affected by this rule.
 
 ### Comment Opt-In
 
@@ -46,8 +48,11 @@ If an otherwise ambiguous file contains any of the following syntax, it is detec
 - A [`style {}` block](https://v5.markojs.com/docs/class-components/#styles)
 - Inline JS in a [`$ scriptlet;`](https://v5.markojs.com/docs/syntax/#inline-javascript)
 - An [Attribute argument](https://v5.markojs.com/docs/syntax/#arguments) (`<button onClick("handleClick")>`)
-- Any of [these tags](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/translator/interop/feature-detection.ts#L182-L190):
+- Any of [these tags](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/translator/interop/feature-detection.ts#L180-L188):
   - `<await-reorderer>` `<class>` `<include-html>` `<include-text>` `<init-components>` `<macro>` `<module-code>` `<while>`
+
+> [!NOTE]
+> `static`, `server`, and `client` statements are shared by both APIs and are not detection signals.
 
 ### Tags API Syntax
 
@@ -55,7 +60,7 @@ If an otherwise ambiguous file contains any of the following syntax, it is detec
 
 - A [tag variable](../reference/language.md#tag-variables) (`<div/var>`)
 - The [bind shorthand](../reference/language.md#shorthand-change-handlers-two-way-binding) (`:=`)
-- Any of [these tags](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/translator/interop/feature-detection.ts#L191-L200):
+- Any of [these tags](https://github.com/marko-js/marko/blob/main/packages/runtime-tags/src/translator/interop/feature-detection.ts#L189-L198):
   - `<const>` `<debug>` `<define>` `<id>` `<let>` `<lifecycle>` `<log>` `<return>` `<try>`
 
 ```marko
@@ -89,3 +94,7 @@ src/
   tags/
     some-tag.marko
 ```
+
+## Limitations
+
+Attributes, [content](../reference/language.md#tag-content), [attribute tags](../reference/language.md#attribute-tags), and [tag parameters](../reference/language.md#tag-parameters) all cross between the runtimes. A pending promise does not: when content containing an unsettled [`<await>`](../reference/core-tag.md#await) crosses between the runtimes, rendering fails with `Cannot serialize promise across tags/class compat layer`. Keep each `<await>` and the content it renders within a single API.

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -421,6 +421,23 @@ export interface Input {
 > [!NOTE]
 > The interpolated value is automatically escaped to avoid [XSS](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XSS).
 
+#### Unescaped Text
+
+Prefixing the interpolation with `!` outputs the value without escaping. This is intended for markup that was already generated and sanitized elsewhere, such as compiled markdown.
+
+```marko
+export interface Input {
+  articleHtml: string;
+}
+
+<article>
+  $!{input.articleHtml}
+</article>
+```
+
+> [!CAUTION]
+> Unescaped interpolations are written into the document as-is, so untrusted values expose the page to [XSS](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XSS). Never use `$!{...}` with user-provided content.
+
 ## Attribute Tags
 
 Tags prefixed with an `@` are not rendered, but instead passed alongside attributes in [`input`](./language.md#input). Attribute tags allow for passing named or repeated [content](#tag-content) as additional attributes.


### PR DESCRIPTION
Aligns `docs/guide/marko-5-interop.md` with the actual behavior of `feature-detection.ts` in marko-js/marko, and fills a gap in the language reference. Verified against the compiler source and by compiling test files with the interop translator.

**`docs/guide/marko-5-interop.md`**

- The heuristics NOTE claimed the rules are checked in order of precedence with the first match winning. In reality each file is classified as a whole and signals from *both* APIs in one file are a compile error (`Cannot mix Tags API and Class API features in the same file`), so an opt-in comment cannot override conflicting syntax. The TLDR's "per-tag" wording is now "per file" to match.
- Notes that `static`, `server`, and `client` statements are shared by both APIs and are not detection signals.
- Documents the two exceptions to the `tags/` directory rule: a nested `components/` directory (vendored Class API code inside a tags tree) and `marko.json` `tags-dir` registrations.
- Adds a Limitations section covering the one thing that cannot cross the runtime boundary: a pending `<await>` (`Cannot serialize promise across tags/class compat layer`).
- Refreshes the `feature-detection.ts` line anchors, which had drifted (Class list now `#L180-L188`, Tags list `#L189-L198`).

**`docs/reference/language.md`**

- Documents unescaped placeholders (`$!{...}`) under Dynamic Text, with a CAUTION about XSS. Marko 6 fully supports them (`visitors/placeholder.ts` selects `_escape`/`_unescaped`), but the reference only mentioned `${...}` — leaving migrating Marko 5 users unable to confirm the syntax survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDH4Y2L2wqtYHgDMhcosqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDH4Y2L2wqtYHgDMhcosqy)_