### PR TITLE
fix(search): match replies to the query that asked for them

### DIFF
--- a/src/tags/search-dialog/search-worker-client.ts
+++ b/src/tags/search-dialog/search-worker-client.ts
@@ -2,6 +2,9 @@ import type { SearchHit } from "../../util/search-worker";
 
 let worker: Worker | undefined;
 let ready: Promise<void> | undefined;
+let lastQueryId = 0;
+/** Resolvers keyed by request id, so a reply only settles the query it answers. */
+const pending = new Map<number, (hits: SearchHit[]) => void>();
 
 function ensureWorker(): Promise<void> {
   if (ready) return ready;
@@ -20,6 +23,14 @@ function ensureWorker(): Promise<void> {
     }
     worker!.addEventListener("message", onMessage);
   });
+  worker.addEventListener("message", (e: MessageEvent) => {
+    if (e.data?.type !== "results") return;
+    const resolve = pending.get(e.data.id);
+    if (resolve) {
+      pending.delete(e.data.id);
+      resolve(e.data.results);
+    }
+  });
   worker.postMessage({ type: "init" });
   return ready;
 }
@@ -34,15 +45,10 @@ export function warmSearch(): void {
 
 export async function sendQuery(q: string): Promise<SearchHit[]> {
   await ensureWorker();
+  const id = ++lastQueryId;
   const result = new Promise<SearchHit[]>((resolve) => {
-    worker!.addEventListener(
-      "message",
-      (e: MessageEvent) => {
-        if (e.data.type === "results") resolve(e.data.results);
-      },
-      { once: true },
-    );
+    pending.set(id, resolve);
   });
-  worker!.postMessage({ type: "query", query: q });
+  worker!.postMessage({ type: "query", query: q, id });
   return result;
 }

--- a/src/util/search-worker.ts
+++ b/src/util/search-worker.ts
@@ -154,7 +154,7 @@ function lookup(hrefs: string[]): SearchHit[] {
 // ── Worker message handler ───────────────────────────────────────────
 
 self.onmessage = async (e: MessageEvent) => {
-  const { type, query, hrefs } = e.data;
+  const { type, query, hrefs, id } = e.data;
 
   switch (type) {
     case "init": {
@@ -173,7 +173,8 @@ self.onmessage = async (e: MessageEvent) => {
 
     case "query": {
       const results = search(query);
-      self.postMessage({ type: "results", results, query });
+      // `id` is echoed so the client can tell which query a reply answers.
+      self.postMessage({ type: "results", results, query, id });
       break;
     }
 


### PR DESCRIPTION
`sendQuery` attached a `{ once: true }` message listener and resolved on whatever came back first, which broke two ways.

**Results trail a keystroke behind.** Any in-flight query is settled by the first reply to arrive, regardless of which query it answers. Type `a`, then `ab` before `a` returns: the reply for `a` fires both listeners, so the promise for `ab` resolves with `a`'s hits. `search-dialog.marko`'s `$signal.aborted` guard does not catch this — the newest effect is not the aborted one — so the panel commits the stale hits. The reply for `ab` then arrives with no listener left and is dropped. While typing quickly the panel steadily shows the previous keystroke's results.

**A non-`results` message strands the query.** `once` is spent by whichever message arrives, so anything else in the stream left that promise pending forever.

Queries now carry an id which the worker echoes back, and one persistent listener resolves only the matching request. Replies that match nothing are ignored, which also makes the unused `recents` branch (it posts `results` with no id) harmless rather than a source of cross-talk.

Best checked on the preview: type quickly into the search dialog and confirm the results match what is in the box rather than the previous keystroke.