### PR TITLE
fix(playground): terminate the preview worker a rebuild replaces

### DIFF
--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -132,6 +132,9 @@ export async function update(
   optimize: boolean,
 ) {
   const fs = new FileSystem({});
+  // Read before `workspace` is reassigned below: this holds the only reference
+  // to the running preview server, which stays up until this build replaces it.
+  const previous = workspace;
   const ws: Workspace = (workspace = {
     fs,
     optimize,
@@ -196,13 +199,13 @@ export async function update(
       if (signal.aborted) return;
 
       const code = getAssetCode(output, file);
-      workspace.server?.terminate();
+      previous?.server?.terminate();
 
       if (!code) {
         return;
       }
 
-      ws.server = new Worker(
+      const server = new Worker(
         toAssetURL(
           file,
           "application/javascript",
@@ -215,7 +218,17 @@ export async function update(
           type: "module",
         },
       );
-      ws.server.addEventListener("error", onRuntimeError, { signal });
+
+      // An abort between the check above and here would otherwise strand this
+      // worker: `workspace` already points at a newer build, so nothing else
+      // holds a reference to terminate it.
+      if (signal.aborted) {
+        server.terminate();
+        return;
+      }
+
+      ws.server = server;
+      server.addEventListener("error", onRuntimeError, { signal });
     })();
     const browserBuild = (async function buildClient() {
       const file = "client.js";


### PR DESCRIPTION
`update()` reassigns the module-level `workspace` to the new build on its first statement:

```ts
const ws: Workspace = (workspace = { … });
```

so by the time `buildServer` reached `workspace.server?.terminate()`, `workspace` was the **new** workspace, whose `server` is not assigned until ~15 lines further down. The terminate call was always a no-op — and the only reference to the worker it was meant to kill had already been overwritten by that same reassignment.

The result is a live `Worker` stranded per rebuild, each holding a full compiled Marko server bundle. `result.marko` drives `update()` from an effect on debounced `files`, so typing a handful of characters leaves a handful of workers running until the tab is closed.

Two changes:

- The previous workspace is captured **before** the reassignment, and its worker is terminated at the same point as before — after the new build has produced code. Keeping that placement matters: the running preview server stays up while a rebuild is in flight instead of the preview going blank.
- A build that gets past the final `signal.aborted` check can still construct a worker that nothing can reach, because `workspace` already points at a newer build. That worker is now terminated rather than installed.

### Verification

There is no browser driver in this repo, so this is **not** demonstrated at runtime — worth knowing when reviewing. What I did check, in the built `playground-*.js`:

```js
async function z4(e,t,n,r){ let i=new g4({}), a=A4, o=A4={fs:i,…}
                                              ^^^^ previous captured before the reassign
…if(a?.server?.terminate(),!l)return;            ← terminates the previous, not the new one
…if(e.aborted){u.terminate();return}o.server=u   ← the stranded-worker guard
```

Type-check, lint, prettier, the unit tests and a full production build all pass.

Teardown is not a third leak path: there is no `pushState`/`popstate` anywhere in `src`, so leaving the playground is a full page navigation and the last worker goes with the document.