### PR TITLE
fix(playground): resolve tags imported by absolute path

### DIFF
--- a/src/util/workspace/main-plugin.ts
+++ b/src/util/workspace/main-plugin.ts
@@ -67,6 +67,14 @@ export function mainPlugin({
       if (suffix) {
         id = id.slice(0, -suffix.length);
       }
+
+      // `resolveSync` only understands relative and bare specifiers. Templates
+      // compiled from a tag directory import each other by absolute path, so
+      // those are looked up directly.
+      if (id.startsWith("/")) {
+        return id in fs.files ? id + (suffix || "") : undefined;
+      }
+
       const resolved = resolveSync(id, {
         browser,
         silent: true,

--- a/src/util/workspace/modules-shim.ts
+++ b/src/util/workspace/modules-shim.ts
@@ -21,6 +21,12 @@ const resolveFS: ResolveOptions["fs"] = {
 
 function tryResolve(id: string, from = "/") {
   if (!currentFS) return undefined;
+  // `resolveSync` only understands relative and bare specifiers, so an absolute
+  // path -- which is what the taglib records for a discovered tag -- has to be
+  // looked up directly or it never resolves.
+  if (id.startsWith("/")) {
+    return id in currentFS.files ? id : undefined;
+  }
   try {
     const resolved = resolveSync(id, {
       from: `${from.endsWith("/") ? from : `${from}/`}_`,


### PR DESCRIPTION
Custom tag discovery has been broken in the playground since files moved to the root: [this share link](https://markojs.com/playground#djIfiwgAAAAAAAATi65WKkgsyVCyUsrMS0mt0MtNLMrOV9JRSs7PK0nNK1GyUipJTFeq1YErK0lMx6JIV1chI1OpNhYAN5GE9E8AAAA) has `index.marko` using `<tag>` beside a `tag.marko`, and it fails.

A tag discovered through `tags-dir` is recorded by its **absolute** path, and both of the playground's resolvers passed that straight to `resolveSync`, which only understands relative and bare specifiers. So the compiler reported `Cannot resolve module "/tag.marko"` and rollup logged `"/tag.marko" ... could not be resolved – treating it as an external dependency`. Both now look an absolute id up in the workspace filesystem directly.

The `/app/tags` layout never hit this because nothing asked either resolver for an absolute path; mounting at the root made it the normal case. So the bug was latent in the resolvers, not in the layout, and reverting the layout would only have hidden it.

Verified in a real browser: driving headless Chrome over CDP at the failing share link, the preview iframe now renders `hi`, the error panel is empty, and the resolution warning is gone.