### PR TITLE
fix: escape unescaped placeholder syntax in markdown code spans

### DIFF
--- a/src/util/markodown.ts
+++ b/src/util/markodown.ts
@@ -305,6 +305,7 @@ function markoDocs(): MarkedExtension {
       },
       codespan(token) {
         return `<code>${token.text
+          .replaceAll("$!{", "&#36;!{")
           .replaceAll("${", "&#36;{")
           .replaceAll("<", "&lt;")}</code>`;
       },


### PR DESCRIPTION
Fixes the site build, which is currently failing on `main` after #173.

The docs compiler's `codespan` renderer (`src/util/markodown.ts`) escapes `${` in inline code spans but not `$!{`. The unescaped placeholder syntax documented in #173 (`` `$!{...}` `` in the language reference's CAUTION) therefore reached the compiled `.marko` page raw, where Marko parses `$!{` as an unescaped placeholder open and fails with `CompileError: Unexpected token` (this is what failed the `deploy-preview` check on #173, and now fails `main`).

One line: also escape `$!{` as `&#36;!{`.

Verified locally: `npm run build` fails on `main` without this change and passes with it, and the built `docs/reference/language.html` renders `Never use <code>$!{...}</code>` as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDH4Y2L2wqtYHgDMhcosqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDH4Y2L2wqtYHgDMhcosqy)_