### PR TITLE
build: drop the 404 pages the crawler emits at URLs that do not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "marko-run build && node scripts/rebase-html.mjs",
+    "build": "marko-run build && node scripts/prune-crawl-artifacts.mjs && node scripts/rebase-html.mjs",
     "deploy": "pnpm run build && gh-pages --nojekyll -d dist/public -u \"marko-js <noreply@markojs.com>\"",
     "dev": "marko-run",
     "format": "prettier . -w",

--- a/scripts/prune-crawl-artifacts.mjs
+++ b/scripts/prune-crawl-artifacts.mjs
@@ -1,0 +1,82 @@
+// Deletes 404 pages the static adapter emits at URLs that do not exist.
+//
+// `@marko/run-adapter-static` discovers pages by crawling, and resolves every
+// href it finds against the *origin* rather than the page it found them on
+// (`resolvePath(href, origin)` in its `visit`). A relative link is therefore
+// stripped of its directory: `./concise-syntax` on `/docs/reference/language`
+// becomes `/concise-syntax`. That path 404s, and the crawler writes the 404
+// body out as `concise-syntax.html`, which a static host then serves at 200.
+//
+// The result is dozens of thin, identical, indexable pages sitting beside the
+// real docs, all titled "Marko", none carrying `noindex`. Until the adapter
+// resolves against the current page, they are pruned here.
+//
+// A page is one of these when it is byte-for-byte the 404 page apart from the
+// URL baked into its resume payload, which every page carries a copy of.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const dir = path.resolve("dist/public");
+const notFound = path.join(dir, "404.html");
+
+const canonical = await read(notFound);
+if (canonical === undefined) {
+  console.error("prune: no 404.html to compare against; skipping.");
+  process.exit(0);
+}
+
+const pages = await htmlFiles(dir);
+const bogus = [];
+for (const file of pages) {
+  if (file === notFound) continue;
+  if (normalize(await read(file)) === normalize(canonical)) bogus.push(file);
+}
+
+// The crawler always finds the real pages through the nav, so a run that wants
+// to delete everything means the comparison, not the site, is wrong.
+if (bogus.length === pages.length - 1) {
+  console.error("prune: every page matched the 404; refusing to delete.");
+  process.exit(1);
+}
+
+await Promise.all(bogus.map((file) => fs.rm(file)));
+await pruneEmptyDirs(dir);
+
+console.log(
+  bogus.length
+    ? `prune: removed ${bogus.length} crawler-emitted 404 page(s); ${pages.length - bogus.length} real page(s) remain.`
+    : "prune: no crawler-emitted 404 pages found.",
+);
+
+/** Every page embeds its own URL, and that is the only legitimate difference. */
+function normalize(html) {
+  return html.replace(/new URL\("[^"]*"\)/g, 'new URL("")');
+}
+
+async function read(file) {
+  try {
+    return await fs.readFile(file, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+async function htmlFiles(from) {
+  const found = [];
+  for (const entry of await fs.readdir(from, { withFileTypes: true })) {
+    const full = path.join(from, entry.name);
+    if (entry.isDirectory()) found.push(...(await htmlFiles(full)));
+    else if (entry.name.endsWith(".html")) found.push(full);
+  }
+  return found;
+}
+
+async function pruneEmptyDirs(from) {
+  for (const entry of await fs.readdir(from, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const full = path.join(from, entry.name);
+    await pruneEmptyDirs(full);
+    if ((await fs.readdir(full)).length === 0) await fs.rmdir(full);
+  }
+}


### PR DESCRIPTION
The static build emits **168** copies of the 404 page at URLs that were never routes, against 57 real pages. 65 of them are doc-shaped and indexable — `/adapters`, `/cli`, `/concise-syntax`, `/march-2026`, `/TODO` — all titled "Marko", none carrying `noindex`, sitting beside the real docs.

### Cause

`@marko/run-adapter-static` discovers pages by crawling, and resolves every href it finds against the **origin** instead of the page it found them on:

```js
async function visit(path2) {          // the page being crawled
  onopentag(name, attrs) {
    const path3 = href && resolvePath(href, origin);   // ← base is the origin
```

So a relative link loses its directory:

```
crawling /docs/reference/language, link ./concise-syntax
  adapter (base = origin):       /concise-syntax
  correct (base = current page): /docs/reference/concise-syntax
```

That path 404s, and the crawler writes the 404 body out under the bogus name. GitHub Pages then serves it at 200.

### This change

A post-build prune, wired into `build` ahead of `rebase-html` (which exits early on the production deploy, so it could not host this).

Pages are identified **structurally, not by their copy**: one is a crawler artifact when it matches `404.html` byte for byte once the URL each page bakes into its resume payload is normalized away — that URL is the only legitimate difference between them. Matching on the 404 wording would rot the moment someone edits it.

Guards: it skips if there is no `404.html` to compare against, and refuses to delete if *every* page matches, since the crawler always reaches the real pages through the nav.

### Verified

```
prune: removed 168 crawler-emitted 404 page(s); 57 real page(s) remain.
```

- all 51 source docs still have an emitted page
- surviving set is 52 docs plus `/404`, `/brand`, `/docs`, `/index`, `/playground`
- no real page matched the predicate
- re-running on pruned output is a no-op

### This is a workaround

The real fix is one line in the adapter — resolve against the current page, which `visit` already has in scope. `marko-js/run` is not in this workspace; if you add it I will send that instead and this script can go.