### PR TITLE
feat(playground): render compile errors as a highlighted code frame

### DIFF
--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -1,3 +1,19 @@
 # Developer Experience
 
 Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).
+
+## Map playground runtime errors back to the user's source
+
+`src/util/workspace.ts` › `onRuntimeError` | 2026-07-27 | impact:med | effort:med
+
+When an `ErrorEvent` carries no `error`, the handler synthesizes an `Error` whose
+message appends `ev.filename`, `ev.lineno` and `ev.colno`. Those coordinates
+point into the generated bundle, so the playground reports a location such as
+`server.js:1,38842`, which is real but names no file the user can open. Build
+errors avoid this because marko's `CompileError` frame already names the authored
+file, and the error output renders that frame. The workspace keeps sourcemaps for
+both the preview modules and the compiled templates, so the position could be
+mapped back to the authored file and line before the error is stored, letting
+runtime errors render the same code frame as build errors. Re-verify by entering
+a template that throws on render, such as calling a string method on a number,
+and reading the location shown in the runtime error card.

--- a/cspell.json
+++ b/cspell.json
@@ -47,6 +47,8 @@
     "mlog",
     "nbsp",
     "noindex",
+    "noopener",
+    "noreferrer",
     "onbeforeinput",
     "openjsf",
     "optgroup",

--- a/shim/kleur/browser.js
+++ b/shim/kleur/browser.js
@@ -1,0 +1,80 @@
+/**
+ * The playground bundles `@marko/compiler` for the browser, where terminal
+ * colors are meaningless: marko strips ANSI from a `CompileError` message
+ * anyway, and the playground renders the code frame itself.
+ *
+ * Beyond being unnecessary, kleur is actively broken in that bundle. It arrives
+ * as a lazily-initialized CJS module whose initializer has not run by the time
+ * the compiler formats an error, so `kleur.default.cyan` is undefined and every
+ * compile error surfaces as `TypeError: cyan is not a function` in place of the
+ * real diagnostic. Identity functions sidestep both problems, and drop kleur's
+ * ANSI machinery from the client bundle.
+ *
+ * The compiler reaches these through `require("kleur")` wrapped in an interop
+ * helper, which lands on either the module namespace or the default export
+ * depending on how it is bundled, so both carry the full surface.
+ */
+
+/** Returns the chain when called bare, so `bold().red(s)` keeps working. */
+const style = (text) => (text === undefined ? kleur : `${text}`);
+
+const kleur = {
+  enabled: false,
+  reset: style,
+  bold: style,
+  dim: style,
+  italic: style,
+  underline: style,
+  inverse: style,
+  hidden: style,
+  strikethrough: style,
+  black: style,
+  red: style,
+  green: style,
+  yellow: style,
+  blue: style,
+  magenta: style,
+  cyan: style,
+  white: style,
+  gray: style,
+  grey: style,
+  bgBlack: style,
+  bgRed: style,
+  bgGreen: style,
+  bgYellow: style,
+  bgBlue: style,
+  bgMagenta: style,
+  bgCyan: style,
+  bgWhite: style,
+};
+
+export const {
+  reset,
+  bold,
+  dim,
+  italic,
+  underline,
+  inverse,
+  hidden,
+  strikethrough,
+  black,
+  red,
+  green,
+  yellow,
+  blue,
+  magenta,
+  cyan,
+  white,
+  gray,
+  grey,
+  bgBlack,
+  bgRed,
+  bgGreen,
+  bgYellow,
+  bgBlue,
+  bgMagenta,
+  bgCyan,
+  bgWhite,
+} = kleur;
+
+export default kleur;

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -142,9 +142,7 @@ div class=styles.result
 
   div class=styles.output
     if=ws.buildErrors
-      div class=styles.error
-        p -- ${ws.buildErrors.join("\n")}
-        p -- Check the devtools console for more information.
+      error-output errors=ws.buildErrors kind="build"
     else if=outputType !== "preview"
       div
         ,id=styles.compiled
@@ -160,9 +158,7 @@ div class=styles.result
           )
         }
     else if=ws.runtimeErrors
-      div class=styles.error
-        p -- ${ws.runtimeErrors.join("\n")}
-        p -- Check the devtools console for more information.
+      error-output errors=ws.runtimeErrors kind="runtime"
 
     iframe/$frame
       ,title="code output"

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -95,16 +95,6 @@
   }
 }
 
-.error {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  white-space: pre;
-  padding: 1rem;
-}
-
 .stats {
   display: flex;
   align-items: center;

--- a/src/routes/playground/tags/playground/tags/result/tags/error-output/error-output.marko
+++ b/src/routes/playground/tags/playground/tags/result/tags/error-output/error-output.marko
@@ -1,0 +1,100 @@
+client import highlighter from "app/util/shiki";
+import { styleToClass } from "app/util/style-to-class";
+import {
+  langForFile,
+  parseError,
+  parseInline,
+  type CodeFrame,
+  type Inline,
+} from "app/util/compile-error";
+import styles from "./error-output.style.module.scss";
+export interface Input {
+  errors: readonly unknown[];
+  kind: "build" | "runtime";
+}
+
+// Both playground themes are emitted at once and picked by a media query, so
+// tokens carry `--shiki-light`/`--shiki-dark` rather than a resolved color.
+static const themes = { light: "marko-light", dark: "marko-dark" } as const;
+
+// Diagnostics only ever nest code spans inside a link, never another link, so
+// the leaf renderer stays separate rather than recursing.
+define/Leaf|{ node }: { node: Inline }|
+  if=node.type === "code"
+    code -- ${node.value}
+  else -- ${(node as { value: string }).value}
+
+define/Text|{ nodes }: { nodes: Inline[] }|
+  for|node| of=nodes
+    if=node.type === "link"
+      a
+        ,href=node.href
+        ,target=node.external && "_blank"
+        ,rel=node.external && "noopener noreferrer"
+        for|child| of=node.children
+          Leaf node=child
+    else
+      Leaf node=node
+
+define/Frame|{ frame }: { frame: CodeFrame }|
+  // Highlighting the frame as one snippet keeps constructs spanning its lines
+  // tokenized together, and yields one token array per row.
+  const/lines=(
+    highlighter.codeToTokens(frame.rows.map((row) => row.code).join("\n"), {
+      lang: langForFile(frame.file),
+      defaultColor: false,
+      themes,
+    }).tokens
+  )
+  div/frameEl class=styles.frame
+    for|row, i| of=frame.rows
+      div class=styles.gutter aria-hidden="true" data-error=row.isError --
+        ${row.num}
+      // `shiki` is the global class the layout hangs the theme's
+      // `--shiki-light`/`--shiki-dark` to `color` mapping off of.
+      div class=[styles.line, "shiki"] data-error=row.isError
+        for|token| of=lines[i] || []
+          span class=styleToClass(token.htmlStyle) -- ${token.content}
+      if=row.marker
+        div class=styles.gutter aria-hidden="true"
+        // Plain text on the same monospace grid, so the carets line up with
+        // the source above without measuring anything.
+        div class=styles.marker
+          -- ${" ".repeat(row.marker.start)}
+          span data-caret -- ${"^".repeat(row.marker.width)}
+
+  script --
+    const el = frameEl();
+    const caret = frame.rows.some((row) => row.marker)
+      ? (el.querySelector("[data-caret]") as HTMLElement | null)
+      : null;
+    if (caret) {
+      // A long line pushes the underlined token off the right edge, leaving a
+      // frame that shows everything except the part being pointed at.
+      el.scrollLeft = Math.max(0, caret.offsetLeft - el.clientWidth / 3);
+    }
+
+div class=styles.errors role="alert"
+  for|err| of=input.errors
+    const/parsed=parseError(err)
+    section class=styles.error
+      header class=styles.head
+        span class=styles.badge --
+          ${input.kind === "build" ? "Build failed" : "Runtime error"}
+        if=parsed.frame
+          span class=styles.location --
+            ${`${parsed.frame.file}:${parsed.frame.line}:${parsed.frame.col}`}
+        // A bare "Error" only repeats the badge; anything more specific earns
+        // its place.
+        else if=parsed.name !== "Error"
+          span class=styles.location -- ${parsed.name}
+
+      if=parsed.message
+        p class=styles.message
+          Text nodes=parseInline(parsed.message)
+
+      if=parsed.frame
+        Frame frame=parsed.frame
+
+      if=parsed.details
+        pre class=styles.details -- ${parsed.details}

--- a/src/routes/playground/tags/playground/tags/result/tags/error-output/error-output.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/tags/error-output/error-output.style.module.scss
@@ -1,0 +1,149 @@
+.errors {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: var(--color-background);
+}
+
+.error {
+  border: 1px solid var(--color-red-dim);
+  border-left-width: 4px;
+  border-radius: 4px;
+  background-color: var(--color-background);
+  overflow: hidden;
+}
+
+.head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-red-dim);
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: bold;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-red);
+}
+
+.location {
+  font-family: "Ubuntu Mono", monospace;
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.75;
+  margin-left: auto;
+}
+
+.message {
+  margin: 0;
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  // Runtime errors carry their location on a second line; without this it runs
+  // straight into the end of the sentence.
+  white-space: pre-wrap;
+
+  code {
+    font-family: "Ubuntu Mono", monospace;
+    font-size: 1em;
+    padding: 0.05em 0.3em;
+    border-radius: 3px;
+    background-color: var(--color-gray-dim);
+  }
+
+  a {
+    color: var(--color-blue);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+
+    &:hover {
+      text-decoration-thickness: 2px;
+    }
+
+    // Diagnostics routinely wrap a code span in a link. Letting the chip keep
+    // its own background breaks the underline into disconnected runs.
+    code {
+      padding: 0;
+      background: none;
+      color: inherit;
+    }
+  }
+}
+
+.frame {
+  // A two-column grid keeps every gutter and caret row on the same baseline
+  // grid as the source above it.
+  display: grid;
+  // `max-content` floor so a row's background spans the whole scrollable width
+  // rather than stopping at the container edge; `1fr` still fills short frames.
+  grid-template-columns: auto minmax(max-content, 1fr);
+  align-items: start;
+  // Makes this the offset parent the caret's scroll position is measured from.
+  position: relative;
+  font-family: "Ubuntu Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--color-gray-alt-dim);
+  background-color: var(--color-gray-dim);
+  overflow-x: auto;
+}
+
+.gutter {
+  // Stays put while a long line scrolls horizontally underneath it, so the
+  // line numbers remain readable. Needs an opaque background to cover the code.
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background-color: var(--color-gray-dim);
+  padding: 0 0.75rem 0 0.5rem;
+  text-align: right;
+  user-select: none;
+  opacity: 0.5;
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
+
+  &[data-error] {
+    opacity: 1;
+    color: var(--color-red);
+    font-weight: bold;
+    background-color: var(--color-red-dim);
+  }
+}
+
+.line {
+  white-space: pre;
+  padding-right: 0.75rem;
+
+  &[data-error] {
+    background-color: var(--color-red-dim);
+  }
+}
+
+.marker {
+  white-space: pre;
+  padding-right: 0.75rem;
+  color: var(--color-red);
+  font-weight: bold;
+}
+
+.details {
+  margin: 0;
+  padding: 0.75rem;
+  border-top: 1px solid var(--color-gray-alt-dim);
+  font-family: "Ubuntu Mono", monospace;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  opacity: 0.75;
+}

--- a/src/util/compile-error.ts
+++ b/src/util/compile-error.ts
@@ -1,0 +1,196 @@
+/**
+ * Marko's `CompileError` carries a Babel-style code frame inside its message:
+ *
+ *     at app/tags/index.marko:1:2
+ *     > 1 | <log/>
+ *         |  ^^^ The [`<log>` tag](https://markojs.com/docs/...) requires ...
+ *       2 |
+ *
+ * Rendering that string as-is loses the alignment the frame depends on and
+ * leaves the diagnostic's markdown as literal brackets and raw URLs. Parsing it
+ * back into rows lets the playground syntax highlight the source, align the
+ * carets on a real grid, and turn the links into links.
+ */
+
+/** `at <file>:<line>:<col>` */
+const LOCATION_ROW = /^\s*at (.+?):(\d+):(\d+)\s*$/;
+/** `> 1 | <source>` for the offending line, `  2 | <source>` for context. */
+const CODE_ROW = /^(\s*)(>)?\s*(\d+) \|(?: ?(.*))?$/;
+/** `    |  ^^^ <message>` — the pipe aligns with the code rows' pipe. */
+const MARKER_ROW = /^\s*\|( *)(\^+) ?(.*)$/;
+
+const DOCS_ORIGIN = "https://markojs.com/";
+
+export interface CodeRow {
+  num: number;
+  code: string;
+  /** The line the compiler pointed at, marked `>` in the raw frame. */
+  isError: boolean;
+  /** Column offset and width of the `^^^` run underlining this row. */
+  marker?: { start: number; width: number };
+}
+
+export interface CodeFrame {
+  file: string;
+  line: number;
+  col: number;
+  rows: CodeRow[];
+}
+
+export interface ParsedError {
+  name: string;
+  /** The diagnostic itself, as markdown. Empty when the error carries none. */
+  message: string;
+  frame?: CodeFrame;
+  /** Anything that did not belong to the frame, such as a runtime stack. */
+  details?: string;
+}
+
+export function parseError(err: unknown): ParsedError {
+  const name = errorName(err);
+  const raw = errorMessage(err);
+  const lines = raw.split("\n");
+
+  let frame: CodeFrame | undefined;
+  let message = "";
+  const leading: string[] = [];
+  const trailing: string[] = [];
+
+  for (const line of lines) {
+    const location = LOCATION_ROW.exec(line);
+    if (location && !frame) {
+      frame = {
+        file: location[1],
+        line: +location[2],
+        col: +location[3],
+        rows: [],
+      };
+      continue;
+    }
+
+    if (frame) {
+      const code = CODE_ROW.exec(line);
+      if (code) {
+        frame.rows.push({
+          num: +code[3],
+          code: code[4] ?? "",
+          isError: !!code[2],
+        });
+        continue;
+      }
+
+      const marker = MARKER_ROW.exec(line);
+      if (marker) {
+        const row = frame.rows[frame.rows.length - 1];
+        if (row) {
+          // The code starts one space past the pipe, so the caret's own
+          // leading run is one wider than its offset into the source line.
+          row.marker = { start: marker[1].length - 1, width: marker[2].length };
+        }
+        if (marker[3]) message = marker[3];
+        continue;
+      }
+    }
+
+    if (line.trim()) (frame ? trailing : leading).push(line);
+  }
+
+  // A frame whose trailing context line is blank adds nothing but height.
+  while (frame?.rows.length && isBlankTail(frame.rows)) frame.rows.pop();
+
+  if (!message) message = leading.join("\n").trim();
+  else if (leading.length) trailing.unshift(...leading);
+
+  return {
+    name,
+    message,
+    frame: frame?.rows.length ? frame : undefined,
+    details: trailing.join("\n").trim() || undefined,
+  };
+}
+
+function isBlankTail(rows: CodeRow[]) {
+  const last = rows[rows.length - 1];
+  return rows.length > 1 && !last.isError && !last.marker && !last.code.trim();
+}
+
+function errorName(err: unknown) {
+  const name = (err as Error)?.name;
+  return typeof name === "string" && name ? name : "Error";
+}
+
+function errorMessage(err: unknown) {
+  if (err instanceof Error) return err.message;
+  return typeof err === "string" ? err : String(err);
+}
+
+export type Inline =
+  | { type: "text"; value: string }
+  | { type: "code"; value: string }
+  | { type: "link"; href: string; external: boolean; children: Inline[] };
+
+/** `[label](href)` or `` `code` ``. Labels may themselves hold code spans. */
+const INLINE_TOKEN = /\[((?:[^[\]]|\[[^\]]*\])*)\]\(([^\s)]+)\)|`([^`]+)`/g;
+
+/**
+ * Diagnostics are authored as markdown, but only ever use links and code spans,
+ * so a full markdown parser would be far more machinery than the grammar needs.
+ */
+export function parseInline(markdown: string): Inline[] {
+  const nodes: Inline[] = [];
+  let last = 0;
+
+  for (const match of markdown.matchAll(INLINE_TOKEN)) {
+    pushText(nodes, markdown.slice(last, match.index));
+    last = match.index + match[0].length;
+
+    if (match[3] !== undefined) {
+      nodes.push({ type: "code", value: match[3] });
+    } else {
+      const href = resolveHref(match[2]);
+      nodes.push({
+        type: "link",
+        href,
+        external: href === match[2] && /^[a-z]+:/i.test(href),
+        children: parseInline(match[1]),
+      });
+    }
+  }
+
+  pushText(nodes, markdown.slice(last));
+  return nodes;
+}
+
+function pushText(nodes: Inline[], value: string) {
+  if (value) nodes.push({ type: "text", value });
+}
+
+/**
+ * Diagnostics link to markojs.com absolutely. The playground is served from
+ * that same site, so keep those links in-page — and on the right deploy, since
+ * PR previews live under a base path.
+ */
+function resolveHref(href: string) {
+  if (!href.startsWith(DOCS_ORIGIN)) return href;
+  // `import.meta.env` is absent when this module runs outside the bundler.
+  const base =
+    typeof import.meta.env === "undefined" ? "/" : import.meta.env.BASE_URL;
+  return base + href.slice(DOCS_ORIGIN.length);
+}
+
+const LANGS: Record<string, string> = {
+  marko: "marko",
+  js: "js",
+  mjs: "js",
+  cjs: "js",
+  ts: "ts",
+  mts: "ts",
+  json: "json",
+  css: "css",
+  html: "html",
+};
+
+export function langForFile(file: string | undefined) {
+  const ext = file?.slice(file.lastIndexOf(".") + 1).toLowerCase();
+  return (ext && LANGS[ext]) || "marko";
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,17 @@ export default defineConfig({
         find: /^prettier$/,
         replacement: "prettier/standalone",
       },
+      // @marko/compiler colors a CompileError's file name with kleur. Bundled
+      // for the browser it becomes a lazily-initialized CJS module that is still
+      // uninitialized when the compiler formats an error, so every compile error
+      // in the playground surfaced as `TypeError: cyan is not a function` rather
+      // than the diagnostic. Only the browser bundle resolves through Vite; the
+      // compiler that runs the build is required by node, so its output stays
+      // colored.
+      {
+        find: /^kleur$/,
+        replacement: path.resolve("./shim/kleur/browser.js"),
+      },
     ],
   },
   optimizeDeps: {


### PR DESCRIPTION
Marko's `CompileError` already carries a Babel-style code frame in its message, but the playground rendered it with `errors.join("\n")` into a `<p>` in the body font, so the gutter and carets it depends on no longer lined up, and the diagnostic's markdown showed as literal brackets and raw URLs.

`compile-error.ts` parses the frame back into rows and a message. The new `<error-output>` tag re-renders it with the source syntax highlighted through the existing shiki setup, carets on a monospace grid under the token they point at, and the markdown links resolved against `BASE_URL` so they stay in-site on previews. Long lines auto-scroll to reveal the caret and keep the line numbers pinned. Runtime errors, which have no frame, degrade to the message alone.

The second commit fixes a pre-existing production-only bug this surfaced. `@marko/compiler` colors a `CompileError`'s file name with kleur, which reaches the client bundle as a lazily-initialized CJS module that is still uninitialized when an error is formatted, so every compile error in production showed `TypeError: cyan is not a function` in place of the diagnostic. It reproduces on `main`, and dev is unaffected because Vite pre-bundles kleur as real ESM. Aliasing kleur to an identity shim for the browser fixes it and drops the ANSI machinery from the bundle; the compiler that runs the build resolves outside Vite, so terminal output stays colored.