### PR TITLE
fix(a11y): add a skip link and name the nav landmarks

### DIFF
--- a/src/routes/+layout.marko
+++ b/src/routes/+layout.marko
@@ -26,6 +26,10 @@ html lang="en"
     prefetch-links
 
   body spellcheck="false"
+    // Docs pages put ~50 nav links ahead of the article, and they are the only
+    // ones that render the `#main-content` target this jumps to.
+    if=($global.meta.headings)
+      a.skip-link href="#main-content" -- Skip to content
     div#root
       app-header
       main

--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -180,3 +180,22 @@ main {
     }
   }
 }
+
+// Off-screen until focused, so keyboard users can jump the docs sidebar
+// without the link taking up room for everyone else.
+.skip-link {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  padding: 0.75rem 1rem;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  outline: 2px solid currentColor;
+  border-radius: 0 0 0.25rem 0;
+  transform: translateY(-100%);
+
+  &:focus {
+    transform: none;
+  }
+}

--- a/src/routes/docs/+layout.marko
+++ b/src/routes/docs/+layout.marko
@@ -6,7 +6,9 @@ export interface Input {
   content: Marko.Body;
 }
 
-article id=styles.article
+// A stable id so the layout's skip link has something to target; the styling
+// hook moved to a class to free it up.
+article id="main-content" tabindex="-1" class=styles.article
   ${input.content}
   hr
   section id=styles.contributors

--- a/src/routes/docs/+layout.style.module.scss
+++ b/src/routes/docs/+layout.style.module.scss
@@ -22,7 +22,12 @@ main {
   }
 }
 
-#article {
+.article {
+  // Focused by the skip link, which should not leave a ring on a whole page.
+  &:focus {
+    outline: none;
+  }
+
   flex: 1;
   padding: 2.5rem 0;
   line-height: 1.5;

--- a/src/tags/app-header/app-header.marko
+++ b/src/tags/app-header/app-header.marko
@@ -41,7 +41,7 @@ header#header
     ,onClick() {
       mobileMenu = !mobileMenu;
     }
-    ,aria-pressed=(mobileMenu ? "true" : "false")
+    ,aria-expanded=(mobileMenu ? "true" : "false")
     ,aria-label=`${mobileMenu ? "Hide" : "Show"} menu`
     ,id=styles.hamburger
 

--- a/src/tags/app-menu/app-menu.marko
+++ b/src/tags/app-menu/app-menu.marko
@@ -20,7 +20,7 @@ div#site-menu class=styles.menu
       a href=value aria-current=($global.url.pathname === value && "true")
         ${content}
 
-  nav/$nav class=styles.nav id=styles.siteNav
+  nav/$nav aria-label="Documentation" class=styles.nav id=styles.siteNav
     ul
       li
         strong -- Newsletter


### PR DESCRIPTION
A docs page puts **52** tabbable elements between the top of the document and the article — 46 links, 2 buttons, 3 inputs and a select — with no way past them. Reaching the prose meant tabbing the entire sidebar on every navigation (WCAG 2.4.1).

The layout now renders a skip link as the first focusable element in the body, pointing at a stable `#main-content` on the docs article. The article's styling hook moves from `#article` to a class so the id is free — it had been a hashed CSS-module name (`_d1`), which nothing outside the module could link to.

It renders only on docs pages. Those are the only pages carrying the target and the only ones deep enough in nav to need it, so an always-present link would be a dead anchor elsewhere. The gate is `$global.meta.headings`, which `markodown` writes into `+meta.json` for every docs page and nothing else, and which resolves before render.

Two landmark fixes alongside it:

- The site nav had no accessible name while the table of contents beside it did, so every docs page carried two `nav` landmarks with only one distinguishable. It is now labelled `Documentation`.
- The mobile menu button reported `aria-pressed`, which describes a toggle button rather than a disclosure — it never announced that the menu had opened. Now `aria-expanded`.

### Checked in the built output

```
first tabbable in <body>:  <a href=#main-content class=skip-link>
target:                    <article id=main-content tabindex=-1 class=_d1>
nav:                       <nav aria-label=Documentation class=_z id=_A>
button:                    <button aria-expanded=false aria-label="Show menu" id=_v>
home page:                 0 skip links
```

The article's section-colour cycling survives the id→class move (`._d1>section:nth-of-type(4n+1..3)` still emitted), and the only remaining `aria-pressed` on a docs page is inside code samples in the language reference, not live markup.

There is no browser driver in this repo, so **focus behaviour is not exercised here** — worth a pass on the preview: Tab once from the address bar, confirm the link appears, and press Enter to land on the article.