### PR TITLE
Generate an OG image for the playground

### DIFF
--- a/src/routes/playground/+meta.json
+++ b/src/routes/playground/+meta.json
@@ -1,4 +1,5 @@
 {
   "pageTitle": "Playground",
-  "hideFooter": true
+  "hideFooter": true,
+  "ogImage": "/og/playground.png"
 }

--- a/src/util/markodown.ts
+++ b/src/util/markodown.ts
@@ -67,7 +67,8 @@ export default function markodownPlugin(): PluginOption {
             buildDocsBanner(docsPath, file, ogFile, headings[0].title),
           ]);
         }),
-        buildDefaultBanner(),
+        buildDefaultBanner("default"),
+        buildDefaultBanner("playground", "Playground"),
         pruneDocsBanners(mdFiles),
         buildSearchIndex(docsPath),
       ]);
@@ -115,11 +116,13 @@ async function buildDocsBanner(
   }
 }
 
-async function buildDefaultBanner() {
-  const target = path.join(process.cwd(), "public", "og", "default.png");
-  if (await isStale(target, bannerModule(), ...defaultBannerSources())) {
+async function buildDefaultBanner(name: string, suffix?: string) {
+  // this module is a source too since it provides the suffix
+  const self = path.join(process.cwd(), "src", "util", "markodown.ts");
+  const target = path.join(process.cwd(), "public", "og", `${name}.png`);
+  if (await isStale(target, bannerModule(), self, ...defaultBannerSources())) {
     await fs.mkdir(path.dirname(target), { recursive: true });
-    await fs.writeFile(target, await renderDefaultBanner());
+    await fs.writeFile(target, await renderDefaultBanner(suffix));
   }
 }
 

--- a/src/util/og-banner.ts
+++ b/src/util/og-banner.ts
@@ -255,12 +255,31 @@ function docsBanner(
   ]);
 }
 
-function defaultBanner(logo: string): Element {
+function defaultBanner(logo: string, suffix?: string): Element {
   return frame("#00CFFB", [
     { type: "div", props: { style: { display: "flex" } } },
     {
-      type: "img",
-      props: { src: logo, width: 560, height: 115 },
+      type: "div",
+      props: {
+        style: { display: "flex", flexDirection: "column", gap: 96 },
+        children: [
+          {
+            type: "img",
+            props: { src: logo, width: 560, height: 115 },
+          },
+          ...(suffix
+            ? [
+                {
+                  type: "div",
+                  props: {
+                    style: { fontSize: 96, fontWeight: 700, lineHeight: 1 },
+                    children: suffix,
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
     },
     {
       type: "div",
@@ -298,7 +317,7 @@ export async function renderDocsBanner(title: string, section: string) {
   return render(docsBanner(title, section, logomark, widget));
 }
 
-export async function renderDefaultBanner() {
+export async function renderDefaultBanner(suffix?: string) {
   const { logo } = await loadAssets();
-  return render(defaultBanner(logo));
+  return render(defaultBanner(logo, suffix));
 }


### PR DESCRIPTION
Generates a build-time OG image for the playground (the default banner with "Playground" below the logo) so shared playground links get their own social preview instead of the site default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdc9s3c4B6yFcpd8xCFf6V)_