### PR TITLE
fix(playground): prevent renaming index.marko

### DIFF
--- a/src/routes/playground/tags/playground/tags/editor/tags/tabs/tabs.marko
+++ b/src/routes/playground/tags/playground/tags/editor/tags/tabs/tabs.marko
@@ -25,7 +25,7 @@ div class=styles.tabs
         ,tabindex=0
         ,role="button"
         ,onClick() {
-          if (isSelected && !isEditing) {
+          if (isSelected && isEditable && !isEditing) {
             editingIndex = i;
           } else if (!isEditing) {
             selected = i;
@@ -33,7 +33,7 @@ div class=styles.tabs
         }
         ,onKeyDown(e, el) {
           if (e.target === el && (e.key === " " || e.key === "Enter")) {
-            if (isSelected && !isEditing) {
+            if (isSelected && isEditable && !isEditing) {
               editingIndex = i;
             } else if (!isEditing) {
               selected = i;


### PR DESCRIPTION
Guards the playground tab rename handlers with the existing `isEditable` check so `index.marko`, which the workspace hardcodes as its bundle entry point, can no longer be renamed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01858berHqaLjfZ8xSCKyLQo)_