### PR TITLE
perf(search): load the search index on demand instead of on every page

### DIFF
--- a/src/tags/search-dialog/search-dialog.marko
+++ b/src/tags/search-dialog/search-dialog.marko
@@ -1,5 +1,5 @@
 import styles from "./search-dialog.style.module.scss";
-client import { sendQuery } from "./search-worker-client";
+client import { sendQuery, warmSearch } from "./search-worker-client";
 import type { SearchHit } from "../../util/search-worker";
 
 static function highlightSegments(text: string, query: string) {
@@ -25,6 +25,7 @@ let/activeIndex=-1
 
 script --
   if (open) {
+    warmSearch();
     if (!$dialog().open) {
       $dialog().showModal();
       $input().focus();

--- a/src/tags/search-dialog/search-worker-client.ts
+++ b/src/tags/search-dialog/search-worker-client.ts
@@ -24,7 +24,13 @@ function ensureWorker(): Promise<void> {
   return ready;
 }
 
-ensureWorker();
+/**
+ * Start the worker and its index fetch before the first keystroke. Best effort:
+ * a failed init is reported when `sendQuery` awaits the same promise.
+ */
+export function warmSearch(): void {
+  ensureWorker().catch(() => {});
+}
 
 export async function sendQuery(q: string): Promise<SearchHit[]> {
   await ensureWorker();


### PR DESCRIPTION
`search-worker-client.ts` called `ensureWorker()` at module scope. The search dialog lives in the layout, so every one of the 223 rendered pages spawned the worker and fetched `search-index.json` before the user did anything:

| | raw | gzip |
|---|---|---|
| `search-worker.js` | 50.9 KB | 17.2 KB |
| `search-index.json` | 249.7 KB | 70.0 KB |
| **deferred total** | **300.6 KB** | **87.2 KB** |
| a docs page (html + css + js, 8 files) | 97.9 KB | 26.0 KB |

So the search payload was ~3.4x the gzipped weight of the page carrying it, on every navigation including the 404 page.

`sendQuery` already awaits `ensureWorker()`, so removing the eager call is sufficient on its own. To avoid trading that for a slow first search, `warmSearch()` is called from the dialog's open effect, so the fetch starts when the dialog opens rather than on the first keystroke. A query issued while the index is still loading already renders nothing rather than a premature "No results found." — that branch requires `results` to be defined.

`warmSearch` swallows its rejection because the real error path is `sendQuery`, which awaits the same promise; the previous module-scope call had no handler at all and produced an unhandled rejection whenever init failed.

Verified in the built bundle: the bare module-scope call (`…postMessage({type:'init'}),Zt)}Qt();`) is gone, replaced by the wrapper, and the dialog effect compiles to `e.j?($t(),e.a.open||(e.a.showModal()…` — warming before it opens.