### PR TITLE
ci: gate the production deploy on the check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
 
@@ -41,6 +41,9 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    # Without this the two jobs race, and a lint, formatting or type-check
+    # failure still deploys to markojs.com.
+    needs: check
     if: "${{ github.repository_owner == 'marko-js' && github.event_name == 'push' }}"
     permissions:
       contents: write


### PR DESCRIPTION
`check` and `release` are two independent jobs in one workflow — there is no `needs:` anywhere in `.github/workflows/`. On a push to `main` the deploy starts in parallel with lint, formatting and type-check, so a failure in any of those still reaches markojs.com. A hard build break is caught only incidentally, because `release` happens to rebuild.

Adding `needs: check` makes the deploy wait on the gate. `check` has no `if:` guard so it always runs on push, and if it fails or is cancelled, `release` is skipped.

Also adds `reopened` to the `pull_request` trigger. `preview.yml` already listens for it, so reopening a stale PR deployed a fresh preview with no CI run at all and left the PR looking green from an older base.

Trade-off worth naming: the deploy now waits for a full `check` run (which builds and type-checks) before `release` starts its own build, so time-to-deploy on `main` roughly doubles. Sharing one build artifact between the jobs would avoid that, but the two builds are not interchangeable today — `release` builds with `REPO_GITHUB_API_TOKEN` and `check` does not, so they produce different contributor data. That is worth fixing separately.