### PR TITLE
docs(reference): use step for the stepped-for TypeScript example

### DIFF
--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -172,7 +172,7 @@ export interface Input {
   content: Marko.Body<[number]>
 }
 
-<for|i| from=0 to=input.to by=2>
+<for|i| from=0 to=input.to step=2>
   <${input.content}(i)/>
 </for>
 ```


### PR DESCRIPTION
The typed-tag-parameter example (`for-by-two.marko`) on the TypeScript reference page uses `<for|i| from=0 to=input.to by=2>`, but on a ranged `<for from to>` the increment attribute is `step`. `by` is the hydration key, typed as an `(index) => string` callback, so `by=2`:

- **fails `mtc`** with TS2322 (`Type 'number' is not assignable to type '(index: number) => string'`), and
- **silently mis-renders**: `by` is dropped as the increment (which defaults to `step=1`), so the loop iterates by one instead of two.

An agent copying this official typed example hits a type error it can't resolve without already knowing `by != step`, and casting past it yields wrong output. Changing `by=2` to `step=2` type-checks cleanly and iterates correctly.

The same example ships in `@marko/runtime-class`'s docs; it's fixed in a companion PR (marko-js/marko#3498).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm9BdxbRQyQJeWbcBTTsJp)_