### PR TITLE
fix(a11y): make the docs mode toggles reachable by keyboard

### DIFF
--- a/src/tags/app-switch/app-switch.marko
+++ b/src/tags/app-switch/app-switch.marko
@@ -10,6 +10,8 @@ const/{ on, off, ...checkboxInput }=input
 label class=styles.label
   span -- ${off}
   span class=styles.appSwitch
-    input ...checkboxInput type="checkbox"
+    // `switch` announces the on/off state a checkbox only implies, which the
+    // visible "HTML"/"Concise" pair does not convey on its own.
+    input ...checkboxInput type="checkbox" role="switch"
     fa-icon=faToggleOff
   span -- ${on}

--- a/src/tags/app-switch/app-switch.style.module.scss
+++ b/src/tags/app-switch/app-switch.style.module.scss
@@ -1,7 +1,25 @@
 .appSwitch {
   width: 1.5rem;
+  position: relative;
+
+  // Hidden visually but still focusable and exposed to assistive tech. With
+  // `display: none` the control was reachable only by pointer.
   > input {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+  }
+
+  // The input carries the focus but cannot show it, so the icon stands in.
+  &:has(> input:focus-visible) {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+    border-radius: 2px;
   }
 
   > input:checked + svg {


### PR DESCRIPTION
The Concise/HTML and JS/TS switches are `<input type=checkbox>` styled with `display: none`. That removes them from the tab order **and** from the accessibility tree, so the `aria-label` each one carries was never announced and the only way to operate them was clicking the label. Two site-wide docs features were unusable without a pointer — WCAG 2.1.1 and 4.1.2.

The input is now hidden the way a control has to be if it still needs to work: clipped to a pixel but painted, so it stays focusable and exposed. Because it can no longer show its own focus ring, the icon draws one on its behalf with `:has(> input:focus-visible)`.

`role="switch"` is added so the on/off state is stated rather than implied. The visible "HTML"/"Concise" text sits outside the accessible name (the `aria-label` wins), so nothing else conveyed which way the control was set.

### Checked in the built output

Rendered markup, both toggles:

```html
<label class=_s><span>HTML</span><span class=_r><input type=checkbox role=switch aria-label="Toggle Concise mode">
<label class=_s><span>JS</span><span class=_r><input type=checkbox role=switch checked aria-label="Toggle TS mode">
```

Emitted CSS — `display:none` is gone, and the existing checked-state styling still applies:

```css
._r>input{clip-path:inset(50%);border:0;width:1px;height:1px;margin:-1px;padding:0;position:absolute;overflow:hidden}
._r:has(>input:focus-visible){outline-offset:3px;border-radius:2px;outline:2px solid}
._r>input:checked+svg{transform:scaleX(-1)}
._s:has(input:checked)>:first-child,._s:has(input:not(:checked))>:last-child{opacity:.5}
```

The focus outline inherits `currentColor` (`--color-foreground`), which computes to 16.1:1 against the background in both light and dark — well past the 3:1 a focus indicator needs.

Worth a quick manual pass on the preview: Tab to each toggle in the docs sidebar, confirm the ring appears and Space flips it.