### PR TITLE
chore: drop the unused events polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "autoprefixer": "^10.5.4",
     "codemirror": "^6.0.2",
     "cspell": "^10.0.1",
-    "events": "^3.3.0",
     "gh-pages": "^6.3.0",
     "github-slugger": "^2.0.0",
     "glob": "^13.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       cspell:
         specifier: ^10.0.1
         version: 10.0.1
-      events:
-        specifier: ^3.3.0
-        version: 3.3.0
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
@@ -2015,10 +2012,6 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -5116,8 +5109,6 @@ snapshots:
       '@types/estree': 1.0.9
 
   etag@1.8.1: {}
-
-  events@3.3.0: {}
 
   expect-type@1.4.0: {}
 


### PR DESCRIPTION
`events` was added alongside the `assert`/`util`/`path` browser shims back when the playground compiled marko in the page. That pipeline has since been rewritten around a virtual filesystem that resolves modules itself, and nothing imports `events` any more.

Verified by removing it: the build succeeds (rolldown fails on unresolved bare imports, so a real consumer would surface there), no emitted chunk contains the package, and the dev server serves `/`, `/playground`, and a docs page with a clean log.