### PR TITLE
fix(search): resolve the index against BASE_URL so previews can search

### DIFF
--- a/src/util/search-worker.ts
+++ b/src/util/search-worker.ts
@@ -159,7 +159,9 @@ self.onmessage = async (e: MessageEvent) => {
   switch (type) {
     case "init": {
       try {
-        const res = await fetch("/search-index.json");
+        // Root-relative would miss the index on a preview deploy, which serves
+        // the site from /previews/pr-N/. BASE_URL always carries a trailing slash.
+        const res = await fetch(`${import.meta.env.BASE_URL}search-index.json`);
         const blocks: SearchBlock[] = await res.json();
         init(blocks);
         self.postMessage({ type: "ready" });


### PR DESCRIPTION
`search-worker.ts` fetched `/search-index.json` root-relative. Preview deploys serve the site from `/previews/pr-N/`, so that request 404s, `ready` rejects, and every subsequent `sendQuery` rejects with it — search silently returns nothing for the entire preview session.

Previews are a supported target, not an accident: `search-index-builder.ts:32` deliberately bakes `BASE_URL` into every result href. The index fetch was the one place that missed it.

Vite replaces `import.meta.env.BASE_URL` inside the worker bundle as well as the main one, so this needs no `init` message plumbing. Verified by building both ways:

- `BASE_URL=/previews/pr-999/` → `fetch(\`/previews/pr-999/search-index.json\`)`, with zero unresolved `import.meta.env` left in the worker
- no `BASE_URL` → `fetch(\`/search-index.json\`)`, and the emitted worker chunk hash is unchanged at `search-worker-9HKwpoCR.js`, so production output is byte-identical

Best checked on this PR's own preview: search should return results there, where it currently returns nothing on any preview.