### PR TITLE
docs: warn that a dynamic tag name must already be sanitized

### DIFF
--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -810,6 +810,9 @@ export interface Input {
 <${"h" + input.headingSize}>Hello!</>
 ```
 
+> [!CAUTION]
+> A string tag name is written into the document as-is, so untrusted values expose the page to [XSS](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XSS). Never use user-provided content as a dynamic tag name.
+
 ### Dynamic Custom Tags
 
 ```marko


### PR DESCRIPTION
A string tag name is written into the document as-is, the same contract as an unescaped `$!{}` placeholder, but only the placeholder carried a caution. Wording follows the existing one.

Pairs with marko-js/marko#3594.