### PR TITLE
feat(seo): add a sitemap and replace the stale robots.txt

### DIFF
--- a/.marko-run/routes.d.ts
+++ b/.marko-run/routes.d.ts
@@ -10,8 +10,9 @@ import type * as $ from "@marko/run";
 declare module "@marko/run" {
 	interface App extends $.DefineRoutes<{
 		"/": [L1, P1, D1];
+		"/sitemap.xml": [H1];
 		"/brand": [L1, P2, D2];
-		"/docs": [M1, H1];
+		"/docs": [M1, H2];
 		"/docs/newsletter": [M1, L1, L2, P3, D3];
 		"/docs/newsletter/april-2026": [M1, L1, L2, P4, D4];
 		"/docs/newsletter/february-2026": [M1, L1, L2, P5, D5];
@@ -63,8 +64,8 @@ declare module "@marko/run" {
 		"/docs/reference/typescript": [M1, L1, L2, P51, D51];
 		"/docs/tutorial/components-and-reactivity": [M1, L1, L2, P52, D52];
 		"/docs/tutorial/fundamentals": [M1, L1, L2, P53, D53];
-		"/docs/reference-full.md": [M1, H2];
-		"/docs/newsletter/feed.xml": [M1, H3];
+		"/docs/reference-full.md": [M1, H3];
+		"/docs/newsletter/feed.xml": [M1, H4];
 		"/playground": [L1, P54, D54];
 	}> {}
 }
@@ -92,11 +93,34 @@ declare module "../src/routes/docs/+middleware" {
   }
 }
 
-type H1 = $.Handler<"H1", typeof import("../src/routes/docs/+handler")>;
-declare module "../src/routes/docs/+handler" {
+type H1 = $.Handler<"H1", typeof import("../src/routes/sitemap%2exml+handler")>;
+declare module "../src/routes/sitemap%2exml+handler" {
   const Run: $.Namespace<H1>;
   namespace Run {
     type Context = $.ContextForFile<H1>;
+  }
+
+  /** @deprecated use `Run` namespace instead */
+  namespace MarkoRun {
+    export { NotHandled, NotMatched, GetPaths, PostPaths, GetablePath, GetableHref, PostablePath, PostableHref, Platform };
+    export type Route = $.Routes["/sitemap.xml"];
+    export type Context = $.MultiRouteContext<Route>;
+    export type Handler = $.HandlerLike<Route>;
+    export type GET = $.HandlerLike<Route, "GET">;
+    export type HEAD = $.HandlerLike<Route, "HEAD">;
+    export type POST = $.HandlerLike<Route, "POST">;
+    export type PUT = $.HandlerLike<Route, "PUT">;
+    export type DELETE = $.HandlerLike<Route, "DELETE">;
+    export type PATCH = $.HandlerLike<Route, "PATCH">;
+    export type OPTIONS = $.HandlerLike<Route, "OPTIONS">;
+  }
+}
+
+type H2 = $.Handler<"H2", typeof import("../src/routes/docs/+handler")>;
+declare module "../src/routes/docs/+handler" {
+  const Run: $.Namespace<H2>;
+  namespace Run {
+    type Context = $.ContextForFile<H2>;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -115,11 +139,11 @@ declare module "../src/routes/docs/+handler" {
   }
 }
 
-type H2 = $.Handler<"H2", typeof import("../src/routes/docs/_llms/reference-full%2emd+handler")>;
+type H3 = $.Handler<"H3", typeof import("../src/routes/docs/_llms/reference-full%2emd+handler")>;
 declare module "../src/routes/docs/_llms/reference-full%2emd+handler" {
-  const Run: $.Namespace<H2>;
+  const Run: $.Namespace<H3>;
   namespace Run {
-    type Context = $.ContextForFile<H2>;
+    type Context = $.ContextForFile<H3>;
   }
 
   /** @deprecated use `Run` namespace instead */
@@ -138,11 +162,11 @@ declare module "../src/routes/docs/_llms/reference-full%2emd+handler" {
   }
 }
 
-type H3 = $.Handler<"H3", typeof import("../src/routes/docs/newsletter/feed%2exml+handler")>;
+type H4 = $.Handler<"H4", typeof import("../src/routes/docs/newsletter/feed%2exml+handler")>;
 declare module "../src/routes/docs/newsletter/feed%2exml+handler" {
-  const Run: $.Namespace<H3>;
+  const Run: $.Namespace<H4>;
   namespace Run {
-    type Context = $.ContextForFile<H3>;
+    type Context = $.ContextForFile<H4>;
   }
 
   /** @deprecated use `Run` namespace instead */

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,8 @@
-# Algolia-Crawler-Verif: 77E0315D7AB50620
+User-agent: *
+Allow: /
+
+# PR previews are served from markojs.com/previews/pr-N/ and are left crawlable
+# on purpose: each one sends `<meta name=robots content=noindex>`, which a
+# crawler can only act on if it is allowed to fetch the page.
+
+Sitemap: https://markojs.com/sitemap.xml

--- a/src/routes/sitemap%2exml+handler.ts
+++ b/src/routes/sitemap%2exml+handler.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+import { glob } from "glob";
+
+const docsDir = path.join(process.cwd(), "docs");
+const site = `https://${fs
+  .readFileSync(path.join(process.cwd(), "public", "CNAME"), "utf-8")
+  .trim()}`;
+
+// Pages that are not generated from a markdown file. Kept explicit so a new
+// top-level route has to be considered rather than silently left out.
+const staticPaths = ["/", "/brand", "/playground"];
+
+export const GET = Run.GET(() => {
+  const paths = staticPaths.concat(
+    glob
+      .sync("**/*.md", { cwd: docsDir, posix: true })
+      .map((file) => `/docs/${file.slice(0, -".md".length)}`)
+      .sort(),
+  );
+
+  // No `lastmod`: the build has no reliable per-page modification date, since a
+  // CI checkout stamps every file with the time it was cloned. An invented one
+  // is worse than none.
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${paths
+  .map((urlPath) => `<url><loc>${escapeUrl(site + urlPath)}</loc></url>`)
+  .join("\n")}
+</urlset>
+`;
+
+  return new Response(sitemap, {
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+});
+
+function escapeUrl(url: string) {
+  return encodeURI(url).replace(/&/g, "&amp;");
+}


### PR DESCRIPTION
`robots.txt` contained nothing but a verification comment for the Algolia crawler, which the site stopped using when search moved to a self-hosted FlexSearch index. It now allows crawling and points at a sitemap.

The sitemap is a route handler like the newsletter feed, so the static adapter discovers and emits it with no extra configuration. Listing every page is also what gets the six docs nothing links to discovered.

Verified against a full build: all 54 URLs resolve to an emitted page whose canonical matches exactly, and no page is missing from the sitemap. `lastmod` is deliberately omitted, since a CI checkout stamps every file with its clone time and an invented date is worse than none.