### PR TITLE
fix(a11y): give the search dialog combobox semantics

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json",
   "words": [
+    "activedescendant",
     "afterbegin",
     "afterend",
     "Algolia",

--- a/src/tags/search-dialog/search-dialog.marko
+++ b/src/tags/search-dialog/search-dialog.marko
@@ -46,8 +46,21 @@ script --
     activeIndex = -1;
   }
 
+// The results are a listbox the input owns rather than a focus stop of their
+// own: focus stays in the field and `aria-activedescendant` reports the row
+// the arrow keys are on, which is what lets typing and choosing interleave.
+const/expanded=!!(results && results.length > 0)
+const/status=(
+  !results
+    ? ""
+    : results.length === 0
+      ? "No results found."
+      : `${results.length} result${results.length === 1 ? "" : "s"}`
+)
+
 dialog/$dialog
   ,class=styles.dialog
+  ,aria-label="Search docs"
   ,onCancel(e) {
     e.preventDefault();
     open = false;
@@ -82,11 +95,28 @@ dialog/$dialog
       ,class=styles.input
       ,type="text"
       ,placeholder="Search docs..."
+      ,aria-label="Search docs"
+      ,role="combobox"
+      ,aria-autocomplete="list"
+      ,aria-expanded=(expanded ? "true" : "false")
+      ,aria-controls=(expanded ? "search-results" : undefined)
+      ,aria-activedescendant=(
+        expanded && activeIndex >= 0
+          ? `search-result-${activeIndex}`
+          : undefined
+      )
       ,value:=query
-    if=results && results.length > 0
-      div class=styles.results
+    div class=styles.status role="status" -- ${status}
+    if=expanded
+      div#search-results
+        ,class=styles.results
+        ,role="listbox"
+        ,aria-label="Results"
         for|result, i| of=results
           a/$el
+            ,id=`search-result-${i}`
+            ,role="option"
+            ,aria-selected=(i === activeIndex ? "true" : "false")
             ,href=result.href
             ,class=[styles.result, i === activeIndex && styles.active]
             ,onClick() {

--- a/src/tags/search-dialog/search-dialog.style.module.scss
+++ b/src/tags/search-dialog/search-dialog.style.module.scss
@@ -53,6 +53,19 @@ html {
   }
 }
 
+// Announces the result count to screen readers, which otherwise get no signal
+// that anything happened when the list below the field changes.
+.status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
+
 .results {
   border-top: 1px solid var(--color-gray-dim);
   overflow-y: auto;


### PR DESCRIPTION
The search field was an unlabelled text input and the results were plain links, so a screen reader had no way to know a list had appeared, how many rows it held, or which one the arrow keys were on.

The input is now a combobox owning the results listbox, with `aria-activedescendant` tracking the active row so focus can stay in the field, and a polite status region announces the result count. Marko's types caught that `aria-expanded` needs the literal string, not a boolean, which would have been dropped from the markup entirely.