### PR TITLE
Expand Marko Run documentation with new guides

### DIFF
--- a/.marko-run/routes.d.ts
+++ b/.marko-run/routes.d.ts
@@ -43,28 +43,29 @@ declare module "@marko/run" {
 		"/docs/introduction/welcome-to-marko": [M1, L1, L2, P31, D29];
 		"/docs/introduction/why-marko": [M1, L1, L2, P32, D30];
 		"/docs/marko-run/adapters": [M1, L1, L2, P33, D31];
-		"/docs/marko-run/data-loading": [M1, L1, L2, P34, D32];
-		"/docs/marko-run/file-based-routing": [M1, L1, L2, P35, D33];
-		"/docs/marko-run/getting-started": [M1, L1, L2, P36, D34];
-		"/docs/marko-run/runtime": [M1, L1, L2, P37, D35];
-		"/docs/marko-run/typescript": [M1, L1, L2, P38, D36];
-		"/docs/marko-run/validation": [M1, L1, L2, P39, D37];
-		"/docs/marko-run/vite-plugin": [M1, L1, L2, P40, D38];
-		"/docs/reference/concise-syntax": [M1, L1, L2, P41, D39];
-		"/docs/reference/core-tag": [M1, L1, L2, P42, D40];
-		"/docs/reference/custom-tag": [M1, L1, L2, P43, D41];
-		"/docs/reference/language": [M1, L1, L2, P44, D42];
-		"/docs/reference/lazy-loading": [M1, L1, L2, P45, D43];
-		"/docs/reference/native-tag": [M1, L1, L2, P46, D44];
-		"/docs/reference/reactivity": [M1, L1, L2, P47, D45];
-		"/docs/reference/supported-environments": [M1, L1, L2, P48, D46];
-		"/docs/reference/template": [M1, L1, L2, P49, D47];
-		"/docs/reference/typescript": [M1, L1, L2, P50, D48];
-		"/docs/tutorial/components-and-reactivity": [M1, L1, L2, P51, D49];
-		"/docs/tutorial/fundamentals": [M1, L1, L2, P52, D50];
+		"/docs/marko-run/cli": [M1, L1, L2, P34, D32];
+		"/docs/marko-run/data-loading": [M1, L1, L2, P35, D33];
+		"/docs/marko-run/file-based-routing": [M1, L1, L2, P36, D34];
+		"/docs/marko-run/getting-started": [M1, L1, L2, P37, D35];
+		"/docs/marko-run/runtime": [M1, L1, L2, P38, D36];
+		"/docs/marko-run/typescript": [M1, L1, L2, P39, D37];
+		"/docs/marko-run/validation": [M1, L1, L2, P40, D38];
+		"/docs/marko-run/vite-plugin": [M1, L1, L2, P41, D39];
+		"/docs/reference/concise-syntax": [M1, L1, L2, P42, D40];
+		"/docs/reference/core-tag": [M1, L1, L2, P43, D41];
+		"/docs/reference/custom-tag": [M1, L1, L2, P44, D42];
+		"/docs/reference/language": [M1, L1, L2, P45, D43];
+		"/docs/reference/lazy-loading": [M1, L1, L2, P46, D44];
+		"/docs/reference/native-tag": [M1, L1, L2, P47, D45];
+		"/docs/reference/reactivity": [M1, L1, L2, P48, D46];
+		"/docs/reference/supported-environments": [M1, L1, L2, P49, D47];
+		"/docs/reference/template": [M1, L1, L2, P50, D48];
+		"/docs/reference/typescript": [M1, L1, L2, P51, D49];
+		"/docs/tutorial/components-and-reactivity": [M1, L1, L2, P52, D50];
+		"/docs/tutorial/fundamentals": [M1, L1, L2, P53, D51];
 		"/docs/reference-full.md": [M1, H2];
 		"/docs/newsletter/feed.xml": [M1, H3];
-		"/playground": [L1, P53, D51];
+		"/playground": [L1, P54, D52];
 	}> {}
 }
 
@@ -78,7 +79,7 @@ declare module "../src/routes/docs/+middleware" {
   /** @deprecated use `Run` namespace instead */
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = $.Routes["/docs" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/docs/reference-full.md" | "/docs/newsletter/feed.xml"];
+    export type Route = $.Routes["/docs" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/cli" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/docs/reference-full.md" | "/docs/newsletter/feed.xml"];
     export type Context = $.MultiRouteContext<Route>;
     export type Handler = $.HandlerLike<Route>;
     export type GET = $.HandlerLike<Route, "GET">;
@@ -171,7 +172,7 @@ declare module "../src/routes/+layout.marko" {
   /** @deprecated use `Run` namespace instead */
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = $.Routes["/" | "/brand" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/playground"];
+    export type Route = $.Routes["/" | "/brand" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/cli" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/playground"];
     export type Context = Run.Context;
     export type Handler = $.HandlerLike<Route>;
     export type GET = $.HandlerLike<Route, "GET">;
@@ -195,7 +196,7 @@ declare module "../src/routes/docs/+layout.marko" {
   /** @deprecated use `Run` namespace instead */
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = $.Routes["/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals"];
+    export type Route = $.Routes["/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/cli" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals"];
     export type Context = Run.Context;
     export type Handler = $.HandlerLike<Route>;
     export type GET = $.HandlerLike<Route, "GET">;
@@ -967,11 +968,34 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/adapters+page.marko"
   }
 }
 
-type P34 = $.Template<"P34", typeof import("../src/routes/docs/_compiled-docs/marko-run/data-loading+page.marko")>;
-declare module "../src/routes/docs/_compiled-docs/marko-run/data-loading+page.marko" {
+type P34 = $.Template<"P34", typeof import("../src/routes/docs/_compiled-docs/marko-run/cli+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/cli+page.marko" {
   const Run: $.Namespace<P34>;
   namespace Run {
     type Context = $.ContextForFile<P34> & Marko.Global;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/docs/marko-run/cli"];
+    export type Context = Run.Context;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type P35 = $.Template<"P35", typeof import("../src/routes/docs/_compiled-docs/marko-run/data-loading+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/data-loading+page.marko" {
+  const Run: $.Namespace<P35>;
+  namespace Run {
+    type Context = $.ContextForFile<P35> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -990,11 +1014,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/data-loading+page.ma
   }
 }
 
-type P35 = $.Template<"P35", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko")>;
+type P36 = $.Template<"P36", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko" {
-  const Run: $.Namespace<P35>;
+  const Run: $.Namespace<P36>;
   namespace Run {
-    type Context = $.ContextForFile<P35> & Marko.Global;
+    type Context = $.ContextForFile<P36> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1013,11 +1037,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/file-based-routing+p
   }
 }
 
-type P36 = $.Template<"P36", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+page.marko")>;
+type P37 = $.Template<"P37", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/getting-started+page.marko" {
-  const Run: $.Namespace<P36>;
+  const Run: $.Namespace<P37>;
   namespace Run {
-    type Context = $.ContextForFile<P36> & Marko.Global;
+    type Context = $.ContextForFile<P37> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1036,11 +1060,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/getting-started+page
   }
 }
 
-type P37 = $.Template<"P37", typeof import("../src/routes/docs/_compiled-docs/marko-run/runtime+page.marko")>;
+type P38 = $.Template<"P38", typeof import("../src/routes/docs/_compiled-docs/marko-run/runtime+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/runtime+page.marko" {
-  const Run: $.Namespace<P37>;
+  const Run: $.Namespace<P38>;
   namespace Run {
-    type Context = $.ContextForFile<P37> & Marko.Global;
+    type Context = $.ContextForFile<P38> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1059,11 +1083,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/runtime+page.marko" 
   }
 }
 
-type P38 = $.Template<"P38", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko")>;
+type P39 = $.Template<"P39", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko" {
-  const Run: $.Namespace<P38>;
+  const Run: $.Namespace<P39>;
   namespace Run {
-    type Context = $.ContextForFile<P38> & Marko.Global;
+    type Context = $.ContextForFile<P39> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1082,11 +1106,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/typescript+page.mark
   }
 }
 
-type P39 = $.Template<"P39", typeof import("../src/routes/docs/_compiled-docs/marko-run/validation+page.marko")>;
+type P40 = $.Template<"P40", typeof import("../src/routes/docs/_compiled-docs/marko-run/validation+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/validation+page.marko" {
-  const Run: $.Namespace<P39>;
+  const Run: $.Namespace<P40>;
   namespace Run {
-    type Context = $.ContextForFile<P39> & Marko.Global;
+    type Context = $.ContextForFile<P40> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1105,11 +1129,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/validation+page.mark
   }
 }
 
-type P40 = $.Template<"P40", typeof import("../src/routes/docs/_compiled-docs/marko-run/vite-plugin+page.marko")>;
+type P41 = $.Template<"P41", typeof import("../src/routes/docs/_compiled-docs/marko-run/vite-plugin+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/vite-plugin+page.marko" {
-  const Run: $.Namespace<P40>;
+  const Run: $.Namespace<P41>;
   namespace Run {
-    type Context = $.ContextForFile<P40> & Marko.Global;
+    type Context = $.ContextForFile<P41> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1128,11 +1152,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/vite-plugin+page.mar
   }
 }
 
-type P41 = $.Template<"P41", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko")>;
+type P42 = $.Template<"P42", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko" {
-  const Run: $.Namespace<P41>;
+  const Run: $.Namespace<P42>;
   namespace Run {
-    type Context = $.ContextForFile<P41> & Marko.Global;
+    type Context = $.ContextForFile<P42> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1151,11 +1175,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/concise-syntax+page.
   }
 }
 
-type P42 = $.Template<"P42", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+page.marko")>;
+type P43 = $.Template<"P43", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/core-tag+page.marko" {
-  const Run: $.Namespace<P42>;
+  const Run: $.Namespace<P43>;
   namespace Run {
-    type Context = $.ContextForFile<P42> & Marko.Global;
+    type Context = $.ContextForFile<P43> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1174,11 +1198,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/core-tag+page.marko"
   }
 }
 
-type P43 = $.Template<"P43", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+page.marko")>;
+type P44 = $.Template<"P44", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/custom-tag+page.marko" {
-  const Run: $.Namespace<P43>;
+  const Run: $.Namespace<P44>;
   namespace Run {
-    type Context = $.ContextForFile<P43> & Marko.Global;
+    type Context = $.ContextForFile<P44> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1197,11 +1221,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/custom-tag+page.mark
   }
 }
 
-type P44 = $.Template<"P44", typeof import("../src/routes/docs/_compiled-docs/reference/language+page.marko")>;
+type P45 = $.Template<"P45", typeof import("../src/routes/docs/_compiled-docs/reference/language+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/language+page.marko" {
-  const Run: $.Namespace<P44>;
+  const Run: $.Namespace<P45>;
   namespace Run {
-    type Context = $.ContextForFile<P44> & Marko.Global;
+    type Context = $.ContextForFile<P45> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1220,11 +1244,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/language+page.marko"
   }
 }
 
-type P45 = $.Template<"P45", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+page.marko")>;
+type P46 = $.Template<"P46", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/lazy-loading+page.marko" {
-  const Run: $.Namespace<P45>;
+  const Run: $.Namespace<P46>;
   namespace Run {
-    type Context = $.ContextForFile<P45> & Marko.Global;
+    type Context = $.ContextForFile<P46> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1243,11 +1267,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/lazy-loading+page.ma
   }
 }
 
-type P46 = $.Template<"P46", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+page.marko")>;
+type P47 = $.Template<"P47", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/native-tag+page.marko" {
-  const Run: $.Namespace<P46>;
+  const Run: $.Namespace<P47>;
   namespace Run {
-    type Context = $.ContextForFile<P46> & Marko.Global;
+    type Context = $.ContextForFile<P47> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1266,11 +1290,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/native-tag+page.mark
   }
 }
 
-type P47 = $.Template<"P47", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+page.marko")>;
+type P48 = $.Template<"P48", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/reactivity+page.marko" {
-  const Run: $.Namespace<P47>;
+  const Run: $.Namespace<P48>;
   namespace Run {
-    type Context = $.ContextForFile<P47> & Marko.Global;
+    type Context = $.ContextForFile<P48> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1289,11 +1313,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/reactivity+page.mark
   }
 }
 
-type P48 = $.Template<"P48", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+page.marko")>;
+type P49 = $.Template<"P49", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/supported-environments+page.marko" {
-  const Run: $.Namespace<P48>;
+  const Run: $.Namespace<P49>;
   namespace Run {
-    type Context = $.ContextForFile<P48> & Marko.Global;
+    type Context = $.ContextForFile<P49> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1312,11 +1336,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/supported-environmen
   }
 }
 
-type P49 = $.Template<"P49", typeof import("../src/routes/docs/_compiled-docs/reference/template+page.marko")>;
+type P50 = $.Template<"P50", typeof import("../src/routes/docs/_compiled-docs/reference/template+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/template+page.marko" {
-  const Run: $.Namespace<P49>;
+  const Run: $.Namespace<P50>;
   namespace Run {
-    type Context = $.ContextForFile<P49> & Marko.Global;
+    type Context = $.ContextForFile<P50> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1335,11 +1359,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/template+page.marko"
   }
 }
 
-type P50 = $.Template<"P50", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+page.marko")>;
+type P51 = $.Template<"P51", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/typescript+page.marko" {
-  const Run: $.Namespace<P50>;
+  const Run: $.Namespace<P51>;
   namespace Run {
-    type Context = $.ContextForFile<P50> & Marko.Global;
+    type Context = $.ContextForFile<P51> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1358,11 +1382,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/typescript+page.mark
   }
 }
 
-type P51 = $.Template<"P51", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+page.marko")>;
+type P52 = $.Template<"P52", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+page.marko" {
-  const Run: $.Namespace<P51>;
+  const Run: $.Namespace<P52>;
   namespace Run {
-    type Context = $.ContextForFile<P51> & Marko.Global;
+    type Context = $.ContextForFile<P52> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1381,11 +1405,11 @@ declare module "../src/routes/docs/_compiled-docs/tutorial/components-and-reacti
   }
 }
 
-type P52 = $.Template<"P52", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.marko")>;
+type P53 = $.Template<"P53", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.marko" {
-  const Run: $.Namespace<P52>;
+  const Run: $.Namespace<P53>;
   namespace Run {
-    type Context = $.ContextForFile<P52> & Marko.Global;
+    type Context = $.ContextForFile<P53> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1404,11 +1428,11 @@ declare module "../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.mar
   }
 }
 
-type P53 = $.Template<"P53", typeof import("../src/routes/playground/+page.marko")>;
+type P54 = $.Template<"P54", typeof import("../src/routes/playground/+page.marko")>;
 declare module "../src/routes/playground/+page.marko" {
-  const Run: $.Namespace<P53>;
+  const Run: $.Namespace<P54>;
   namespace Run {
-    type Context = $.ContextForFile<P53> & Marko.Global;
+    type Context = $.ContextForFile<P54> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1480,23 +1504,24 @@ type D28 = $.Meta<"D28", typeof import("../src/routes/docs/_compiled-docs/introd
 type D29 = $.Meta<"D29", typeof import("../src/routes/docs/_compiled-docs/introduction/welcome-to-marko+meta.json")>;
 type D30 = $.Meta<"D30", typeof import("../src/routes/docs/_compiled-docs/introduction/why-marko+meta.json")>;
 type D31 = $.Meta<"D31", typeof import("../src/routes/docs/_compiled-docs/marko-run/adapters+meta.json")>;
-type D32 = $.Meta<"D32", typeof import("../src/routes/docs/_compiled-docs/marko-run/data-loading+meta.json")>;
-type D33 = $.Meta<"D33", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+meta.json")>;
-type D34 = $.Meta<"D34", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+meta.json")>;
-type D35 = $.Meta<"D35", typeof import("../src/routes/docs/_compiled-docs/marko-run/runtime+meta.json")>;
-type D36 = $.Meta<"D36", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+meta.json")>;
-type D37 = $.Meta<"D37", typeof import("../src/routes/docs/_compiled-docs/marko-run/validation+meta.json")>;
-type D38 = $.Meta<"D38", typeof import("../src/routes/docs/_compiled-docs/marko-run/vite-plugin+meta.json")>;
-type D39 = $.Meta<"D39", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+meta.json")>;
-type D40 = $.Meta<"D40", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+meta.json")>;
-type D41 = $.Meta<"D41", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+meta.json")>;
-type D42 = $.Meta<"D42", typeof import("../src/routes/docs/_compiled-docs/reference/language+meta.json")>;
-type D43 = $.Meta<"D43", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+meta.json")>;
-type D44 = $.Meta<"D44", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+meta.json")>;
-type D45 = $.Meta<"D45", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+meta.json")>;
-type D46 = $.Meta<"D46", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+meta.json")>;
-type D47 = $.Meta<"D47", typeof import("../src/routes/docs/_compiled-docs/reference/template+meta.json")>;
-type D48 = $.Meta<"D48", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+meta.json")>;
-type D49 = $.Meta<"D49", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+meta.json")>;
-type D50 = $.Meta<"D50", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+meta.json")>;
-type D51 = $.Meta<"D51", typeof import("../src/routes/playground/+meta.json")>;
+type D32 = $.Meta<"D32", typeof import("../src/routes/docs/_compiled-docs/marko-run/cli+meta.json")>;
+type D33 = $.Meta<"D33", typeof import("../src/routes/docs/_compiled-docs/marko-run/data-loading+meta.json")>;
+type D34 = $.Meta<"D34", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+meta.json")>;
+type D35 = $.Meta<"D35", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+meta.json")>;
+type D36 = $.Meta<"D36", typeof import("../src/routes/docs/_compiled-docs/marko-run/runtime+meta.json")>;
+type D37 = $.Meta<"D37", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+meta.json")>;
+type D38 = $.Meta<"D38", typeof import("../src/routes/docs/_compiled-docs/marko-run/validation+meta.json")>;
+type D39 = $.Meta<"D39", typeof import("../src/routes/docs/_compiled-docs/marko-run/vite-plugin+meta.json")>;
+type D40 = $.Meta<"D40", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+meta.json")>;
+type D41 = $.Meta<"D41", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+meta.json")>;
+type D42 = $.Meta<"D42", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+meta.json")>;
+type D43 = $.Meta<"D43", typeof import("../src/routes/docs/_compiled-docs/reference/language+meta.json")>;
+type D44 = $.Meta<"D44", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+meta.json")>;
+type D45 = $.Meta<"D45", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+meta.json")>;
+type D46 = $.Meta<"D46", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+meta.json")>;
+type D47 = $.Meta<"D47", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+meta.json")>;
+type D48 = $.Meta<"D48", typeof import("../src/routes/docs/_compiled-docs/reference/template+meta.json")>;
+type D49 = $.Meta<"D49", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+meta.json")>;
+type D50 = $.Meta<"D50", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+meta.json")>;
+type D51 = $.Meta<"D51", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+meta.json")>;
+type D52 = $.Meta<"D52", typeof import("../src/routes/playground/+meta.json")>;

--- a/.marko-run/routes.d.ts
+++ b/.marko-run/routes.d.ts
@@ -42,24 +42,29 @@ declare module "@marko/run" {
 		"/docs/introduction/integrations": [M1, L1, L2, P30, D28];
 		"/docs/introduction/welcome-to-marko": [M1, L1, L2, P31, D29];
 		"/docs/introduction/why-marko": [M1, L1, L2, P32, D30];
-		"/docs/marko-run/file-based-routing": [M1, L1, L2, P33, D31];
-		"/docs/marko-run/getting-started": [M1, L1, L2, P34, D32];
-		"/docs/marko-run/typescript": [M1, L1, L2, P35, D33];
-		"/docs/reference/concise-syntax": [M1, L1, L2, P36, D34];
-		"/docs/reference/core-tag": [M1, L1, L2, P37, D35];
-		"/docs/reference/custom-tag": [M1, L1, L2, P38, D36];
-		"/docs/reference/language": [M1, L1, L2, P39, D37];
-		"/docs/reference/lazy-loading": [M1, L1, L2, P40, D38];
-		"/docs/reference/native-tag": [M1, L1, L2, P41, D39];
-		"/docs/reference/reactivity": [M1, L1, L2, P42, D40];
-		"/docs/reference/supported-environments": [M1, L1, L2, P43, D41];
-		"/docs/reference/template": [M1, L1, L2, P44, D42];
-		"/docs/reference/typescript": [M1, L1, L2, P45, D43];
-		"/docs/tutorial/components-and-reactivity": [M1, L1, L2, P46, D44];
-		"/docs/tutorial/fundamentals": [M1, L1, L2, P47, D45];
+		"/docs/marko-run/adapters": [M1, L1, L2, P33, D31];
+		"/docs/marko-run/data-loading": [M1, L1, L2, P34, D32];
+		"/docs/marko-run/file-based-routing": [M1, L1, L2, P35, D33];
+		"/docs/marko-run/getting-started": [M1, L1, L2, P36, D34];
+		"/docs/marko-run/runtime": [M1, L1, L2, P37, D35];
+		"/docs/marko-run/typescript": [M1, L1, L2, P38, D36];
+		"/docs/marko-run/validation": [M1, L1, L2, P39, D37];
+		"/docs/marko-run/vite-plugin": [M1, L1, L2, P40, D38];
+		"/docs/reference/concise-syntax": [M1, L1, L2, P41, D39];
+		"/docs/reference/core-tag": [M1, L1, L2, P42, D40];
+		"/docs/reference/custom-tag": [M1, L1, L2, P43, D41];
+		"/docs/reference/language": [M1, L1, L2, P44, D42];
+		"/docs/reference/lazy-loading": [M1, L1, L2, P45, D43];
+		"/docs/reference/native-tag": [M1, L1, L2, P46, D44];
+		"/docs/reference/reactivity": [M1, L1, L2, P47, D45];
+		"/docs/reference/supported-environments": [M1, L1, L2, P48, D46];
+		"/docs/reference/template": [M1, L1, L2, P49, D47];
+		"/docs/reference/typescript": [M1, L1, L2, P50, D48];
+		"/docs/tutorial/components-and-reactivity": [M1, L1, L2, P51, D49];
+		"/docs/tutorial/fundamentals": [M1, L1, L2, P52, D50];
 		"/docs/reference-full.md": [M1, H2];
 		"/docs/newsletter/feed.xml": [M1, H3];
-		"/playground": [L1, P48, D46];
+		"/playground": [L1, P53, D51];
 	}> {}
 }
 
@@ -73,7 +78,7 @@ declare module "../src/routes/docs/+middleware" {
   /** @deprecated use `Run` namespace instead */
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = $.Routes["/docs" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/docs/reference-full.md" | "/docs/newsletter/feed.xml"];
+    export type Route = $.Routes["/docs" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/docs/reference-full.md" | "/docs/newsletter/feed.xml"];
     export type Context = $.MultiRouteContext<Route>;
     export type Handler = $.HandlerLike<Route>;
     export type GET = $.HandlerLike<Route, "GET">;
@@ -166,7 +171,7 @@ declare module "../src/routes/+layout.marko" {
   /** @deprecated use `Run` namespace instead */
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = $.Routes["/" | "/brand" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/playground"];
+    export type Route = $.Routes["/" | "/brand" | "/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals" | "/playground"];
     export type Context = Run.Context;
     export type Handler = $.HandlerLike<Route>;
     export type GET = $.HandlerLike<Route, "GET">;
@@ -190,7 +195,7 @@ declare module "../src/routes/docs/+layout.marko" {
   /** @deprecated use `Run` namespace instead */
   namespace MarkoRun {
     export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
-    export type Route = $.Routes["/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/typescript" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals"];
+    export type Route = $.Routes["/docs/newsletter" | "/docs/newsletter/april-2026" | "/docs/newsletter/february-2026" | "/docs/newsletter/january-2026" | "/docs/newsletter/june-2026" | "/docs/newsletter/march-2026" | "/docs/newsletter/may-2026" | "/docs/explanation/class-vs-tags-api" | "/docs/explanation/controllable-components" | "/docs/explanation/fine-grained-bundling" | "/docs/explanation/immutable-state" | "/docs/explanation/let-vs-const" | "/docs/explanation/nested-reactivity" | "/docs/explanation/optimizing-performance" | "/docs/explanation/separation-of-concerns" | "/docs/explanation/serializable-state" | "/docs/explanation/streaming" | "/docs/explanation/targeted-compilation" | "/docs/explanation/why-is-marko-fast" | "/docs/guide/duplicate-form-submissions" | "/docs/guide/library-integration" | "/docs/guide/low-level-apis" | "/docs/guide/marko-5-interop" | "/docs/guide/publishing-components" | "/docs/guide/styling" | "/docs/introduction/getting-started" | "/docs/introduction/installation" | "/docs/introduction/integrations" | "/docs/introduction/welcome-to-marko" | "/docs/introduction/why-marko" | "/docs/marko-run/adapters" | "/docs/marko-run/data-loading" | "/docs/marko-run/file-based-routing" | "/docs/marko-run/getting-started" | "/docs/marko-run/runtime" | "/docs/marko-run/typescript" | "/docs/marko-run/validation" | "/docs/marko-run/vite-plugin" | "/docs/reference/concise-syntax" | "/docs/reference/core-tag" | "/docs/reference/custom-tag" | "/docs/reference/language" | "/docs/reference/lazy-loading" | "/docs/reference/native-tag" | "/docs/reference/reactivity" | "/docs/reference/supported-environments" | "/docs/reference/template" | "/docs/reference/typescript" | "/docs/tutorial/components-and-reactivity" | "/docs/tutorial/fundamentals"];
     export type Context = Run.Context;
     export type Handler = $.HandlerLike<Route>;
     export type GET = $.HandlerLike<Route, "GET">;
@@ -939,11 +944,57 @@ declare module "../src/routes/docs/_compiled-docs/introduction/why-marko+page.ma
   }
 }
 
-type P33 = $.Template<"P33", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko")>;
-declare module "../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko" {
+type P33 = $.Template<"P33", typeof import("../src/routes/docs/_compiled-docs/marko-run/adapters+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/adapters+page.marko" {
   const Run: $.Namespace<P33>;
   namespace Run {
     type Context = $.ContextForFile<P33> & Marko.Global;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/docs/marko-run/adapters"];
+    export type Context = Run.Context;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type P34 = $.Template<"P34", typeof import("../src/routes/docs/_compiled-docs/marko-run/data-loading+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/data-loading+page.marko" {
+  const Run: $.Namespace<P34>;
+  namespace Run {
+    type Context = $.ContextForFile<P34> & Marko.Global;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/docs/marko-run/data-loading"];
+    export type Context = Run.Context;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type P35 = $.Template<"P35", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/file-based-routing+page.marko" {
+  const Run: $.Namespace<P35>;
+  namespace Run {
+    type Context = $.ContextForFile<P35> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -962,11 +1013,11 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/file-based-routing+p
   }
 }
 
-type P34 = $.Template<"P34", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+page.marko")>;
+type P36 = $.Template<"P36", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/marko-run/getting-started+page.marko" {
-  const Run: $.Namespace<P34>;
+  const Run: $.Namespace<P36>;
   namespace Run {
-    type Context = $.ContextForFile<P34> & Marko.Global;
+    type Context = $.ContextForFile<P36> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -985,11 +1036,34 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/getting-started+page
   }
 }
 
-type P35 = $.Template<"P35", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko")>;
-declare module "../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko" {
-  const Run: $.Namespace<P35>;
+type P37 = $.Template<"P37", typeof import("../src/routes/docs/_compiled-docs/marko-run/runtime+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/runtime+page.marko" {
+  const Run: $.Namespace<P37>;
   namespace Run {
-    type Context = $.ContextForFile<P35> & Marko.Global;
+    type Context = $.ContextForFile<P37> & Marko.Global;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/docs/marko-run/runtime"];
+    export type Context = Run.Context;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type P38 = $.Template<"P38", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/typescript+page.marko" {
+  const Run: $.Namespace<P38>;
+  namespace Run {
+    type Context = $.ContextForFile<P38> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1008,11 +1082,57 @@ declare module "../src/routes/docs/_compiled-docs/marko-run/typescript+page.mark
   }
 }
 
-type P36 = $.Template<"P36", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko")>;
-declare module "../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko" {
-  const Run: $.Namespace<P36>;
+type P39 = $.Template<"P39", typeof import("../src/routes/docs/_compiled-docs/marko-run/validation+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/validation+page.marko" {
+  const Run: $.Namespace<P39>;
   namespace Run {
-    type Context = $.ContextForFile<P36> & Marko.Global;
+    type Context = $.ContextForFile<P39> & Marko.Global;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/docs/marko-run/validation"];
+    export type Context = Run.Context;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type P40 = $.Template<"P40", typeof import("../src/routes/docs/_compiled-docs/marko-run/vite-plugin+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/marko-run/vite-plugin+page.marko" {
+  const Run: $.Namespace<P40>;
+  namespace Run {
+    type Context = $.ContextForFile<P40> & Marko.Global;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/docs/marko-run/vite-plugin"];
+    export type Context = Run.Context;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type P41 = $.Template<"P41", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko")>;
+declare module "../src/routes/docs/_compiled-docs/reference/concise-syntax+page.marko" {
+  const Run: $.Namespace<P41>;
+  namespace Run {
+    type Context = $.ContextForFile<P41> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1031,11 +1151,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/concise-syntax+page.
   }
 }
 
-type P37 = $.Template<"P37", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+page.marko")>;
+type P42 = $.Template<"P42", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/core-tag+page.marko" {
-  const Run: $.Namespace<P37>;
+  const Run: $.Namespace<P42>;
   namespace Run {
-    type Context = $.ContextForFile<P37> & Marko.Global;
+    type Context = $.ContextForFile<P42> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1054,11 +1174,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/core-tag+page.marko"
   }
 }
 
-type P38 = $.Template<"P38", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+page.marko")>;
+type P43 = $.Template<"P43", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/custom-tag+page.marko" {
-  const Run: $.Namespace<P38>;
+  const Run: $.Namespace<P43>;
   namespace Run {
-    type Context = $.ContextForFile<P38> & Marko.Global;
+    type Context = $.ContextForFile<P43> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1077,11 +1197,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/custom-tag+page.mark
   }
 }
 
-type P39 = $.Template<"P39", typeof import("../src/routes/docs/_compiled-docs/reference/language+page.marko")>;
+type P44 = $.Template<"P44", typeof import("../src/routes/docs/_compiled-docs/reference/language+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/language+page.marko" {
-  const Run: $.Namespace<P39>;
+  const Run: $.Namespace<P44>;
   namespace Run {
-    type Context = $.ContextForFile<P39> & Marko.Global;
+    type Context = $.ContextForFile<P44> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1100,11 +1220,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/language+page.marko"
   }
 }
 
-type P40 = $.Template<"P40", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+page.marko")>;
+type P45 = $.Template<"P45", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/lazy-loading+page.marko" {
-  const Run: $.Namespace<P40>;
+  const Run: $.Namespace<P45>;
   namespace Run {
-    type Context = $.ContextForFile<P40> & Marko.Global;
+    type Context = $.ContextForFile<P45> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1123,11 +1243,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/lazy-loading+page.ma
   }
 }
 
-type P41 = $.Template<"P41", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+page.marko")>;
+type P46 = $.Template<"P46", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/native-tag+page.marko" {
-  const Run: $.Namespace<P41>;
+  const Run: $.Namespace<P46>;
   namespace Run {
-    type Context = $.ContextForFile<P41> & Marko.Global;
+    type Context = $.ContextForFile<P46> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1146,11 +1266,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/native-tag+page.mark
   }
 }
 
-type P42 = $.Template<"P42", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+page.marko")>;
+type P47 = $.Template<"P47", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/reactivity+page.marko" {
-  const Run: $.Namespace<P42>;
+  const Run: $.Namespace<P47>;
   namespace Run {
-    type Context = $.ContextForFile<P42> & Marko.Global;
+    type Context = $.ContextForFile<P47> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1169,11 +1289,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/reactivity+page.mark
   }
 }
 
-type P43 = $.Template<"P43", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+page.marko")>;
+type P48 = $.Template<"P48", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/supported-environments+page.marko" {
-  const Run: $.Namespace<P43>;
+  const Run: $.Namespace<P48>;
   namespace Run {
-    type Context = $.ContextForFile<P43> & Marko.Global;
+    type Context = $.ContextForFile<P48> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1192,11 +1312,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/supported-environmen
   }
 }
 
-type P44 = $.Template<"P44", typeof import("../src/routes/docs/_compiled-docs/reference/template+page.marko")>;
+type P49 = $.Template<"P49", typeof import("../src/routes/docs/_compiled-docs/reference/template+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/template+page.marko" {
-  const Run: $.Namespace<P44>;
+  const Run: $.Namespace<P49>;
   namespace Run {
-    type Context = $.ContextForFile<P44> & Marko.Global;
+    type Context = $.ContextForFile<P49> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1215,11 +1335,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/template+page.marko"
   }
 }
 
-type P45 = $.Template<"P45", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+page.marko")>;
+type P50 = $.Template<"P50", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/reference/typescript+page.marko" {
-  const Run: $.Namespace<P45>;
+  const Run: $.Namespace<P50>;
   namespace Run {
-    type Context = $.ContextForFile<P45> & Marko.Global;
+    type Context = $.ContextForFile<P50> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1238,11 +1358,11 @@ declare module "../src/routes/docs/_compiled-docs/reference/typescript+page.mark
   }
 }
 
-type P46 = $.Template<"P46", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+page.marko")>;
+type P51 = $.Template<"P51", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+page.marko" {
-  const Run: $.Namespace<P46>;
+  const Run: $.Namespace<P51>;
   namespace Run {
-    type Context = $.ContextForFile<P46> & Marko.Global;
+    type Context = $.ContextForFile<P51> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1261,11 +1381,11 @@ declare module "../src/routes/docs/_compiled-docs/tutorial/components-and-reacti
   }
 }
 
-type P47 = $.Template<"P47", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.marko")>;
+type P52 = $.Template<"P52", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.marko")>;
 declare module "../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.marko" {
-  const Run: $.Namespace<P47>;
+  const Run: $.Namespace<P52>;
   namespace Run {
-    type Context = $.ContextForFile<P47> & Marko.Global;
+    type Context = $.ContextForFile<P52> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1284,11 +1404,11 @@ declare module "../src/routes/docs/_compiled-docs/tutorial/fundamentals+page.mar
   }
 }
 
-type P48 = $.Template<"P48", typeof import("../src/routes/playground/+page.marko")>;
+type P53 = $.Template<"P53", typeof import("../src/routes/playground/+page.marko")>;
 declare module "../src/routes/playground/+page.marko" {
-  const Run: $.Namespace<P48>;
+  const Run: $.Namespace<P53>;
   namespace Run {
-    type Context = $.ContextForFile<P48> & Marko.Global;
+    type Context = $.ContextForFile<P53> & Marko.Global;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -1359,19 +1479,24 @@ type D27 = $.Meta<"D27", typeof import("../src/routes/docs/_compiled-docs/introd
 type D28 = $.Meta<"D28", typeof import("../src/routes/docs/_compiled-docs/introduction/integrations+meta.json")>;
 type D29 = $.Meta<"D29", typeof import("../src/routes/docs/_compiled-docs/introduction/welcome-to-marko+meta.json")>;
 type D30 = $.Meta<"D30", typeof import("../src/routes/docs/_compiled-docs/introduction/why-marko+meta.json")>;
-type D31 = $.Meta<"D31", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+meta.json")>;
-type D32 = $.Meta<"D32", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+meta.json")>;
-type D33 = $.Meta<"D33", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+meta.json")>;
-type D34 = $.Meta<"D34", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+meta.json")>;
-type D35 = $.Meta<"D35", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+meta.json")>;
-type D36 = $.Meta<"D36", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+meta.json")>;
-type D37 = $.Meta<"D37", typeof import("../src/routes/docs/_compiled-docs/reference/language+meta.json")>;
-type D38 = $.Meta<"D38", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+meta.json")>;
-type D39 = $.Meta<"D39", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+meta.json")>;
-type D40 = $.Meta<"D40", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+meta.json")>;
-type D41 = $.Meta<"D41", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+meta.json")>;
-type D42 = $.Meta<"D42", typeof import("../src/routes/docs/_compiled-docs/reference/template+meta.json")>;
-type D43 = $.Meta<"D43", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+meta.json")>;
-type D44 = $.Meta<"D44", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+meta.json")>;
-type D45 = $.Meta<"D45", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+meta.json")>;
-type D46 = $.Meta<"D46", typeof import("../src/routes/playground/+meta.json")>;
+type D31 = $.Meta<"D31", typeof import("../src/routes/docs/_compiled-docs/marko-run/adapters+meta.json")>;
+type D32 = $.Meta<"D32", typeof import("../src/routes/docs/_compiled-docs/marko-run/data-loading+meta.json")>;
+type D33 = $.Meta<"D33", typeof import("../src/routes/docs/_compiled-docs/marko-run/file-based-routing+meta.json")>;
+type D34 = $.Meta<"D34", typeof import("../src/routes/docs/_compiled-docs/marko-run/getting-started+meta.json")>;
+type D35 = $.Meta<"D35", typeof import("../src/routes/docs/_compiled-docs/marko-run/runtime+meta.json")>;
+type D36 = $.Meta<"D36", typeof import("../src/routes/docs/_compiled-docs/marko-run/typescript+meta.json")>;
+type D37 = $.Meta<"D37", typeof import("../src/routes/docs/_compiled-docs/marko-run/validation+meta.json")>;
+type D38 = $.Meta<"D38", typeof import("../src/routes/docs/_compiled-docs/marko-run/vite-plugin+meta.json")>;
+type D39 = $.Meta<"D39", typeof import("../src/routes/docs/_compiled-docs/reference/concise-syntax+meta.json")>;
+type D40 = $.Meta<"D40", typeof import("../src/routes/docs/_compiled-docs/reference/core-tag+meta.json")>;
+type D41 = $.Meta<"D41", typeof import("../src/routes/docs/_compiled-docs/reference/custom-tag+meta.json")>;
+type D42 = $.Meta<"D42", typeof import("../src/routes/docs/_compiled-docs/reference/language+meta.json")>;
+type D43 = $.Meta<"D43", typeof import("../src/routes/docs/_compiled-docs/reference/lazy-loading+meta.json")>;
+type D44 = $.Meta<"D44", typeof import("../src/routes/docs/_compiled-docs/reference/native-tag+meta.json")>;
+type D45 = $.Meta<"D45", typeof import("../src/routes/docs/_compiled-docs/reference/reactivity+meta.json")>;
+type D46 = $.Meta<"D46", typeof import("../src/routes/docs/_compiled-docs/reference/supported-environments+meta.json")>;
+type D47 = $.Meta<"D47", typeof import("../src/routes/docs/_compiled-docs/reference/template+meta.json")>;
+type D48 = $.Meta<"D48", typeof import("../src/routes/docs/_compiled-docs/reference/typescript+meta.json")>;
+type D49 = $.Meta<"D49", typeof import("../src/routes/docs/_compiled-docs/tutorial/components-and-reactivity+meta.json")>;
+type D50 = $.Meta<"D50", typeof import("../src/routes/docs/_compiled-docs/tutorial/fundamentals+meta.json")>;
+type D51 = $.Meta<"D51", typeof import("../src/routes/playground/+meta.json")>;

--- a/cspell.json
+++ b/cspell.json
@@ -52,6 +52,7 @@
     "optgroup",
     "popovertarget",
     "recents",
+    "Referer",
     "renderable",
     "renderId",
     "reorder",
@@ -70,6 +71,7 @@
     "tsrx",
     "TTFB",
     "unitless",
+    "vite",
     "webkitdirectory",
     "webp",
     "WHATWG"

--- a/docs/marko-run/adapters.md
+++ b/docs/marko-run/adapters.md
@@ -1,0 +1,155 @@
+# Adapters
+
+Adapters change the development, build, and preview process to fit different deployment platforms and runtimes. Application code stays written in [web standard APIs](./runtime.md#context). By swapping the adapter, the same routes can be served by a Node process, deployed to an edge platform, or rendered to static files.
+
+## Choosing an Adapter
+
+[Marko Run's Vite plugin](./vite-plugin.md) resolves the adapter in this order:
+
+1. The `adapter` specified in the plugin options
+2. The first dependency in `package.json` whose name starts with `@marko/run-adapter` or contains `marko-run-adapter`
+3. The default Node-based adapter that ships with `@marko/run`
+
+For most applications, installing an adapter package is all that is needed. To configure an adapter (or choose between several installed ones), pass it to the plugin explicitly:
+
+```ts
+import { defineConfig } from "vite";
+import marko from "@marko/run/vite";
+import netlify from "@marko/run-adapter-netlify"; // Import the adapter
+
+export default defineConfig({
+  plugins: [
+    marko({
+      adapter: netlify({ edge: true }), // Configure and apply the adapter
+    }),
+  ],
+});
+```
+
+## Node
+
+[`@marko/run-adapter-node`](https://github.com/marko-js/run/tree/main/packages/adapters/node) previews and deploys apps on Connect-style servers such as Express.
+
+```sh
+npm install @marko/run-adapter-node
+```
+
+Beyond building a standalone server, this adapter provides middleware that converts Connect-style requests into [WHATWG requests](https://developer.mozilla.org/en-US/docs/Web/API/Request) and writes [WHATWG responses](https://developer.mozilla.org/en-US/docs/Web/API/Response) back. This lets an application mount its Marko Run routes inside an existing server.
+
+The **router middleware** fully handles requests that match a route:
+
+```ts
+import express from "express";
+import { routerMiddleware } from "@marko/run-adapter-node/middleware";
+
+express()
+  .use("/assets", express.static("assets"))
+  .use(routerMiddleware()) // register the router middleware
+  .listen(8080);
+```
+
+The **match middleware** instead attaches the matched route onto the request object, where it can be invoked later. This is useful when other middleware needs to run between finding a match and invoking the route:
+
+```ts
+import express from "express";
+import { matchMiddleware } from "@marko/run-adapter-node/middleware";
+
+express()
+  .use("/assets", express.static("assets"))
+  .use(matchMiddleware()) // register the match middleware
+  .use((req, res, next) => {
+    if (req.route) {
+      // `req.route.config` contains the route's metadata
+    }
+    next();
+  })
+  .use((req, res, next) => {
+    if (req.route) {
+      req.route.invoke(req, res, next); // finally invoke the route
+    } else {
+      next();
+    }
+  })
+  .listen(8080);
+```
+
+## Static
+
+[`@marko/run-adapter-static`](https://github.com/marko-js/run/tree/main/packages/adapters/static) builds the application into static files that can be served from any file server or CDN.
+
+```sh
+npm install @marko/run-adapter-static
+```
+
+At build time, the adapter renders every statically known route and crawls relative anchor links in the rendered pages to discover more. The `urls` option provides additional entry points beyond those discovered automatically:
+
+```ts
+import { defineConfig } from "vite";
+import marko from "@marko/run/vite";
+import staticAdapter from "@marko/run-adapter-static";
+
+export default defineConfig({
+  plugins: [
+    marko({
+      adapter: staticAdapter({
+        urls: ["/products/lamp", "/products/chair"],
+      }),
+    }),
+  ],
+});
+```
+
+> [!NOTE]
+> The `urls` option can also be an async function that receives the discovered routes and returns URL strings.
+
+## Netlify
+
+[`@marko/run-adapter-netlify`](https://github.com/marko-js/run/tree/main/packages/adapters/netlify) deploys apps to Netlify Functions or Edge Functions.
+
+```sh
+npm install @marko/run-adapter-netlify
+```
+
+Netlify applications require a [`netlify.toml`](https://docs.netlify.com/configure-builds/file-based-configuration/) configuration. This example is a starting point for apps deployed to Netlify Functions:
+
+```toml
+[build]
+  command = "marko-run build"
+  publish = "dist/public"
+  functions = "dist"
+```
+
+To build for [Edge Functions](https://docs.netlify.com/edge-functions/overview/) instead, configure the adapter with `edge: true`:
+
+```ts
+import { defineConfig } from "vite";
+import marko from "@marko/run/vite";
+import netlifyAdapter from "@marko/run-adapter-netlify";
+
+export default defineConfig({
+  plugins: [
+    marko({
+      adapter: netlifyAdapter({ edge: true }),
+    }),
+  ],
+});
+```
+
+and specify the `edge_functions` directory in `netlify.toml` instead of `functions`:
+
+```toml
+[build]
+  command = "marko-run build"
+  publish = "dist/public"
+  edge_functions = "dist"
+```
+
+## Custom Adapters
+
+An adapter is an object implementing the `Adapter` interface from `@marko/run/vite`, with hooks into the dev server, build, and preview lifecycle. The [official adapters](https://github.com/marko-js/run/tree/main/packages/adapters) serve as reference implementations.
+
+## Next Steps
+
+- [Vite Plugin](./vite-plugin.md)
+- [Runtime](./runtime.md#embedding)
+- [Getting Started](./getting-started.md#cli)

--- a/docs/marko-run/adapters.md
+++ b/docs/marko-run/adapters.md
@@ -152,4 +152,4 @@ An adapter is an object implementing the `Adapter` interface from `@marko/run/vi
 
 - [Vite Plugin](./vite-plugin.md)
 - [Runtime](./runtime.md#embedding)
-- [Getting Started](./getting-started.md#cli)
+- [CLI](./cli.md)

--- a/docs/marko-run/cli.md
+++ b/docs/marko-run/cli.md
@@ -1,0 +1,54 @@
+# CLI
+
+The `marko-run` CLI develops, builds, and previews Marko Run applications. It is installed with `@marko/run` and run with `npm exec marko-run` or from package.json scripts.
+
+The CLI has three commands: `dev`, `build`, and `preview`. All commands accept these options:
+
+| Option           | Description                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `-c`, `--config` | Path to a Vite config file (by default, looks for a `vite.config` file with a `.js`, `.cjs`, `.mjs`, `.ts`, or `.mts` extension) |
+| `-e`, `--env`    | Path to a dotenv file                                                                                                            |
+
+## `dev`
+
+Starts a development server in watch mode. This is the default command, so both of the following are equivalent:
+
+```sh
+npm exec marko-run
+npm exec marko-run dev
+```
+
+| Option         | Description                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `-p`, `--port` | Port to listen on (defaults: `server.port` then `preview.port` in the Vite config, the `PORT` env variable, or 3000) |
+
+## `build`
+
+Creates a production build.
+
+```sh
+npm exec marko-run build
+```
+
+| Option           | Description                                                                 |
+| ---------------- | --------------------------------------------------------------------------- |
+| `-o`, `--output` | Directory to write built files (default: `build.outDir` in the Vite config) |
+
+## `preview`
+
+Creates a production build and starts a production-like server.
+
+```sh
+npm exec marko-run preview
+```
+
+| Option           | Description                                                                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `-o`, `--output` | Directory to serve files from, and write built files to (default: `build.outDir` in the Vite config)                                |
+| `-p`, `--port`   | Port the server should listen on (defaults: `preview.port` then `server.port` in the Vite config, the `PORT` env variable, or 3000) |
+| `-f`, `--file`   | Output file to start                                                                                                                |
+
+## Next Steps
+
+- [Vite Plugin](./vite-plugin.md)
+- [Adapters](./adapters.md)

--- a/docs/marko-run/data-loading.md
+++ b/docs/marko-run/data-loading.md
@@ -1,0 +1,95 @@
+# Data Loading
+
+Handlers and middleware pass data to everything downstream, including pages and layouts, by calling `next` with an object. This is the primary way a page gets data that requires server-side work: fetching from a database, reading a session, or calling another service.
+
+## Passing Data
+
+Data passed to `next` is shallowly merged into `ctx.data`, which templates access as `$global.data`:
+
+```ts
+/* +handler.ts */
+export const GET = Run.GET((ctx, next) => {
+  return next({ user: loadUser(ctx.params.id) }); // pass the promise itself
+});
+```
+
+```marko
+/* +page.marko */
+<await|user|=$global.data.user>
+  <h1>Hello ${user.name}</h1>
+</await>
+```
+
+Each middleware and handler in the chain contributes to the same object. A root middleware can load data shared by every page, like the current session. Handlers then add data specific to their route.
+
+Note that `ctx.data` is populated per route and verb. With [generated types](./typescript.md#generated-types), each file sees the routes and verbs it actually participates in, so the type of `$global.data` in a page or layout reflects exactly the middleware and handlers that run before it.
+
+> [!WARNING]
+> The merge is shallow. A handler that passes `{ user: ... }` replaces any `user` value provided upstream instead of merging into it.
+
+## Promises over Awaiting
+
+Notice that the handler above does not `await` the data. Passing the promise and unwrapping it in the template with [`<await>`](../reference/core-tag.md#await) lets the response start [streaming](../explanation/streaming.md) immediately. Static markup, the document `<head>`, and anything else that does not depend on the data reach the browser while the data is still loading. Each `<await>` section then flushes as its promise resolves.
+
+Independent data sources are best kept as separate promises. Two `<await>` sections resolve independently, while awaiting both in a handler serializes them behind one another.
+
+> [!WARNING]
+> Avoid awaiting data in a `GET` handler before calling `next`. Every `await` before `next` holds back the entire response until that data resolves. This forfeits streaming and delays even the parts of the page that never needed the data. Pass the promise through `next` and let the template await it instead.
+
+## Rendering and Responses
+
+The `next` function renders the page for `GET`, `HEAD`, and `POST` requests where applicable, or returns a `204` response when there is no page. A handler decides what to do with that result:
+
+```ts
+export const GET = Run.GET((ctx, next) => {
+  if (!ctx.url.searchParams.has("beta")) {
+    return ctx.redirect("/request-access"); // never renders the page
+  }
+  return next({ features: loadBetaFeatures() });
+});
+```
+
+> [!NOTE]
+> A handler that always returns its own `Response` never renders the page, so its verb is excluded from the template's typed context.
+
+## Forms
+
+When a route has both a page and a `POST` handler, the handler calling `next` renders the page, so form submissions can be answered with HTML directly. A `POST` handler has two ways to respond, and they serve different purposes:
+
+- On success, when the user should move to a new screen or experience, respond with a [redirect](./runtime.md#redirect). This is the [Post/Redirect/Get](https://en.wikipedia.org/wiki/Post/Redirect/Get) pattern. The browser lands on an ordinary `GET` page, so refreshing does not resubmit the form and the URL can be shared or revisited safely.
+- Return `next()` to render the page from the `POST` itself. This is useful for rendering validation errors while keeping the submitted form intact, or for an ephemeral page that has no meaning outside this submission.
+
+```ts
+/* +handler.ts */
+export const POST = Run.POST(
+  { form: { validator: parseSignup } },
+  async (ctx, next) => {
+    const [signup, issues] = await ctx.body;
+    if (issues) {
+      return next({ issues }); // re-render the form with errors
+    }
+    await saveSignup(signup);
+    return ctx.redirect("/thanks"); // Post/Redirect/Get on success
+  },
+);
+```
+
+```marko
+/* +page.marko */
+<form method="post">
+  <if=$global.data.issues>
+    <p>Please correct the highlighted fields.</p>
+  </if>
+  <input name="email" type="email">
+  <button>Sign up</button>
+</form>
+```
+
+> [!WARNING]
+> A page rendered by returning `next()` from a `POST` is still a `POST` response. Refreshing it prompts the browser to resubmit the request, and the URL cannot be bookmarked or shared. Reserve it for error re-renders and ephemeral pages. Redirect whenever the submission succeeds and the user moves on.
+
+## Next Steps
+
+- [Validation](./validation.md#request-bodies)
+- [Runtime](./runtime.md#context-methods)
+- [Streaming](../explanation/streaming.md)

--- a/docs/marko-run/file-based-routing.md
+++ b/docs/marko-run/file-based-routing.md
@@ -1,28 +1,13 @@
 # File-based Routing
 
-## Routes Directory
+Marko Run discovers routes from the file system. The directory structure under the **routes directory**, `./src/routes`, determines the paths an application serves. A small set of `+` prefixed file names determines what happens at each path.
 
-The plugin looks for route files in the configured **routes directory**. By default, this is set to `./src/routes` relative to the Vite config file. This directory contains all the routing logic for the application.
-
-Here's how to configure a different routes directory:
-
-```ts
-/* vite.config.ts */
-import { defineConfig } from "vite";
-import marko from "@marko/run/vite";
-
-export default defineConfig({
-  plugins: [
-    marko({
-      routesDir: "src/pages", // Use `./src/pages` (relative to this file) as the routes directory
-    }),
-  ],
-});
-```
+> [!NOTE]
+> The `+` prefix makes routable files explicit. Anything without the prefix is ignored by the router, so components, tests, stories, and utilities can be colocated alongside the pages that use them without accidentally being served.
 
 ## Routable Files
 
-The router only recognizes certain filenames, all prefixed with `+`. The following filenames will be discovered in any directory inside your application’s [routes directory](#routes-directory).
+The router only recognizes certain filenames, all prefixed with `+`. The following filenames will be discovered in any directory inside the application's routes directory.
 
 ### `+page.marko`
 
@@ -30,11 +15,11 @@ These files establish a route at the current directory path, which will be serve
 
 ### `+layout.marko`
 
-These files provide a **layout component**, which will wrap all nested layouts and pages. Information is obtained from [`$global`](../reference/language.md#global) and `input`
-Layouts are like any other Marko component, with no extra constraints. Each layout receives the request, path params, URL, and route metadata as input, as well as a `content` which refers to the nested page that is being rendered.
+These files provide a **layout component**, which will wrap all nested layouts and pages.
+
+Layouts are like any other Marko component, with no extra constraints. Each layout receives a `content` input which refers to the nested page or layout being rendered. The [request context](./runtime.md#context) is available as [`$global`](../reference/language.md#global).
 
 ```marko
-/* +layout.marko */
 export interface Input {
   content: Marko.Body;
 }
@@ -42,88 +27,130 @@ export interface Input {
 <main>
   <h1>My Products</h1>
 
-  <${input.content}/> // render the page or layout here
+  // render the nested page or layout here
+  <${input.content}/>
 </main>
 ```
 
 ### `+handler.*`
 
-These files establish a route at the current directory path that can handle requests for `GET`, `POST`, `PUT`, and `DELETE` HTTP methods. <!-- TODO: what about HEAD? -->
+These files establish a route at the current directory path that can respond to any HTTP method: exported functions named `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `PATCH`, or `OPTIONS` handle requests with the matching method.
 
-Typically, these will be `.js` or `.ts` files, depending on your project. Like pages, only one handler for each method may exist for any served path. A handler should export functions
+Typically, these will be `.js` or `.ts` files, depending on the project. Like pages, only one handler file may exist for any served path.
 
-- Valid exports are functions named `GET`, `POST`, `PUT`, or `DELETE`.
-- Exports can be one of the following
-  - Handler function (see below)
-  - Array of handler functions - will be composed by calling them in order
-  - Promise that resolves to a handler function or an array of handler functions
-- Handler functions are synchronous or asynchronous functions that
+Handlers are created with the global [verb helpers](./validation.md#verb-helpers) (`Run.GET`, `Run.POST`, etc.), which add request validation, typed bodies, and [data loading](./data-loading.md):
 
-  - Receives a `context` and `next` argument,
-    - The `context` argument contains the WHATWG request object, path parameters, URL, and route metadata.
-    - The `next` argument will call the page for `GET` requests where applicable or return a `204` response.
-  - Return a WHATWG response, throw a WHATWG response, and return undefined. If the function returns undefined, the `next` argument will be automatically called and used as the response.
+```ts
+export const POST = Run.POST(async (ctx, next) => {
+  const { request, params, url, meta } = ctx;
+  return new Response("Successfully updated", { status: 200 });
+});
+```
 
-    ```ts
-    /* +handler.ts */
-    export function POST(context, next) {
-      const { request, params, url, meta } = context;
-      return new Response("Successfully updated", { status: 200 });
-    }
+Handler functions are synchronous or asynchronous functions that receive two arguments:
 
-    export async function GET(context, next) {
-      // do something before calling `next`
-      const response = await next();
-      return response;
-    }
-    ```
+- `ctx` contains the WHATWG request object, path parameters, URL, and route metadata (see [Context](./runtime.md#context))
+- `next` renders the page for `GET`, `HEAD`, and `POST` requests where applicable, or returns a `204` response. Pass it an object to [make data available](./data-loading.md) to downstream handlers and the page.
+
+A handler function may return (or throw) a WHATWG response, or return `undefined`. If the function returns `undefined`, `next` will be automatically called and used as the response.
+
+```ts
+export const GET = Run.GET(async (ctx, next) => {
+  // do something before rendering the page
+  const response = await next();
+  // do something with the response
+  return response;
+});
+
+export const PUT = Run.PUT((ctx, next) => {
+  // `next` will be called automatically since nothing is returned
+});
+
+export const DELETE = Run.DELETE((ctx, next) => {
+  return new Response("Successfully removed", { status: 204 });
+});
+```
+
+> [!NOTE]
+> When a route has no `HEAD` export, `HEAD` requests are served by the `GET` handler (or page) with the response body stripped.
 
 ### `+middleware.*`
 
-These files are like layouts, but for handlers. Middleware files are called before handlers and let you perform arbitrary work before and after.
+These files are like layouts, but for handlers. Middleware files are called before handlers and allow work to be performed before and after them.
+
+Middleware files expect a `default` export with the same shapes as handler exports: a handler function, an array of handler functions, or a promise resolving to either. Middleware is created with `Run.ALL` or a specific verb helper. It may also be options-only, e.g. `Run.ALL({ search: ... })`, to attach [validation](./validation.md) for every route below it without adding behavior.
+
+```ts
+export default Run.ALL(async (ctx, next) => {
+  const requestName = `${ctx.request.method} ${ctx.url.href}`;
+  let success = true;
+  console.log(`${requestName} request started`);
+  try {
+    return await next(); // Wait for subsequent middleware, handler, and page
+  } catch (err) {
+    success = false;
+    throw err;
+  } finally {
+    console.log(
+      `${requestName} completed ${success ? "successfully" : "with errors"}`,
+    );
+  }
+});
+```
 
 > [!NOTE]
-> Unlike handlers, middleware runs for all HTTP methods.
-
-- Expects a `default` export that can be one of the following
-  - Handler function (see below)
-  - Array of handler functions - will be composed by calling them in order
-  - Promise that resolves to a handler function or an array of handler functions
-- Handler functions are synchronous or asynchronous functions that
-
-  - Receives a `context` and `next` argument,
-    - The `context` argument contains the WHATWG request object, path parameters, URL, and route metadata.
-    - The `next` argument will call the page for `GET` requests where applicable or return a `204` response.
-  - Return a WHATWG response, throw a WHATWG response, and return undefined. If the function returns undefined, the `next` argument will be automatically called and used as the response.
-
-    ```ts
-    /* +middleware.ts */
-    export default async function (context, next) {
-      const requestName = `${context.request.method} ${context.url.href}`;
-      let success = true;
-      console.log(`${requestName} request started`);
-      try {
-        return await next(); // Wait for subsequent middleware, handler, and page
-      } catch (err) {
-        success = false;
-        throw err;
-      } finally {
-        console.log(
-          `${requestName} completed ${success ? "successfully" : "with errors"}`,
-        );
-      }
-    }
-    ```
+> Unlike handlers, middleware runs for all HTTP methods. Middleware created with `Run.ALL(...)` runs for every method, while middleware created with a specific verb helper (e.g. `Run.POST(...)`) is skipped for other methods.
 
 ### `+meta.*`
 
-These files represent static metadata to attach to the route. This metadata will be automatically provided on the route `context` when invoking a route.
+These files represent static metadata to attach to the route. This metadata will be automatically provided as `ctx.meta` when the route is invoked. When the file is a non-JSON file, its default export will be used.
+
+Metadata supports verb-specific overrides when it is an object (e.g. a JSON file or `export default { ... }`). Top-level keys that match one of `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `PATCH`, or `OPTIONS` are shallowly merged into the base object for requests of that method, overriding any existing values. These keys are excluded from the base object, and ignored when their value is not an object. For example, given a `+meta.json` file:
+
+```json
+{
+  "name": "Default Name",
+  "POST": {
+    "name": "Post Name",
+    "postOnlyData": "foo"
+  },
+  "GET": {
+    "name": "Get Name"
+  },
+  "PUT": "Ignored"
+}
+```
+
+for a `POST` request, the value of `ctx.meta` will be
+
+```js
+{
+  name: "Post Name",
+  postOnlyData: "foo"
+}
+```
+
+for a `GET` request, it will be
+
+```js
+{
+  name: "Get Name"
+}
+```
+
+and for all other methods, including `PUT`, it will be the base object
+
+```js
+{
+  name: "Default Name"
+}
+```
 
 ## Special Files
 
-In addition to the files above, which can be defined in any directory under the [routes directory](#routes-directory), some special files can only be defined at its top level. <!-- TODO: do we want to keep this restriction? Having nested 404s would be handy for disambiguating things like “there’s no user with that name” or “that promotion wasn’t found, it may have expired” -->
+In addition to the files above, which can be defined in any directory under the routes directory, some special files can only be defined at its top level.
 
-These special pages are subject to a root layout file (`pages/+layout.marko` in the default configuration).
+These special pages are subject to a root layout file (`src/routes/+layout.marko` in the default configuration).
 
 ### `+404.marko`
 
@@ -166,71 +193,80 @@ When the path `/about` is requested, the routable files execute in the following
 3. Layouts from root-most to leaf-most
 4. Page
 
-<!-- mermaid diagram from README -->
+> [!NOTE]
+> Layouts and the page are combined at build time into a single component, so nested layouts add no runtime overhead.
 
 ## Path Structure
 
-Within the [routes directory](#routes-directory), the directory structure determines the path from which the route is served. There are four types of directory names: **static**, **pathless**, **dynamic**, and **catch-all**.
+Within the routes directory, the directory structure determines the path from which the route is served. There are four types of directory names: **static**, **pathless**, **dynamic**, and **catch-all**.
 
-1. **Static directories** - The most common type, and the default behavior. Each static directory contributes its name as a segment in the route's served path, similar to a traditional file server. Unless a directory name matches the requirements for one of the below types, it is seen as a static directory.
+### Static Directories
 
-   Examples:
+The most common type, and the default behavior. Each static directory contributes its name as a segment in the route's served path, similar to a traditional file server. Unless a directory name matches the requirements for one of the below types, it is seen as a static directory.
 
-   ```text
-   /foo
-   /users
-   /projects
-   ```
+Examples:
 
-2. **Pathless directories** - These directories do **not** contribute their name to the route's served path. Directory names that start with an underscore (`_`) will be ignored when parsing the route.
+```text
+/foo
+/users
+/projects
+```
 
-   Examples:
+### Pathless Directories
 
-   ```text
-   /_users
-   /_public
-   ```
+These directories do **not** contribute their name to the route's served path. Directory names that start with an underscore (`_`) will be ignored when parsing the route.
 
-3. **Dynamic directories** - These directories introduce a dynamic parameter to the route's served path and will match any value at that segment. Any directory name that starts with a single dollar sign (`$`) will be a dynamic directory, and the remaining directory name will be the parameter at runtime. If the directory name is exactly `$`, the parameter will not be captured, but it will be matched.
+Examples:
 
-   Examples:
+```text
+/_users
+/_public
+```
 
-   ```text
-   /$id
-     /$name
-   /$
-   ```
+### Dynamic Directories
 
-4. **Catch-all directories** - These directories are similar to dynamic directories and introduce a dynamic parameter, but instead of matching a single path segment, they match to the end of the path. Any directory that starts with two dollar signs (`$$`) will be a catch-all directory, and the remaining directory name will be the parameter at runtime. In the case of a directory named `$$`, the parameter name will not be captured, but it will match. Catch-all directories can be used to make `404` Not Found routes at any level, including the root.
+These directories introduce a dynamic parameter to the route's served path and will match any value at that segment. Any directory name that starts with a single dollar sign (`$`) will be a dynamic directory, and the remaining directory name will be the parameter at runtime. If the directory name is exactly `$`, the parameter will not be captured, but it will be matched.
 
-   Because catch-all directories match any path segment and consume the rest of the path, you cannot nest route files in them, and no further directories will be traversed.
+Examples:
 
-   Examples:
+```text
+/$id
+/$name
+/$
+```
 
-   ```text
-   /$$all
-     /$$rest
-   /$$
-   ```
+### Catch-all Directories
+
+These directories are similar to dynamic directories and introduce a dynamic parameter, but instead of matching a single path segment, they match to the end of the path. Any directory that starts with two dollar signs (`$$`) will be a catch-all directory, and the remaining directory name will be the parameter at runtime. In the case of a directory named `$$`, the parameter name will not be captured, but it will match. Catch-all directories can be used to make `404` Not Found routes at any level, including the root.
+
+Because catch-all directories match any path segment and consume the rest of the path, route files cannot be nested inside them, and no further directories will be traversed.
+
+Examples:
+
+```text
+/$$all
+/$$rest
+/$$
+```
 
 ## Flat Routes
 
-Flat routes let you define paths without needing additional directories. Instead, the directory structure can be defined either in the file or directory name. This allows you to decouple your routes from your directory structure or co-locate them as needed. To define a flat route, use periods (`.`) to delineate each path segment. This behaves exactly like creating a new directory, and each segment will be parsed using the rules described above for static, dynamic, and pathless routes.
+Flat routes define paths without needing additional directories. Instead, the directory structure can be defined either in the file or directory name. This allows routes to be decoupled from the directory structure or co-located as needed. To define a flat route, use periods (`.`) to delineate each path segment. This behaves exactly like creating a new directory, and each segment will be parsed using the rules described above for static, dynamic, and pathless routes.
 
-Flat routes syntax can be used for both directories and routable files (eg. pages, handlers, middleware, etc.). For these files, anything preceding the plus (`+`) will be treated as the flat route.
+Flat route syntax can be used for both directories and routable files (e.g. pages, handlers, middleware). For these files, anything preceding the plus (`+`) will be treated as the flat route.
 
 For example, to define a page at `/projects/$projectId/members` with a root layout and a project layout:
 
-Without flat routes, you would have a file structure like:
+Without flat routes, the file structure would look like:
 
 ```text
 routes/
   projects/
     $projectId/
-    $members/
-      +page.marko
-        +layout.marko
-        +layout.marko
+      members/
+        +page.marko
+      +layout.marko
+  +layout.marko
 ```
 
 With flat routes, move the path defined by the directories into the files and separate with a period
@@ -238,21 +274,21 @@ With flat routes, move the path defined by the directories into the files and se
 ```text
 routes/
   +layout.marko
-  projects+layout.marko
+  projects.$projectId+layout.marko
   projects.$projectId.members+page.marko
 ```
 
-Additionally, you can continue to organize files under directories to decrease duplication and use flat route syntax in the folder name
+Additionally, files can still be organized under directories to decrease duplication, with flat route syntax in the directory name
 
 ```text
 routes/
   projects.$projectId/
-  +layout.marko
-  members+page.marko
+    +layout.marko
+    members+page.marko
   +layout.marko
 ```
 
-Finally, flat routes and routes defined with directories are all treated equally and merged together. For example, this page will have layout
+Finally, flat routes and routes defined with directories are all treated equally and merged together. For example, this page will have the layout defined in the nested directories:
 
 ```text
 routes/
@@ -262,9 +298,9 @@ routes/
   projects.$projectId+page.marko
 ```
 
-## Multiple Paths, Groups and Optional Segments
+### Multiple Paths
 
-Along with describing multiple segments, flat route syntax supports defining routes that match more than one path and segments that are optional. To describe a route that matches multiple paths, use a comma (`,`) and define each route.
+Along with describing multiple segments, flat route syntax supports defining routes that match more than one path. To describe a route that matches multiple paths, use a comma (`,`) and define each route.
 
 For example the following page matches `/projects/$projectId/members` and `/projects/$projectId/people`
 
@@ -273,24 +309,28 @@ routes/
   projects.$projectId.members,projects.$projectId.people+page.marko
 ```
 
-This file name is a bit long, so you might do something like this
+This file name is a bit long, so a directory can shoulder the shared prefix
 
 ```text
 routes/
-  projects.$projectId
-  members,people+page.marko
+  projects.$projectId/
+    members,people+page.marko
 ```
 
-We can simplify this by introducing another concept: **grouping**. Groups allow you to define segments within a flat route that match multiple sub-paths by surrounding them with parentheses (`(` and `)`). For the example, this means you can do the following:
+### Groups
+
+**Grouping** simplifies multiple paths further. Groups define segments within a flat route that match multiple sub-paths by surrounding them with parentheses (`(` and `)`). With a group, the page above collapses back into a single file:
 
 ```text
 routes/
   projects.$projectId.(members,people)+page.marko
 ```
 
-This is a simple example of grouping, but you can nest groups and make them as complicated as you want.
+This is a basic use of grouping, but groups can be nested and combined as needed.
 
-The last concept is **optionality**. By introducing an empty segment or pathless segment along with another value, you can make that segment optional. For example, if we want a page that matches `/projects` and `/projects/home`, you can create a flat route that optionally matches `home`
+### Optional Segments
+
+Introducing an empty segment or pathless segment along with another value makes that segment optional. For example, a page that matches both `/projects` and `/projects/home` can be created with a flat route that optionally matches `home`
 
 ```text
 routes/
@@ -304,4 +344,35 @@ routes/
   projects.(home,_pathless)+page.marko
 ```
 
-While both of these create a route which matches the paths, they have slightly different semantics. Using a pathless segment is the same as creating a pathless directory, which allows you to isolate middleware and layouts. Using an empty segment is the same as defining a file at the current location.
+While both of these create a route which matches the paths, they have slightly different semantics. Using a pathless segment is the same as creating a pathless directory, which allows middleware and layouts to be isolated. Using an empty segment is the same as defining a file at the current location.
+
+## Escaping Characters
+
+To include a control character (`.`, `,`, `+`, `(`, `)`, `$`, `_`) as a literal in a route path, surround it with backticks (`` ` ``). For example, to create a route served at `/sitemap.xml`:
+
+```text
+routes/
+  `sitemap.xml`/
+    +handler.ts
+```
+
+or
+
+```text
+routes/
+  sitemap`.`xml/
+    +handler.ts
+```
+
+or
+
+```text
+routes/
+  sitemap`.`xml+handler.ts
+```
+
+## Next Steps
+
+- [TypeScript](./typescript.md)
+- [Validation](./validation.md)
+- [Data Loading](./data-loading.md)

--- a/docs/marko-run/getting-started.md
+++ b/docs/marko-run/getting-started.md
@@ -1,94 +1,101 @@
 # Getting Started
 
-Marko Run is a framework for building web applications with Marko. This is a _meta_-framework for Marko, similar to Next.js or Remix for React, SvelteKit for Svelte, and Nuxt for Vue.
+Marko Run ([`@marko/run`](https://github.com/marko-js/run)) is the application framework for Marko. It turns a directory of Marko templates into a full web application with [file-based routing](./file-based-routing.md), nested layouts, middleware, streaming server-side rendering, and [adapters](./adapters.md) for deploying to different platforms.
 
-Marko Run is powered by Vite, a fast and modern build tool that provides a great developer experience. It is designed to be easy to use and flexible, allowing developers to build applications with Marko quickly and efficiently.
+Marko Run is powered by [Vite](https://vitejs.dev/) and works with zero configuration. The package ships with a default Vite config and a Node-based adapter, so a single `+page.marko` file is enough to serve an application.
 
 ## Using a Template
 
-Marko's CLI provides a variety of templates to get started with Marko, many of which use Marko Run.
+Marko provides project templates through `npm init marko`, many of which use Marko Run.
 
 ```sh
 npm init marko
 ```
 
-## Starting from Zero
-
-The smallest possible Marko Run project requires just a few files.
+After choosing a template and project name:
 
 ```sh
-npm init
-npm install @marko/run
+cd PROJECT_NAME
+npm run dev
 ```
 
-## Adding to an Existing Project
+## Manual Setup
 
-Marko Run can be added to an existing Marko project by installing the package.
+Marko Run requires just one dependency, whether starting fresh or adding it to an existing Marko project.
 
-```sh
-npm install @marko/run
-```
-
-## Zero Config Setup
-
-`marko-run` enables quick project initialization with minimal configuration. The package ships with a default Vite config and node-based adapter.
-
-Starting with a template:
-
-1. Create a new project
+1. Install the package
 
    ```sh
-   npm init marko -- -t basic
+   npm install @marko/run
    ```
 
-2. Navigate to project directory
+2. Create the first page at `src/routes/+page.marko`
+
+   ```marko
+   <h1>Hello Marko Run</h1>
+   ```
+
+3. Start the development server
 
    ```sh
-   cd PROJECT_NAME
+   npm exec marko-run
    ```
 
-3. Start development server
+The application is now available at `http://localhost:3000` 🚀
 
-   ```sh
-   npm run dev
-   ```
+> [!NOTE]
+> No Vite config file is required, and [adapters](./adapters.md) are discovered automatically by package name. When a config file is needed, for example to set plugin options or register additional Vite plugins, see [Marko Run's Vite plugin](./vite-plugin.md).
 
-Manual project setup:
+## CLI
 
-1. Install the required package: `npm install @marko/run`
-2. Create the entry file: `src/routes/+page.marko`
-3. Start the development server: `npm exec marko-run`
+The `marko-run` CLI has three commands: `dev`, `build`, and `preview`. All commands accept these options:
 
-The application will be available at `http://localhost:3000` 🚀
+| Option           | Description                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `-c`, `--config` | Path to a Vite config file (by default, looks for a `vite.config` file with a `.js`, `.cjs`, `.mjs`, `.ts`, or `.mts` extension) |
+| `-e`, `--env`    | Path to a dotenv file                                                                                                            |
 
-## CLI Commands
+### `dev`
 
-### `marko-run dev`
-
-Starts a development server in watch mode
+Starts a development server in watch mode. This is the default command, so both of the following are equivalent:
 
 ```sh
 npm exec marko-run
-```
-
-or (with explicit sub command)
-
-```sh
 npm exec marko-run dev
 ```
 
-### `marko-run build`
+| Option         | Description                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `-p`, `--port` | Port to listen on (defaults: `server.port` then `preview.port` in the Vite config, the `PORT` env variable, or 3000) |
 
-Creates a production build
+### `build`
+
+Creates a production build.
 
 ```sh
 npm exec marko-run build
 ```
 
-### `marko-run preview`
+| Option           | Description                                                                 |
+| ---------------- | --------------------------------------------------------------------------- |
+| `-o`, `--output` | Directory to write built files (default: `build.outDir` in the Vite config) |
 
-Creates a production build and start the preview server
+### `preview`
+
+Creates a production build and starts a production-like server.
 
 ```sh
 npm exec marko-run preview
 ```
+
+| Option           | Description                                                                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `-o`, `--output` | Directory to serve files from, and write built files to (default: `build.outDir` in the Vite config)                                |
+| `-p`, `--port`   | Port the server should listen on (defaults: `preview.port` then `server.port` in the Vite config, the `PORT` env variable, or 3000) |
+| `-f`, `--file`   | Output file to start                                                                                                                |
+
+## Next Steps
+
+- [File-based Routing](./file-based-routing.md)
+- [TypeScript](./typescript.md)
+- [Adapters](./adapters.md)

--- a/docs/marko-run/getting-started.md
+++ b/docs/marko-run/getting-started.md
@@ -21,7 +21,7 @@ npm run dev
 
 ## Manual Setup
 
-Marko Run requires just one dependency, whether starting fresh or adding it to an existing Marko project.
+Marko Run requires only one dependency in addition to `marko`, whether starting fresh or adding it to an existing Marko project.
 
 1. Install the package
 
@@ -35,7 +35,7 @@ Marko Run requires just one dependency, whether starting fresh or adding it to a
    <h1>Hello Marko Run</h1>
    ```
 
-3. Start the development server
+3. Start the development server with the [CLI](./cli.md)
 
    ```sh
    npm exec marko-run
@@ -45,54 +45,6 @@ The application is now available at `http://localhost:3000` 🚀
 
 > [!NOTE]
 > No Vite config file is required, and [adapters](./adapters.md) are discovered automatically by package name. When a config file is needed, for example to set plugin options or register additional Vite plugins, see [Marko Run's Vite plugin](./vite-plugin.md).
-
-## CLI
-
-The `marko-run` CLI has three commands: `dev`, `build`, and `preview`. All commands accept these options:
-
-| Option           | Description                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `-c`, `--config` | Path to a Vite config file (by default, looks for a `vite.config` file with a `.js`, `.cjs`, `.mjs`, `.ts`, or `.mts` extension) |
-| `-e`, `--env`    | Path to a dotenv file                                                                                                            |
-
-### `dev`
-
-Starts a development server in watch mode. This is the default command, so both of the following are equivalent:
-
-```sh
-npm exec marko-run
-npm exec marko-run dev
-```
-
-| Option         | Description                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `-p`, `--port` | Port to listen on (defaults: `server.port` then `preview.port` in the Vite config, the `PORT` env variable, or 3000) |
-
-### `build`
-
-Creates a production build.
-
-```sh
-npm exec marko-run build
-```
-
-| Option           | Description                                                                 |
-| ---------------- | --------------------------------------------------------------------------- |
-| `-o`, `--output` | Directory to write built files (default: `build.outDir` in the Vite config) |
-
-### `preview`
-
-Creates a production build and starts a production-like server.
-
-```sh
-npm exec marko-run preview
-```
-
-| Option           | Description                                                                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `-o`, `--output` | Directory to serve files from, and write built files to (default: `build.outDir` in the Vite config)                                |
-| `-p`, `--port`   | Port the server should listen on (defaults: `preview.port` then `server.port` in the Vite config, the `PORT` env variable, or 3000) |
-| `-f`, `--file`   | Output file to start                                                                                                                |
 
 ## Next Steps
 

--- a/docs/marko-run/runtime.md
+++ b/docs/marko-run/runtime.md
@@ -1,0 +1,186 @@
+# Runtime
+
+At build time, Marko Run generates a router from the application's [route files](./file-based-routing.md). For each request, the router creates a **context** object that flows through middleware, handlers, and templates. When using an [adapter](./adapters.md), the runtime is abstracted away. It can also be [embedded](#embedding) in an existing server.
+
+## Context
+
+The context is passed to middleware and handler functions as the first parameter, conventionally named `ctx`. In Marko templates, it is available as [`$global`](../reference/language.md#global). It contains information about the current request:
+
+| Property   | Description                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `route`    | A string identifying the current route's path pattern                                                                                            |
+| `request`  | The current [WHATWG `Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) instance                                                |
+| `method`   | HTTP method of the current request                                                                                                               |
+| `url`      | [WHATWG `URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) instance of the current request                                             |
+| `params`   | The route's path parameters, transformed by any [`params` validators](./validation.md#params-and-search)                                         |
+| `search`   | The request's query string values, transformed by any [`search` validators](./validation.md#params-and-search)                                   |
+| `body`     | Promise for the parsed request body when the route configures a [`json` or `form` option](./validation.md#request-bodies), otherwise `undefined` |
+| `data`     | Data passed from upstream middleware and handlers via [`next(data)`](./data-loading.md)                                                          |
+| `meta`     | Metadata loaded from the current route's [`+meta` file](./file-based-routing.md#meta)                                                            |
+| `platform` | Additional data provided by the [adapter](./adapters.md)                                                                                         |
+| `parent`   | The calling context when the request was made with [`ctx.fetch`](#fetch), otherwise `undefined`                                                  |
+
+> [!NOTE]
+> In templates, `$global.params` and `$global.url` are serialized to the browser by default, so client-side code can read them after hydration. Other context properties can be included by setting them in `ctx.serializedGlobals`.
+
+## Context Methods
+
+The context also provides helpers for producing responses.
+
+### `fetch`
+
+```ts
+fetch(resource: string | URL | Request, init?: RequestInit): Promise<Response>;
+```
+
+Creates a response by making a new request to the router. This method has the same signature as native [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch). Relative URLs resolve against the current request's URL, and the new request's context has this context as its `parent`.
+
+### `render`
+
+```ts
+render<T>(template: Marko.Template<T>, input: T, init?: ResponseInit): Response;
+```
+
+Creates a response that streams the given Marko template and sets the `Content-Type` header to `text/html`.
+
+### `redirect`
+
+```ts
+redirect(to: string | URL, status?: number): Response;
+```
+
+Creates a redirect response, resolving relative paths against the current URL. The status defaults to `302` and must be one of `301`, `302`, `303`, `307`, or `308`.
+
+### `back`
+
+```ts
+back(fallback?: string | URL, status?: number): Response;
+```
+
+Creates a redirect response that uses the current request's `Referer` header, or the fallback (default `/`) when there is none.
+
+## Typed URLs
+
+The runtime also provides `Run.href`, which builds URLs for the application's routes with type checking of the path, params, search, and hash. The path is typed against the routes the application actually serves. Renaming or moving a route turns every stale link into a compile-time error instead of a broken `<a>` tag.
+
+```marko
+<a href=Run.href("/projects/$projectId/members", {
+  params: { projectId: 42 },
+  search: { sort: "name" },
+  hash: "top",
+})>Members</a>
+```
+
+| Option   | Description                                                                                                                                                                             |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `params` | Values for the path's [dynamic segments](./file-based-routing.md#path-structure). Required exactly when the path has them. Catch-all (`$$`) params also accept arrays, joined with `/`. |
+| `search` | Query string values. When the route declares a [`search` validator](./validation.md#params-and-search), the keys are typed against it.                                                  |
+| `hash`   | Fragment appended after `#`.                                                                                                                                                            |
+
+All params, search values, and the hash are URI-encoded automatically.
+
+The full path checking relies on [generated types](./typescript.md#generated-types), so a TSConfig file must be present in the project root for `Run.href` to validate paths and params at compile time. The function still builds correct URLs without it.
+
+> [!NOTE]
+> In client builds, Marko Run rewrites statically analyzable `Run.href(...)` calls at compile time, so most calls cost nothing at runtime.
+
+## Embedding
+
+When more control is needed than an [adapter](./adapters.md) provides, the router can be imported directly and embedded in an existing server:
+
+```ts
+import * as router from "@marko/run/router";
+```
+
+### `router.fetch`
+
+```ts
+function fetch(request: Request, platform: unknown): Promise<Response | void>;
+```
+
+This asynchronous function takes a [WHATWG `Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and an object containing any platform-specific data made available as `ctx.platform`. It returns any of
+
+- a [WHATWG `Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) generated from executing the matched route files
+- `undefined` if the request was not explicitly handled
+- a `404` status response if no route matches the requested path
+- a `500` status response if an uncaught error occurs
+
+Express example:
+
+```ts
+import express from "express";
+import * as router from "@marko/run/router";
+
+express()
+  .use(async (req, res, next) => {
+    const request = createWHATWGRequest(req); // code to create a WHATWG Request from `req`
+
+    const response = await router.fetch(request, { req, res });
+
+    if (response) {
+      applyResponse(response, res); // code to apply a WHATWG Response to `res`
+    } else {
+      next();
+    }
+  })
+  .listen(3000);
+```
+
+> [!TIP]
+> When targeting Node.js servers, the [Node adapter's middleware](./adapters.md#node) already performs this request and response conversion for Connect-style servers like Express.
+
+### `router.match`
+
+```ts
+function match(method: string, pathname: string): Route | null;
+```
+
+This synchronous function takes an HTTP method and path name. It returns an object representing the best matching route (`params` and `meta`), or `null` if no route matches. This is useful when other parts of a server need to know whether a route exists before creating a response.
+
+### `router.invoke`
+
+```ts
+function invoke(
+  route: Route,
+  request: Request,
+  platform: unknown,
+): Promise<Response | void>;
+```
+
+This asynchronous function takes a route object returned by [`router.match`](#routermatch), along with the request and platform data. It produces a response in the same way [`router.fetch`](#routerfetch) does. Together, `match` and `invoke` split `fetch` into its two steps so that other middleware can run in between:
+
+```ts
+import express from "express";
+import * as router from "@marko/run/router";
+
+express()
+  .use((req, res, next) => {
+    res.locals.match = router.match(req.method, req.path);
+    next();
+  })
+
+  // ...other middleware which can check `res.locals.match`
+
+  .use(async (req, res, next) => {
+    if (!res.locals.match) {
+      next();
+      return;
+    }
+
+    const request = createWHATWGRequest(req); // code to create a WHATWG Request from `req`
+    const response = await router.invoke(res.locals.match, request, { req, res });
+
+    if (response) {
+      applyResponse(response, res); // code to apply a WHATWG Response to `res`
+    } else {
+      next();
+    }
+  })
+  .listen(3000);
+```
+
+## Next Steps
+
+- [Vite Plugin](./vite-plugin.md)
+- [Adapters](./adapters.md)
+- [TypeScript](./typescript.md)

--- a/docs/marko-run/typescript.md
+++ b/docs/marko-run/typescript.md
@@ -1,51 +1,59 @@
 # TypeScript
 
-## Global Namespace
+Marko Run is designed to be used with TypeScript. Route files get typed request contexts. Validated params and bodies flow through to pages, and URLs are checked against the routes the application serves.
 
-`marko/run` provides a global namespace `MarkoRun` with the following types:
+## Run Namespace
 
-**`MarkoRun.Handler`** - Type that represents a handler function to be exported by a +handler or +middleware file
+Marko Run provides a global namespace `Run`, available in route files without any imports. At runtime it exposes the [verb helpers](./validation.md#verb-helpers) (`Run.GET`, `Run.POST`, ..., `Run.ALL`) and [`Run.href`](./runtime.md#typed-urls). In TypeScript it also provides:
 
-**`MarkoRun.Route`** - Type of the route's params and metadata
-
-**`MarkoRun.Context`** - Type of the request context object in a handler and `$global` in your Marko files. This type can be extended using TypeScript's module and interface merging by declaring a `Context` interface on the `@marko/run` module within your application code
+**`Run.Context`** - Type of the request context object in a handler and `$global` in Marko files. This type can be extended using TypeScript's module and interface merging by declaring a `Context` interface on the `@marko/run` module within the application code:
 
 ```ts
 declare module "@marko/run" {
   interface Context {
-    customProperty: MyCustomThing; // will be globally defined on MarkoRun.Context
+    customProperty: MyCustomThing; // will be globally defined on Run.Context
   }
 }
 ```
 
-**`MarkoRun.Platform`** - Type of the platform object provided by the adapter in use. This interface can be extended in that same way as `Context` (see above) by declaring a `Platform` interface:
+The platform object provided by the [adapter](./adapters.md) in use can be typed the same way by declaring a `Platform` interface:
 
 ```ts
 declare module "@marko/run" {
   interface Platform {
-    customProperty: MyCustomThing; // will be globally defined on MarkoRun.Platform
+    customProperty: MyCustomThing; // will be available on `ctx.platform`
   }
 }
 ```
 
+> [!NOTE]
+> The previous `MarkoRun` global namespace and its types (`MarkoRun.Handler`, `MarkoRun.Context`, etc.) are deprecated. New code should use the `Run` namespace instead.
+
 ## Generated Types
 
-If a [TSConfig](https://www.typescriptlang.org/tsconfig) file is discovered in the project root, the Vite plugin will automatically generate a .d.ts file which provides more specific types for each of your middleware, handlers, layouts, and pages. This file will be generated at `.marko-run/routes.d.ts` whenever the project is built - including dev.
+If a [TSConfig](https://www.typescriptlang.org/tsconfig) file is discovered in the project root, Marko Run will automatically generate a `.d.ts` file which provides more specific types for each middleware, handler, layout, and page. This file is generated at `.marko-run/routes.d.ts` whenever the project is built, including during dev.
 
-> [!NOTE] TypeScript will not include this file by default. You should use the [Marko VSCode plugin](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode) and [add it in your tsconfig](https://www.typescriptlang.org/tsconfig#include).
+> [!NOTE]
+> TypeScript will not include this file by default. Use the [Marko VSCode plugin](https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode) and [add the file in the tsconfig `include`](https://www.typescriptlang.org/tsconfig#include).
 
-These types are replaced with more specific versions per routable file:
+With the generated types, the `Run` namespace is narrowed per routable file:
 
-**`MarkoRun.Handler`**
+**`Run.Context`**
 
-- Overrides context with specific MarkoRun.Context
-
-**`MarkoRun.Route`**
-
-- Adds specific parameters and meta types
+- Has the exact path params, meta, validated `search` and `body`, and upstream `data` types for the routes the file serves
 - In middleware and layouts which are used in many routes, this type will be a union of all possible routes that the file will see
-
-**`MarkoRun.Context`**
-
-- In middleware and layouts which are used in many routes, this type will be a union of all possible routes that the file will see.
 - When an adapter is used, it can provide types for the platform
+
+**`Run` verb helpers**
+
+Validation options and handler return types are fully inferred, so `ctx.params`, `ctx.search`, `ctx.body`, and the data passed to `next(...)` flow through to downstream handlers, pages, and layouts.
+
+**`Run.href`**
+
+The path and its params are typed against every route the application serves.
+
+## Next Steps
+
+- [Validation](./validation.md)
+- [Runtime](./runtime.md#typed-urls)
+- [TypeScript in Marko](../reference/typescript.md)

--- a/docs/marko-run/typescript.md
+++ b/docs/marko-run/typescript.md
@@ -27,7 +27,7 @@ declare module "@marko/run" {
 ```
 
 > [!NOTE]
-> The previous `MarkoRun` global namespace and its types (`MarkoRun.Handler`, `MarkoRun.Context`, etc.) are deprecated. New code should use the `Run` namespace instead.
+> Reserve the `Context` interface for application-wide properties that every route can rely on, like a database connection or session helper. For route-specific values, prefer [data loading](./data-loading.md) via `next`, which types the data per route automatically.
 
 ## Generated Types
 

--- a/docs/marko-run/validation.md
+++ b/docs/marko-run/validation.md
@@ -1,0 +1,141 @@
+# Validation
+
+Handlers and middleware are written using the verb helpers defined on the global `Run` namespace. Beyond declaring which HTTP method a handler responds to, these helpers accept validation options that check, transform, and type a route's path parameters, query string, and request body.
+
+## Verb Helpers
+
+Each verb helper (`Run.GET`, `Run.HEAD`, `Run.POST`, `Run.PUT`, `Run.DELETE`, `Run.PATCH`, `Run.OPTIONS`, and `Run.ALL`) accepts a handler function or an array of handler functions, optionally preceded by validation options:
+
+```ts
+Run.POST(handler); // a handler function
+Run.POST([auth, handler]); // an array of handlers, composed in order
+Run.POST(options, handler); // validation options plus a handler
+Run.POST(options, [auth, handler]); // validation options plus an array of handlers
+Run.POST(options); // options only, validates and passes through
+```
+
+In a [`+handler` file](./file-based-routing.md#handler), export the result under the matching verb name. In a [`+middleware` file](./file-based-routing.md#middleware), use the default export. Handlers created for a specific verb only run for requests with that method. `Run.ALL`, available in middleware, runs for every method.
+
+> [!NOTE]
+> The `Run` namespace is a global, so no imports are needed in route files. See [TypeScript](./typescript.md#run-namespace) for the types it provides.
+
+## Params and Search
+
+The `params` and `search` options validate, and can transform, the route's [path parameters](./file-based-routing.md#path-structure) and query string. A validator is either a function or a [Standard Schema](https://github.com/standard-schema/standard-schema) (Zod, Valibot, ArkType, etc.).
+
+Consider a middleware that normalizes a `page` query parameter for every route below it, and a handler that converts its `id` path parameter to a number:
+
+```ts
+/* +middleware.ts */
+export default Run.ALL({
+  search(value) {
+    return { ...value, page: Number(value.page) || 0 };
+  },
+});
+```
+
+```ts
+/* $id/+handler.ts */
+export const GET = Run.GET(
+  {
+    params(value) {
+      return { id: Number(value.id) };
+    },
+  },
+  (ctx) => {
+    ctx.params.id; // number
+    ctx.search.page; // number
+  },
+);
+```
+
+Function validators replace the value with whatever they return. Standard Schema validators produce a [`[value, issues]` tuple](#schema-results).
+
+Validators are lazy. `ctx.params` and `ctx.search` do not run their validators until the property is accessed. The first access runs the validator and caches the result for later reads. A request that never touches these properties never pays for their validation.
+
+> [!WARNING]
+> Standard Schema validation must be synchronous. Passing a schema whose validation resolves asynchronously throws at runtime.
+
+## Request Bodies
+
+`POST`, `PUT`, and `PATCH` handlers declare how request bodies are read with the `json` and `form` options. When either is configured, `ctx.body` is a promise for the parsed and validated body. Otherwise `ctx.body` is `undefined`.
+
+```ts
+import * as v from "valibot";
+
+export const POST = Run.POST(
+  {
+    form: v.object({
+      name: v.string(),
+      age: v.pipe(v.string(), v.toNumber()),
+    }),
+  },
+  async (ctx) => {
+    const [data, issues] = await ctx.body;
+    if (issues) {
+      return Response.json({ issues }, { status: 400 });
+    }
+    return Response.json(data);
+  },
+);
+```
+
+Like `params` and `search`, `ctx.body` is lazy. The body is only read, parsed, and validated when the promise is consumed, meaning it is awaited or its `.then` method is called. A handler that rejects a request early does so without reading the body at all.
+
+Function validators resolve `ctx.body` to their return value. Standard Schema validators resolve it to a [`[value, issues]` tuple](#schema-results). With no validator, it resolves to the raw parsed body.
+
+> [!NOTE]
+> Requests exceeding the configured size limits below are rejected.
+
+### `json`
+
+Handles requests with an `application/json` content type. The option can be a validator, or an options object:
+
+| Option      | Default        | Description                                     |
+| ----------- | -------------- | ----------------------------------------------- |
+| `validator` |                | Function or Standard Schema for the parsed JSON |
+| `maxBytes`  | 1048576 (1MiB) | Maximum request body size in bytes              |
+
+### `form`
+
+Handles requests with an `application/x-www-form-urlencoded` or `multipart/form-data` content type. Repeated field names become arrays. The option can be a validator, or an options object:
+
+| Option         | Default                   | Description                                        |
+| -------------- | ------------------------- | -------------------------------------------------- |
+| `validator`    |                           | Function or Standard Schema for the parsed form    |
+| `maxBytes`     | `maxFiles * maxFileBytes` | Maximum request body size in bytes                 |
+| `maxParts`     | 1000                      | Maximum number of parts in a multipart request     |
+| `maxFiles`     | 20                        | Maximum number of files in a multipart request     |
+| `maxFileBytes` | 1048576 (1MiB)            | Maximum size of each uploaded file in bytes        |
+| `onFile`       |                           | `(ctx, file) => any` called for each uploaded file |
+
+## Schema Results
+
+When a validator is a Standard Schema, the validated value is a `[value, issues]` tuple. On success, `issues` is `undefined` and `value` is the parsed output. On failure, `value` is the raw input and `issues` describes the problems.
+
+In TypeScript this tuple is a discriminated union. The `issues` element must be checked before `value` narrows to the parsed type. Each read of the tuple narrows independently, so this check is required everywhere the result is used. That is simply how TypeScript narrowing works.
+
+> [!TIP]
+> Discriminate the tuple once in the handler and pass the narrowed data to the page with [`next`](./data-loading.md). The template then receives plain, already-validated values instead of repeating the `issues` check in both places.
+
+```ts
+export const POST = Run.POST({ form: signupSchema }, async (ctx, next) => {
+  const [signup, issues] = await ctx.body;
+  if (issues) {
+    return next({ issues });
+  }
+  return next({ signup }); // downstream sees the narrowed type
+});
+```
+
+## Merging Options
+
+All options declared for a route, across its middleware and handler, are merged into a single set. When the same option is declared more than once, the last validator wins and object forms are merged shallowly. A `maxBytes` limit declared in one place combines with a `validator` declared in another.
+
+This makes middleware a natural home for shared validation. An options-only `Run.ALL({ search: ... })` in a [`+middleware` file](./file-based-routing.md#middleware) applies to every route below it.
+
+## Next Steps
+
+- [Data Loading](./data-loading.md)
+- [Runtime](./runtime.md#context)
+- [TypeScript](./typescript.md#generated-types)

--- a/docs/marko-run/validation.md
+++ b/docs/marko-run/validation.md
@@ -49,7 +49,7 @@ export const GET = Run.GET(
 );
 ```
 
-Function validators replace the value with whatever they return. Standard Schema validators produce a [`[value, issues]` tuple](#schema-results).
+Function validators replace the value with whatever they return. Standard Schema validators produce a [`[value, issues]` tuple](#standard-schema).
 
 Validators are lazy. `ctx.params` and `ctx.search` do not run their validators until the property is accessed. The first access runs the validator and caches the result for later reads. A request that never touches these properties never pays for their validation.
 
@@ -82,10 +82,10 @@ export const POST = Run.POST(
 
 Like `params` and `search`, `ctx.body` is lazy. The body is only read, parsed, and validated when the promise is consumed, meaning it is awaited or its `.then` method is called. A handler that rejects a request early does so without reading the body at all.
 
-Function validators resolve `ctx.body` to their return value. Standard Schema validators resolve it to a [`[value, issues]` tuple](#schema-results). With no validator, it resolves to the raw parsed body.
+Function validators resolve `ctx.body` to their return value. Standard Schema validators resolve it to a [`[value, issues]` tuple](#standard-schema). With no validator, it resolves to the raw parsed body. Requests exceeding the configured size limits below are rejected.
 
 > [!NOTE]
-> Requests exceeding the configured size limits below are rejected.
+> `ctx.body` is a promise, not a function. Read the parsed body with `await ctx.body`, there is nothing to call.
 
 ### `json`
 
@@ -109,14 +109,11 @@ Handles requests with an `application/x-www-form-urlencoded` or `multipart/form-
 | `maxFileBytes` | 1048576 (1MiB)            | Maximum size of each uploaded file in bytes        |
 | `onFile`       |                           | `(ctx, file) => any` called for each uploaded file |
 
-## Schema Results
+## Standard Schema
 
-When a validator is a Standard Schema, the validated value is a `[value, issues]` tuple. On success, `issues` is `undefined` and `value` is the parsed output. On failure, `value` is the raw input and `issues` describes the problems.
+When a validator is a Standard Schema, the validated result is a `[value, issues]` tuple. On success, `issues` is `undefined` and `value` holds the parsed output. On failure, `value` holds the raw input and `issues` describes each problem.
 
-In TypeScript this tuple is a discriminated union. The `issues` element must be checked before `value` narrows to the parsed type. Each read of the tuple narrows independently, so this check is required everywhere the result is used. That is simply how TypeScript narrowing works.
-
-> [!TIP]
-> Discriminate the tuple once in the handler and pass the narrowed data to the page with [`next`](./data-loading.md). The template then receives plain, already-validated values instead of repeating the `issues` check in both places.
+TypeScript treats the tuple as a discriminated union: checking `issues` is what narrows `value` to the parsed type. Narrowing applies to one read of the tuple at a time, so every place that uses the result needs its own check.
 
 ```ts
 export const POST = Run.POST({ form: signupSchema }, async (ctx, next) => {
@@ -127,6 +124,9 @@ export const POST = Run.POST({ form: signupSchema }, async (ctx, next) => {
   return next({ signup }); // downstream sees the narrowed type
 });
 ```
+
+> [!TIP]
+> Check `issues` once in the handler and pass the narrowed data to the page with [`next`](./data-loading.md). The template then receives already-validated values instead of repeating the check.
 
 ## Merging Options
 

--- a/docs/marko-run/vite-plugin.md
+++ b/docs/marko-run/vite-plugin.md
@@ -1,0 +1,52 @@
+# Vite Plugin
+
+Marko Run's Vite plugin discovers the application's [route files](./file-based-routing.md), generates the routing code, and registers the [`@marko/vite`](https://github.com/marko-js/vite) plugin to compile `.marko` files.
+
+Marko Run prefers convention over configuration. It ships with a default Vite config, routes live in `src/routes`, and [adapters](#adapter) are discovered automatically, so most applications never need a `vite.config` file at all. When one is needed, register the plugin and pass options there:
+
+```ts
+import { defineConfig } from "vite";
+import marko from "@marko/run/vite"; // Import the Vite plugin
+
+export default defineConfig({
+  plugins: [marko()], // Register the Vite plugin
+});
+```
+
+## Options
+
+Along with the options below, Marko Run's Vite plugin accepts all options of the underlying [`@marko/vite`](https://github.com/marko-js/vite) plugin.
+
+### `routesDir`
+
+The directory containing the [routable files](./file-based-routing.md#routable-files), relative to the Vite config file. Defaults to `src/routes`.
+
+> [!WARNING]
+> Changing the routes directory is discouraged. The default is a convention shared across Marko Run projects, templates, and examples, so keeping it makes any project immediately familiar.
+
+### `adapter`
+
+The [adapter](./adapters.md) used to develop, build, and deploy the application.
+
+Adapters are discovered automatically by package name. The first dependency in `package.json` whose name starts with `@marko/run-adapter` or contains `marko-run-adapter` is used, and the default Node-based adapter applies when none is found. Installing an adapter package is therefore all most applications need. Set this option only to configure an adapter or choose between several installed ones, or pass `null` to opt out of adapter discovery.
+
+### `trailingSlashes`
+
+How the router treats trailing slashes in request paths. Marko Run routes are canonically defined without trailing slashes, and requests are matched against one of the following behaviors. Defaults to RedirectWithout.
+
+| Value             | Description                                                                     |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `RedirectWithout` | Redirect requests with a trailing slash to the path without it (default)        |
+| `RedirectWith`    | Redirect requests without a trailing slash to the path with it                  |
+| `RewriteWithout`  | Serve paths with a trailing slash as if it were absent, without redirecting     |
+| `RewriteWith`     | Serve paths without a trailing slash as if it were present, without redirecting |
+| `Ignore`          | Match paths exactly as requested                                                |
+
+> [!TIP]
+> The redirect options are recommended for public sites since they ensure each page is served from a single canonical URL, which search engines treat as one page.
+
+## Next Steps
+
+- [Adapters](./adapters.md)
+- [File-based Routing](./file-based-routing.md)
+- [TypeScript](./typescript.md#generated-types)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -82,5 +82,6 @@ Marko's key features include:
 - [Validation](/docs/marko-run/validation.md): Validating params, search, and request bodies
 - [Data Loading](/docs/marko-run/data-loading.md): Passing data to pages and layouts
 - [Runtime](/docs/marko-run/runtime.md): Request context, typed URLs, and embedding the router
+- [CLI](/docs/marko-run/cli.md): Commands to develop, build, and preview
 - [Vite Plugin](/docs/marko-run/vite-plugin.md): Plugin options and configuration
 - [Adapters](/docs/marko-run/adapters.md): Deploying to different platforms

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -79,3 +79,8 @@ Marko's key features include:
 - [Getting Started](/docs/marko-run/getting-started.md): Quick start for Marko Run
 - [File-based Routing](/docs/marko-run/file-based-routing.md): Routing in Marko Run
 - [TypeScript](/docs/marko-run/typescript.md): TypeScript with Marko Run
+- [Validation](/docs/marko-run/validation.md): Validating params, search, and request bodies
+- [Data Loading](/docs/marko-run/data-loading.md): Passing data to pages and layouts
+- [Runtime](/docs/marko-run/runtime.md): Request context, typed URLs, and embedding the router
+- [Vite Plugin](/docs/marko-run/vite-plugin.md): Plugin options and configuration
+- [Adapters](/docs/marko-run/adapters.md): Deploying to different platforms

--- a/src/routes/docs/+layout.style.module.scss
+++ b/src/routes/docs/+layout.style.module.scss
@@ -169,13 +169,16 @@ main {
     margin: 3rem 0;
   }
 
-  table {
+  :global(.table-scroll) {
     margin: 2rem 0;
-    border-collapse: collapse;
-    border: 1px solid var(--section-color);
     border-radius: 1rem;
-    overflow: hidden;
-    display: block;
+    overflow-x: auto;
+  }
+
+  table {
+    border-collapse: collapse;
+    display: table;
+    width: 100%;
 
     thead {
       border-bottom: 1px solid var(--section-color);
@@ -183,6 +186,10 @@ main {
 
     th {
       font-weight: 500;
+
+      &:not([align]) {
+        text-align: start;
+      }
     }
 
     thead,

--- a/src/tags/app-menu/app-menu.marko
+++ b/src/tags/app-menu/app-menu.marko
@@ -86,6 +86,7 @@ div#site-menu class=styles.menu
           Page="/docs/marko-run/validation" -- Validation
           Page="/docs/marko-run/data-loading" -- Data Loading
           Page="/docs/marko-run/runtime" -- Runtime
+          Page="/docs/marko-run/cli" -- CLI
           Page="/docs/marko-run/vite-plugin" -- Vite Plugin
           Page="/docs/marko-run/adapters" -- Adapters
   div id=styles.controls

--- a/src/tags/app-menu/app-menu.marko
+++ b/src/tags/app-menu/app-menu.marko
@@ -83,6 +83,11 @@ div#site-menu class=styles.menu
           Page="/docs/marko-run/getting-started" -- Getting Started
           Page="/docs/marko-run/file-based-routing" -- File-based Routing
           Page="/docs/marko-run/typescript" -- TypeScript
+          Page="/docs/marko-run/validation" -- Validation
+          Page="/docs/marko-run/data-loading" -- Data Loading
+          Page="/docs/marko-run/runtime" -- Runtime
+          Page="/docs/marko-run/vite-plugin" -- Vite Plugin
+          Page="/docs/marko-run/adapters" -- Adapters
   div id=styles.controls
     label class=styles.versionControl
       -- Version&nbsp;

--- a/src/util/markodown.ts
+++ b/src/util/markodown.ts
@@ -3,6 +3,7 @@ import path from "path";
 import {
   Marked,
   type MarkedExtension,
+  Renderer,
   type Tokens,
   type TokensList,
 } from "marked";
@@ -291,6 +292,9 @@ function markoDocs(): MarkedExtension {
       }
     },
     renderer: {
+      table(token) {
+        return `<div class="table-scroll">${Renderer.prototype.table.call(this, token)}</div>`;
+      },
       code({ lang, text, html, concise, htmlTS, conciseTS, filename }) {
         let out = `<app-code-block lang="${lang}"`;
         if (filename) {

--- a/src/util/markodown.ts
+++ b/src/util/markodown.ts
@@ -222,7 +222,7 @@ function markoDocs(): MarkedExtension {
       if (token.type === "code") {
         // named files begin with `/* file.name */\n`
         const match = (token.text as string).match(
-          /^\/\* ([\w\./+-]+\.\w+) \*\/\n/,
+          /^\/\* ([\w\./+$-]+\.\w+) \*\/\n/,
         );
 
         if (match) {

--- a/src/util/shiki.ts
+++ b/src/util/shiki.ts
@@ -8,11 +8,12 @@ import js from "@shikijs/langs/javascript";
 import json from "@shikijs/langs/json";
 import marko from "@shikijs/langs/marko";
 import sh from "@shikijs/langs/shellscript";
+import toml from "@shikijs/langs/toml";
 import ts from "@shikijs/langs/typescript";
 import { dark, light } from "./shiki-theme";
 
 export default await createHighlighterCore({
   engine: createOnigurumaEngine(import("shiki/wasm")),
   themes: [dark, light],
-  langs: [css, html, xml, js, json, marko, sh, ts],
+  langs: [css, html, xml, js, json, marko, sh, toml, ts],
 });


### PR DESCRIPTION
This PR significantly expands the Marko Run documentation by adding four new comprehensive guides and reorganizing existing content to improve discoverability and clarity.

## Summary

The documentation now covers the full scope of Marko Run's capabilities with dedicated guides for validation, data loading, runtime APIs, adapters, and the Vite plugin. The file-based routing guide has been substantially rewritten for clarity and completeness.

## Key Changes

- **New guides added:**
  - `docs/marko-run/validation.md` - Covers verb helpers, params/search validation, and request body handling with examples using Standard Schema validators
  - `docs/marko-run/data-loading.md` - Explains passing data through middleware and handlers, streaming patterns, and form handling
  - `docs/marko-run/runtime.md` - Documents the context object, context methods (`fetch`, `render`, `redirect`, `back`), typed URLs with `Run.href`, and router embedding
  - `docs/marko-run/adapters.md` - Introduces adapter concept, documents Node, Static, and Netlify adapters, and explains custom adapter development
  - `docs/marko-run/vite-plugin.md` - Covers plugin configuration, options, and trailing slash handling

- **Substantially rewritten:**
  - `docs/marko-run/file-based-routing.md` - Reorganized with clearer explanations of routable files (`+page.marko`, `+layout.marko`, `+handler.*`, `+middleware.*`, `+meta.*`), improved code examples, and better integration with other guides
  - `docs/marko-run/getting-started.md` - Simplified setup instructions, clarified CLI commands, and added configuration examples
  - `docs/marko-run/typescript.md` - Refocused on the `Run` namespace and generated types

- **Route declarations updated:**
  - `.marko-run/routes.d.ts` - Updated to reflect new routes and reordered marko-run section with new pages

- **Navigation and tooling:**
  - Updated `src/tags/app-menu/app-menu.marko` to include new documentation pages in the sidebar
  - Updated `public/llms.txt` with references to new guides
  - Added TOML syntax highlighting support in `src/util/shiki.ts` for Netlify configuration examples
  - Added "Referer" and "vite" to spell checker dictionary

## Implementation Details

The new documentation follows established conventions:
- Reference documents use clear hierarchical sections with syntax examples and parameter tables
- Code examples are practical and focused, with filenames only when disambiguating multiple blocks
- Cross-references link related concepts throughout the documentation
- Callouts (NOTE, TIP, WARNING) highlight important patterns and gotchas
- Technical tone is formal but accessible, avoiding unnecessary framework comparisons

https://claude.ai/code/session_01UEZFJevB194tvtGWALrnyv