### PR TITLE
feat(playground): faster package installs and a loading indicator

### DIFF
--- a/src/routes/playground/+page.marko
+++ b/src/routes/playground/+page.marko
@@ -1,3 +1,9 @@
+import warmPackages from "./warm-packages.js?raw";
+
+link rel="preconnect" href="https://registry.npmjs.org" crossorigin
+
+html-script -- ${warmPackages};
+
 hash-files/files=[
   {
     path: "index.marko",

--- a/src/routes/playground/tags/playground/tags/editor/tags/tabs/tabs.marko
+++ b/src/routes/playground/tags/playground/tags/editor/tags/tabs/tabs.marko
@@ -153,7 +153,7 @@ div class=styles.tabs
             {
               path: "package.json",
               content:
-                '{\n  "dependencies": { "@evo-web/marko": "^0.5.0" }\n}\n',
+                '{\n  "dependencies": {\n    "@ebay/skin": "latest",\n    "@evo-web/marko": "latest"\n  }\n}\n',
             },
           ];
           document.querySelector<HTMLElement>(".cm-content")?.focus();

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -172,6 +172,10 @@ div class=styles.result
     if=files.length
       script -- update($signal, $frame(), files, !debug);
 
+    if=showPreview && !ws.previewReady
+      div class=styles.loading role="status"
+        span -- setting up
+
     a class=styles.markoLogo href="https://markojs.com" title="Built with Marko"
     if=outputType !== "preview"
       button

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -193,6 +193,35 @@
   }
 }
 
+.loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-black);
+  font-family: "Ubuntu Mono", monospace;
+  font-size: 1.25rem;
+  animation: fade-in 0.3s ease 1s both;
+
+  span {
+    opacity: 0.35;
+    animation: pulse 2.4s ease-in-out infinite;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: 1;
+  }
+}
+
 .spin {
   animation: spin 0.25s ease-out;
 }

--- a/src/routes/playground/warm-packages.js
+++ b/src/routes/playground/warm-packages.js
@@ -1,0 +1,73 @@
+(async () => {
+  try {
+    const hash = location.hash.slice(1);
+    if (!hash) return;
+    const decoded = atob(hash.replace(/-/g, "+").replace(/_/g, "/"));
+    if (!decoded.startsWith("v2")) return;
+    const source = await new Response(
+      new Response(
+        Uint8Array.from(decoded.slice(2), (c) => c.charCodeAt(0)),
+      ).body.pipeThrough(new DecompressionStream("gzip")),
+    ).text();
+    const packageJson = JSON.parse(source).find(
+      (file) => file.path === "package.json",
+    );
+    if (!packageJson) return;
+
+    const compare = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+    const pickVersion = (pack, range) => {
+      const tagged = pack["dist-tags"]?.[range || "latest"];
+      if (tagged) return tagged;
+      if (pack.versions[range]) return range;
+      const match = /^([\^~])(\d+)\.(\d+)\.(\d+)$/.exec(range);
+      if (!match) return;
+      const min = [+match[2], +match[3], +match[4]];
+      const lockMinor = match[1] === "~" || min[0] === 0;
+      let best;
+      for (const version of Object.keys(pack.versions)) {
+        const parts = version.split(".").map(Number);
+        if (parts.length !== 3 || parts.some(isNaN)) continue;
+        if (parts[0] !== min[0] || (lockMinor && parts[1] !== min[1])) continue;
+        if (compare(parts, min) < 0) continue;
+        if (!best || compare(parts, best) > 0) best = parts;
+      }
+      return best && best.join(".");
+    };
+
+    const seen = new Set(["marko", "@marko/compiler", "@marko/run"]);
+    const warm = async (name, range, markoOnly) => {
+      if (seen.has(name) || seen.size > 32) return;
+      seen.add(name);
+      try {
+        const res = await fetch(
+          "https://registry.npmjs.org/" + name.replace("/", "%2f"),
+          { headers: { accept: "application/vnd.npm.install-v1+json" } },
+        );
+        if (!res.ok) return;
+        const pack = await res.json();
+        const meta = pack.versions[pickVersion(pack, range)];
+        if (!meta) return;
+        const isMarko =
+          meta.dependencies?.marko || meta.peerDependencies?.marko;
+        if (markoOnly && !isMarko) return;
+        fetch(meta.dist.tarball).catch(() => {});
+        if (isMarko) {
+          for (const [depName, depRange] of Object.entries(
+            meta.dependencies || {},
+          )) {
+            warm(depName, depRange, true);
+          }
+        }
+      } catch {}
+    };
+
+    const pkg = JSON.parse(packageJson.content);
+    for (const [name, range] of Object.entries({
+      ...pkg.peerDependencies,
+      ...pkg.devDependencies,
+      ...pkg.dependencies,
+    })) {
+      warm(name, range);
+    }
+  } catch {}
+})();

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -28,6 +28,7 @@ export interface LogEntry {
 export interface Workspace {
   fs: FileSystem;
   optimize: boolean;
+  previewReady: boolean;
   previewJS: string;
   previewCSS: string;
   previewHTML: string;
@@ -134,6 +135,7 @@ export async function update(
   const ws: Workspace = (workspace = {
     fs,
     optimize,
+    previewReady: workspace?.previewReady ?? false,
     previewJS: "",
     previewCSS: "",
     previewHTML: "",
@@ -309,6 +311,7 @@ export async function update(
             } else if (data) {
               rawHTML += data;
               ws.previewHTML = prettyPrintHTML(rawHTML);
+              ws.previewReady = true;
               emit();
               domWriter.write(data);
             } else {
@@ -317,6 +320,8 @@ export async function update(
                 emit();
               });
               domWriter.close();
+              ws.previewReady = true;
+              emit();
             }
           };
           server.postMessage(1);
@@ -343,6 +348,8 @@ export async function update(
                 getSourceMapComment(file, getAssetCode(output, `${file}.map`)),
             )}"></script>`
           : "");
+      ws.previewReady = false;
+      emit();
     })();
 
     await Promise.all([serverBuild, browserBuild]);

--- a/src/util/workspace/npm.ts
+++ b/src/util/workspace/npm.ts
@@ -31,6 +31,7 @@ interface Materialization {
   files: Record<string, string>;
   versions: Record<string, string>;
   seen: Set<string>;
+  declared: Set<string>;
 }
 
 export async function fetchNodeModules(packageJsonSource: string): Promise<{
@@ -48,11 +49,16 @@ export async function fetchNodeModules(packageJsonSource: string): Promise<{
     throw new Error(`Could not parse package.json: ${(err as Error).message}`);
   }
 
-  const ctx: Materialization = { files: {}, versions: {}, seen: new Set() };
   const deps = {
     ...pkg.peerDependencies,
     ...pkg.devDependencies,
     ...pkg.dependencies,
+  };
+  const ctx: Materialization = {
+    files: {},
+    versions: {},
+    seen: new Set(),
+    declared: new Set(Object.keys(deps)),
   };
 
   await Promise.all(
@@ -91,21 +97,25 @@ async function materialize(
   }
 
   if (isMarko) {
-    const pkgFiles = await loadTarball(name, meta, includedFile);
+    for (const depName in meta.peerDependencies) {
+      if (!providedPackages.has(depName) && !ctx.declared.has(depName)) {
+        throw new Error(
+          `${name} requires the peer dependency "${depName}", add it to package.json`,
+        );
+      }
+    }
+
+    const [pkgFiles] = await Promise.all([
+      loadTarball(name, meta, includedFile),
+      ...Object.entries(meta.dependencies || {}).map(([depName, depRange]) =>
+        materialize(ctx, depName, depRange, true).catch(() => {}),
+      ),
+    ]);
+
     if ("/marko.json" in pkgFiles) {
       for (const file in pkgFiles) {
         files[`/node_modules/${name}${file}`] = pkgFiles[file];
       }
-
-      await Promise.all([
-        ...Object.entries(meta.dependencies || {}).map(([depName, depRange]) =>
-          materialize(ctx, depName, depRange, true).catch(() => {}),
-        ),
-        ...Object.entries(meta.peerDependencies || {}).map(
-          ([depName, depRange]) =>
-            materialize(ctx, depName, depRange).catch(() => {}),
-        ),
-      ]);
     }
 
     return;


### PR DESCRIPTION
Follow-up to #184. Component libraries took a long time to load in the playground, and the preview pane sat blank with no feedback while they did.

## Changes

- **Pipeline dependency downloads.** A package's dependencies are listed in its registry metadata, so `materialize` now fetches them concurrently with the package's own tarball download instead of waiting for the tarball to be downloaded and untarred first. No custom caching is added: the registry serves tarballs with a one-year `max-age`, so the browser HTTP cache already makes repeat downloads near-instant.
- **Start downloads during HTML parse.** The playground page inlines a small best-effort script that decodes the workspace hash, reads its `package.json`, and fires the same registry requests the installer will make (with a compact resolver for exact/`^`/`~`/dist-tag ranges). Package downloads now overlap the playground bundle load instead of starting after it — on a cold load the first registry request moves from ~2.7s to ~140ms after navigation. A `preconnect` to the registry shaves the connection setup too. Any failure or version mismatch in the warm-up is harmless since the real installer re-requests through the HTTP cache.
- **Peer dependencies are no longer installed implicitly.** Unless the playground provides them (like `marko` itself), a peer dependency missing from the workspace `package.json` is now a build error (`@evo-web/marko requires the peer dependency "@ebay/skin", add it to package.json`), and the `package.json` template declares `@ebay/skin` alongside `@evo-web/marko`.
- **Show a loading indicator whenever the preview pane has nothing to display.** A pulsing `setting up` is server-rendered into the preview pane, covering the initial JS bundle load, package installs, and the gap between the iframe blanking on rebuild and the first server-rendered chunk streaming in. It clears as soon as the render produces output (or completes empty), is suppressed when an error pane is shown, and stays invisible for a one-second grace period so fast loads never flash it.

## Testing

Drove the production build in Chromium with shared-workspace hash URLs:

- Cold load (fresh browser profile): registry fetches start at ~140ms during HTML parse; the transitive tree fans out immediately and the rendered component appears and is interactive.
- A workspace declaring `@evo-web/marko` without `@ebay/skin` shows the missing-peer build error with no stranded indicator.
- The updated `package.json` template installs and `<evo-button>` renders with skin styles.
- Warm reload: both tarball requests are served from the browser HTTP cache in ~100ms each.

`npm run build` and `npm run lint` pass.