### PR TITLE
refactor(playground): mount workspace files at the root

### DIFF
--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -107,11 +107,11 @@ const/compiledCode=(() => {
     switch (outputType) {
       case "dom": {
         return debug
-          ? ws.markoCompiled?.dom?.[`/app/tags/${selectedFile}`]?.code
-          : ws.previewModules?.[`/app/tags/${selectedFile}`]?.code;
+          ? ws.markoCompiled?.dom?.[`/${selectedFile}`]?.code
+          : ws.previewModules?.[`/${selectedFile}`]?.code;
       }
       case "html":
-        return ws.markoCompiled?.html?.[`/app/tags/${selectedFile}`]?.code;
+        return ws.markoCompiled?.html?.[`/${selectedFile}`]?.code;
       case "previewJS":
         return ws.previewJS;
       case "previewCSS":

--- a/src/util/compile-error.test.ts
+++ b/src/util/compile-error.test.ts
@@ -18,7 +18,7 @@ function compileError(
   });
 }
 
-const FILE = "/app/tags/index.marko";
+const FILE = "/index.marko";
 
 test("reads position and message off the error rather than its frame text", () => {
   const files = { [FILE]: "<div>\n<span>\n" };
@@ -32,7 +32,7 @@ test("reads position and message off the error rather than its frame text", () =
 
   const [parsed] = normalizeErrors([err], files);
   expect(parsed.message).toBe('Missing ending "span" tag');
-  expect(parsed.frame?.file).toBe("app/tags/index.marko");
+  expect(parsed.frame?.file).toBe("index.marko");
   expect(parsed.frame?.line).toBe(2);
   expect(parsed.frame?.col).toBe(1);
 
@@ -84,7 +84,7 @@ test("gives each error in an aggregate its own entry", () => {
 });
 
 test("normalizes a Rollup-shaped error, which reports a flat position", () => {
-  const file = "/app/tags/util.js";
+  const file = "/util.js";
   const files = { [file]: "const a = 1;\nexport default a(\n" };
   const err = Object.assign(new Error("Unexpected token"), {
     name: "SyntaxError",
@@ -94,14 +94,14 @@ test("normalizes a Rollup-shaped error, which reports a flat position", () => {
 
   const [parsed] = normalizeErrors([err], files);
   expect(parsed.message).toBe("Unexpected token");
-  expect(parsed.frame?.file).toBe("app/tags/util.js");
+  expect(parsed.frame?.file).toBe("util.js");
   expect(parsed.frame?.line).toBe(2);
 });
 
 test("falls back to the frame text when there is no usable metadata", () => {
   const raw = [
     "",
-    "    at app/tags/index.marko:1:2",
+    "    at index.marko:1:2",
     "    > 1 | <log/>",
     "        |  ^^^ The [`<log>` tag](https://markojs.com/docs/x) requires a value",
     "      2 |",
@@ -110,7 +110,7 @@ test("falls back to the frame text when there is no usable metadata", () => {
     Object.assign(new Error(raw), { name: "CompileError" }),
   );
 
-  expect(parsed.frame?.file).toBe("app/tags/index.marko");
+  expect(parsed.frame?.file).toBe("index.marko");
   expect(parsed.message).toMatch(/requires a value$/);
 });
 

--- a/src/util/compile-error.ts
+++ b/src/util/compile-error.ts
@@ -1,7 +1,7 @@
 /**
  * Marko's `CompileError` carries a Babel-style code frame inside its message:
  *
- *     at app/tags/index.marko:1:2
+ *     at index.marko:1:2
  *     > 1 | <log/>
  *         |  ^^^ The [`<log>` tag](https://markojs.com/docs/...) requires ...
  *       2 |

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -48,9 +48,14 @@ export interface Workspace {
 
 let workspace: Workspace | undefined;
 const encoder = new TextEncoder();
-const projectDir = "/app";
-const packageJsonPath = `${projectDir}/package.json`;
-const rootDir = `${projectDir}/tags/`;
+// Files sit at the root of the virtual filesystem, so a playground file is at
+// the path the author typed rather than under scaffolding they never asked
+// for. `marko.json` is what buys that: without it the compiler only discovers
+// custom tags inside a directory literally named `tags` or `components`.
+const rootDir = "/";
+const packageJsonPath = `${rootDir}package.json`;
+const markoJsonPath = `${rootDir}marko.json`;
+const markoJson = JSON.stringify({ "tags-dir": "." });
 const subs = new Set<(workspace: Workspace) => void>();
 function formatLogArgs(args: unknown[]): string {
   return args
@@ -149,6 +154,8 @@ export async function update(
     server: undefined,
     logs: [],
   });
+  // Written first so an author who adds their own `marko.json` tab still wins.
+  fs.files[markoJsonPath] = markoJson;
   for (const file of files) {
     fs.files[
       file.path === "package.json" ? packageJsonPath : rootDir + file.path
@@ -163,7 +170,7 @@ export async function update(
       if (signal.aborted) return;
       versions = nodeModules.versions;
       for (const path in nodeModules.files) {
-        fs.files[projectDir + path] = nodeModules.files[path];
+        fs.files[path] = nodeModules.files[path];
       }
     }
 


### PR DESCRIPTION
Playground files were mounted under `/app/tags` so the compiler would discover them as custom tags, which leaked into every compile error as `app/tags/index.marko`. A `marko.json` declaring the root as the tags directory gets the same discovery with the files where the author actually put them.

Existing share links are unaffected: they store paths relative to the mount point, so an old link still decodes to the same `index.marko` it always did. Verified against a real link, and against the compiler directly — custom tags and subdirectory tags resolve from the root, nothing leaks out of `node_modules`, and API detection stays `tags` even for a template with no Marko 6 syntax, which no longer gets it for free from a `tags` path segment.