### PR TITLE
fix(a11y): honour prefers-reduced-motion for the looping animations

### DIFF
--- a/src/routes/+404.style.module.scss
+++ b/src/routes/+404.style.module.scss
@@ -84,6 +84,10 @@
     display: grid;
     place-items: center;
     animation: float 6s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   }
 
   @media (max-width: 64rem) {
@@ -166,6 +170,12 @@
       transparent
     );
     animation: shimmer 2s infinite;
+
+    // Dropping the sweep rather than freezing it: with the animation off the
+    // gradient parks over the button as a permanent white smear.
+    @media (prefers-reduced-motion: reduce) {
+      content: none;
+    }
   }
 }
 

--- a/src/routes/_home/tags/home-cta-button/home-cta-button.module.scss
+++ b/src/routes/_home/tags/home-cta-button/home-cta-button.module.scss
@@ -47,6 +47,12 @@
     transparent
   );
   animation: shimmer 2s infinite;
+
+  // Dropping the sweep rather than freezing it: with the animation off the
+  // gradient parks over the button as a permanent white smear.
+  @media (prefers-reduced-motion: reduce) {
+    content: none;
+  }
 }
 
 @keyframes shimmer {

--- a/src/routes/playground/tags/playground/tags/result/result.style.module.scss
+++ b/src/routes/playground/tags/playground/tags/result/result.style.module.scss
@@ -197,6 +197,13 @@
   span {
     opacity: 0.35;
     animation: pulse 2.4s ease-in-out infinite;
+
+    // Held at the bright end of the pulse so the text stays readable once it
+    // is no longer drawing attention to itself by moving.
+    @media (prefers-reduced-motion: reduce) {
+      opacity: 1;
+      animation: none;
+    }
   }
 }
 

--- a/src/tags/app-code-block/app-code-block.style.scss
+++ b/src/tags/app-code-block/app-code-block.style.scss
@@ -91,6 +91,10 @@
           opacity: 0;
         }
       }
+      // Leaves the caret solid, which is what the keyframes rest at.
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
     }
   }
   &-menu {


### PR DESCRIPTION
Five animations looped forever without checking the setting: the 404 mascot's float, the shimmer sweep on the 404 and home call-to-action buttons, the caret blink in every code block, and the playground's pending pulse. The two marquees already paused themselves, so this brings the rest in line with the pattern already in the codebase.

The shimmers are dropped rather than paused, since freezing one parks a white gradient across the button. Scroll-driven animations in `sticky.scss` are deliberately left alone: their progress follows the reader's own scrolling rather than running on its own, and a blanket `animation-duration` override would have broken them.