### PR TITLE
fix(a11y): bring light-theme docs text up to AA contrast

### DIFF
--- a/src/routes/brand/+page.style.module.scss
+++ b/src/routes/brand/+page.style.module.scss
@@ -69,7 +69,7 @@
     background: linear-gradient(
       to bottom right,
       var(--section-color),
-      color-mix(in srgb, var(--section-color-alt), var(--section-color))
+      color-mix(in srgb, var(--section-color-alt) 30%, var(--section-color))
     );
     text-decoration: none;
     padding: 0.1rem 0.5rem;
@@ -95,7 +95,7 @@ h2 {
   background: linear-gradient(
     to bottom,
     var(--section-color),
-    color-mix(in srgb, var(--section-color-alt), var(--section-color))
+    color-mix(in srgb, var(--section-color-alt) 30%, var(--section-color))
   );
   background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/src/routes/docs/+layout.style.module.scss
+++ b/src/routes/docs/+layout.style.module.scss
@@ -60,7 +60,7 @@ main {
     background: linear-gradient(
       to bottom,
       var(--section-color),
-      color-mix(in srgb, var(--section-color-alt), var(--section-color))
+      color-mix(in srgb, var(--section-color-alt) 30%, var(--section-color))
     );
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -81,7 +81,7 @@ main {
     background: linear-gradient(
       to bottom,
       var(--section-color),
-      color-mix(in srgb, var(--section-color-alt), var(--section-color))
+      color-mix(in srgb, var(--section-color-alt) 30%, var(--section-color))
     );
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -95,7 +95,7 @@ main {
         background: linear-gradient(
           to bottom,
           var(--section-color),
-          color-mix(in srgb, var(--section-color-alt), var(--section-color))
+          color-mix(in srgb, var(--section-color-alt) 30%, var(--section-color))
         );
         background-clip: text;
         -webkit-text-fill-color: transparent;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -3,11 +3,14 @@
 
 $black: #202124;
 $white: #ffffff;
+// The first swatch is the light-theme text color: links, inline code and
+// headings all resolve to it, so each one clears 4.5:1 on white and on its own
+// tinted code background. Green and orange had to move furthest (2.83 and 3.15).
 $colors: (
-  ("red", #cc0067, #ff5467) /* mix: #e63467 */,
-  ("green", #00b068, #7ced64) /* mix: #49cf69 */,
-  ("blue", #0073d8, #00cffb) /* mix: #00a2ec */,
-  ("yellow", #fc5c00, #ffd100) /* mix: #ff9800 */,
+  ("red", #ca0066, #ff5467) /* mix: #e52a67 */,
+  ("green", #00814c, #7ced64) /* mix: #3eb758 */,
+  ("blue", #006ccb, #00cffb) /* mix: #009ee3 */,
+  ("yellow", #c44800, #ffd100) /* mix: #e28d00 */,
   ("gray", #6e6e6e, #cccccc) /* mix: #9c9c9c */
 );
 // ("purple", #5b43a7, #c999ec) /* mix: #916dca */

--- a/src/tags/search-dialog/search-dialog.style.module.scss
+++ b/src/tags/search-dialog/search-dialog.style.module.scss
@@ -90,7 +90,8 @@ html {
 
 .breadcrumbs {
   font-size: 0.75rem;
-  color: var(--color-blue-alt);
+  // `-alt` is the opposite theme's swatch, so this was the pale blue on white.
+  color: var(--color-blue);
 }
 
 .empty {


### PR DESCRIPTION
The first swatch of each palette entry is the light-theme text colour — links, inline code and headings all resolve to it — and two of them were well below AA. **This changes visible brand colour in light mode**, so it is worth looking at the preview.

Measured from the emitted stylesheet, before → after:

| | link on white | inline code | heading gradient stop |
|---|---|---|---|
| | *needs 4.5* | *needs 4.5* | *needs 3.0* |
| red | 5.58 → **5.67** | 4.43 → **4.50** | 4.29 → **4.87** |
| green | **2.83** → **4.95** | **2.59** → **4.53** | **2.03** → **3.33** |
| blue | 4.73 → **5.24** | **4.06** → **4.51** | **2.88** → **3.73** |
| orange | **3.15** → **4.91** | **2.89** → **4.52** | **2.18** → **3.38** |

Three separate causes:

- **The swatches.** Darkened only as far as needed to clear 4.5 on white *and* on their own tinted code background, which is the stricter of the two. Red and blue move imperceptibly (`#cc0067` → `#ca0066`, `#0073d8` → `#006ccb`); green and orange move visibly, which is unavoidable at 2.83 and 3.15.
- **Heading gradients** end on a 50/50 mix with the opposite swatch, which pulled green down to 2.03. Weighting that stop to 30% keeps the gradient and clears the 3:1 large-text bar.
- **Search breadcrumbs** asked for `--color-blue-alt` — the *other* theme's swatch, so pale blue on white at 1.86. Now `--color-blue`, 5.24.

### Dark mode is not regressed

It paints from the second swatch, which is untouched; the darker first swatch only deepens the backgrounds sitting behind it, so contrast goes up:

| | link | inline code |
|---|---|---|
| red | 5.15 | 4.72 |
| green | 10.85 | 9.01 *(was 7.96)* |
| blue | 8.68 | 7.29 |
| orange | 11.02 | 9.21 *(was 8.45)* |

All figures are computed from `dist/public/assets/_layout-*.css` after a real build, not from the source values.

### Still outstanding

The home hero headline still fades to 1.46:1 in light mode — `.yellowGradient`/`.blueGradient` in `src/styles/text.module.scss` hard-code `-dark → -light` and are not theme-swapped. Different mechanism and a different visual call, so it is a separate change.