### PR TITLE
fix(playground): fall back to the default files when a share link will not decode

### DIFF
--- a/src/routes/playground/tags/hash-files.marko
+++ b/src/routes/playground/tags/hash-files.marko
@@ -1,5 +1,5 @@
 import type { File } from "app/util/workspace";
-client import { compress, decompress } from "app/util/hasher";
+client import { compress, decodeFiles } from "app/util/hasher";
 export interface Input {
   value: File[];
 }
@@ -7,8 +7,8 @@ export interface Input {
 let/value=[] as File[]
 lifecycle
   ,onMount() {
-    decompress(window.location.hash.slice(1)).then((decompressed) => {
-      value = JSON.parse(decompressed) || input.value;
+    decodeFiles(window.location.hash.slice(1)).then((files) => {
+      value = files ?? input.value;
     });
   }
   ,onUpdate() {

--- a/src/util/hasher.test.ts
+++ b/src/util/hasher.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "vitest";
+
+import { compress, decodeFiles } from "./hasher";
+
+const FILES = [
+  { path: "index.marko", content: "<div>hello</div>\n" },
+  { path: "package.json", content: '{ "name": "playground" }\n' },
+];
+
+async function hashFor(value: unknown) {
+  return compress(JSON.stringify(value));
+}
+
+test("round-trips a real share link", async () => {
+  expect(await decodeFiles(await hashFor(FILES))).toEqual(FILES);
+});
+
+test("survives a hash truncated in transit", async () => {
+  const hash = await hashFor(FILES);
+  // Chat clients and word wrap clip long links; the gzip body then fails.
+  expect(await decodeFiles(hash.slice(0, Math.floor(hash.length / 2)))).toBe(
+    undefined,
+  );
+});
+
+test("survives a hash that is not base64 at all", async () => {
+  // `atob` throws rather than returning empty for these.
+  expect(await decodeFiles("foo!")).toBe(undefined);
+  expect(await decodeFiles("%%%")).toBe(undefined);
+});
+
+test("survives base64 that decodes to something else", async () => {
+  expect(await decodeFiles("abc")).toBe(undefined);
+  expect(await decodeFiles("hello")).toBe(undefined);
+  expect(await decodeFiles(btoa("not our payload"))).toBe(undefined);
+});
+
+test("rejects a payload that is not a file list", async () => {
+  expect(await decodeFiles(await hashFor({ path: "index.marko" }))).toBe(
+    undefined,
+  );
+  expect(await decodeFiles(await hashFor(["index.marko"]))).toBe(undefined);
+  expect(await decodeFiles(await hashFor([{ path: "a.marko" }]))).toBe(
+    undefined,
+  );
+  expect(await decodeFiles(await hashFor(42))).toBe(undefined);
+});
+
+test("treats an empty hash as nothing shared", async () => {
+  expect(await decodeFiles("")).toBe(undefined);
+});
+
+test("keeps content with characters that survive base64 poorly", async () => {
+  const tricky = [
+    { path: "unicode.marko", content: "<p>世界 🎉 — ok</p>\n" },
+    { path: "slashes.marko", content: "a/b+c=d\n" },
+  ];
+  expect(await decodeFiles(await hashFor(tricky))).toEqual(tricky);
+});

--- a/src/util/hasher.ts
+++ b/src/util/hasher.ts
@@ -1,5 +1,6 @@
 import lzString from "lz-string";
 import { streamToIterable } from "./stream-to-iterable";
+import type { File } from "./workspace";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -24,7 +25,44 @@ export async function compress(value: string) {
     .replace(/\//g, "_");
 }
 
-export async function decompress(value: string) {
+/**
+ * Decodes the files out of a share link's hash, or undefined if it cannot be
+ * read -- a link truncated in chat, one mangled in transit, or one holding
+ * something other than a file list. Never rejects, so a bad link falls back to
+ * the default files rather than leaving the playground blank and silent.
+ */
+export async function decodeFiles(hash: string): Promise<File[] | undefined> {
+  let json: string | null;
+  try {
+    json = await decompress(hash);
+  } catch {
+    // `atob` rejects a non-base64 hash, and gzip rejects a truncated one.
+    return undefined;
+  }
+  if (!json) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return isFileList(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isFileList(value: unknown): value is File[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (file) =>
+        !!file &&
+        typeof file === "object" &&
+        typeof file.path === "string" &&
+        typeof file.content === "string",
+    )
+  );
+}
+
+async function decompress(value: string) {
   if (!value) return "null";
   const decoded = atob(value.replace(/-/g, "+").replace(/_/g, "/"));
   if (decoded.startsWith(NEW_COMPRESSION_PREFIX)) {
@@ -36,8 +74,11 @@ export async function decompress(value: string) {
     for (let i = compressed.length; i--;) {
       bytes[i] = compressed.charCodeAt(i);
     }
-    writer.write(bytes);
-    writer.close();
+    // A truncated body errors the stream from both ends. The read below
+    // reports it; swallowing the writer's copy keeps it from surfacing as an
+    // unhandled rejection.
+    void writer.write(bytes).catch(() => {});
+    void writer.close().catch(() => {});
 
     let result = "";
     for await (const chunk of streamToIterable(stream.readable)) {


### PR DESCRIPTION
`onMount` did:

```js
value = JSON.parse(await decompress(hash)) || input.value;
```

The `||` only covers a falsy *parse result*, not a throw — and three real inputs throw:

- a hash containing a non-base64 character, where `atob` throws
- a truncated gzip body, where the decompression stream errors
- valid base64 that is not ours, where the legacy lz-string path returns `""` and `JSON.parse("")` throws

Any of them left `value` at `[]`, so `files.length` was 0, `update()` never ran, and the playground sat blank — no tabs, no editor content, no preview, and no message. A share link clipped by a chat client is enough to hit it.

Decoding now lives in `decodeFiles`, which is total: it returns `undefined` for anything it cannot read — including a payload that parses fine but is not a file list — and the caller falls back to the default files.

### A second bug the tests surfaced

Guarding the read was not sufficient. `writer.write(bytes)` and `writer.close()` return promises that reject independently when the body is truncated, so the stream error still escaped as an **unhandled rejection** (`Z_BUF_ERROR: unexpected end of file`) even with the read wrapped. Those are now handled; the read still reports the failure.

### Testing

Real round-trips and real corrupt inputs — no doubles. `CompressionStream`, `DecompressionStream` and `atob` all exist in Node, so the tests drive the actual code path: compress real files and decode them back, then feed it a half-truncated hash, `foo!`, `%%%`, `abc`, arbitrary base64, non-array payloads, and multi-byte UTF-8 content.