### PR TITLE
Add Wikipedia link to declarative programming

### DIFF
--- a/docs/introduction/welcome-to-marko.md
+++ b/docs/introduction/welcome-to-marko.md
@@ -15,7 +15,7 @@ Frameworks and languages for the web address these issues through concepts like 
 
 ## Declarative Language
 
-Marko embraces a declarative approach, allowing developers to describe what the UI should look like instead of how it should be rendered. This paradigm enables powerful compiler optimizations and simplifies state management.
+Marko embraces a [declarative approach](https://en.wikipedia.org/wiki/Declarative_programming), allowing developers to describe what the UI should look like instead of how it should be rendered. This paradigm enables powerful compiler optimizations and simplifies state management.
 
 ### Components
 


### PR DESCRIPTION
Link the declarative programming mention to its Wikipedia article.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrR2AcncY3p3LzeWsm2MxY)_