### PR TITLE
docs: warn that html-script and html-style parse as markup in svg

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -671,3 +671,6 @@ Though not typically needed, vanilla versions of these tags may be written via t
   @import url('https://fonts.googleapis.com/css2?family=Ubuntu&display=swap');
 </html-style>
 ```
+
+> [!CAUTION]
+> Inside [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) or [`<math>`](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/math) these tags parse as markup rather than raw text, so an interpolated `<` opens a real element. Never nest them in SVG or MathML with user-provided content.


### PR DESCRIPTION
Interpolations in `<html-script>`/`<html-style>` are escaped for html raw text, which neutralizes a closing tag. Inside `<svg>` or `<math>` those bodies parse as markup instead, so an interpolated `<` opens a real element.

Wording follows the existing `$!{...}` caution. Pairs with marko-js/marko#3595.