### PR TITLE
docs: note eager fallback for lazy imports without linkAssets

### DIFF
--- a/docs/reference/lazy-loading.md
+++ b/docs/reference/lazy-loading.md
@@ -172,3 +172,6 @@ import PriceChart from "<price-chart>" with { load: "visible.chart" }
 ## Bundler Support
 
 Lazy loading is coordinated with the bundler through the `linkAssets` compiler option. [`@marko/vite`](https://github.com/marko-js/vite) (and therefore [Marko Run](../marko-run/getting-started.md)) configures this automatically, so no setup is required.
+
+> [!NOTE]
+> Integrations that do not configure `linkAssets`, such as `@marko/vite` with `linked: false` (used by Storybook), cannot code-split. A `with { load }` import then compiles as a normal eager import, so templates that render a lazily-loaded component still build and render normally.


### PR DESCRIPTION
Clarifies in the lazy loading reference that integrations which do not configure `linkAssets` (eg `@marko/vite` with `linked: false`, as used by Storybook) compile `with { load }` imports as normal eager imports rather than erroring, so templates rendering a lazily-loaded component still build.

Documents the behavior added in marko-js/marko#3434.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjEbMyghdbGd5Ho4F4c6aG)_