### PR TITLE
docs: document $global.serializedGlobals

### DIFF
--- a/docs/explanation/serializable-state.md
+++ b/docs/explanation/serializable-state.md
@@ -16,6 +16,8 @@ Most standard data types can be serialized, including:
 
 ... and many more.
 
+State reaches the client automatically when something there depends on it. [`$global`](../reference/language.md#global) does not: it is server data until a property is named in [`$global.serializedGlobals`](../reference/template.md#globalserializedglobals), which is what makes request-scoped values such as a locale readable after hydration.
+
 ## Unserializable Data
 
 Some values cannot be serialized. When these values are encountered the Marko runtime will provide a helpful message to locate the relevant code.

--- a/docs/marko-run/runtime.md
+++ b/docs/marko-run/runtime.md
@@ -21,7 +21,7 @@ The context is passed to middleware and handler functions as the first parameter
 | `parent`   | The calling context when the request was made with [`ctx.fetch`](#fetch), otherwise `undefined`                                                  |
 
 > [!NOTE]
-> In templates, `$global.params` and `$global.url` are serialized to the browser by default, so client-side code can read them after hydration. Other context properties can be included by setting them in `ctx.serializedGlobals`.
+> In templates, `$global.params` and `$global.url` are serialized to the browser by default, so client-side code can read them after hydration. Other context properties can be included by setting them in `ctx.serializedGlobals`, which is the same list described under [`$global.serializedGlobals`](../reference/template.md#globalserializedglobals).
 
 ## Context Methods
 

--- a/docs/reference/template.md
+++ b/docs/reference/template.md
@@ -171,6 +171,33 @@ When a template is rendered via the [`render`](#templaterenderinput) or [`mount`
 
 Some properties on the `$global` are picked up by Marko itself and have predefined functionality.
 
+### `$global.serializedGlobals`
+
+> `string[] | Record<string, boolean> | undefined`
+
+`$global` stays on the server. Naming a property here also writes its value into the page, which makes it readable as [`$global`](./language.md#global) from client code such as an event handler.
+
+```js
+Template.render({
+  $global: {
+    locale: "en-GB",
+    apiToken: "secret",
+    serializedGlobals: ["locale"],
+  },
+});
+```
+
+Above, `$global.locale` can be read in the browser and `$global.apiToken` cannot. An object selects the same properties and suits a list assembled in more than one place, which is how [Marko Run](../marko-run/runtime.md#context) exposes it as `ctx.serializedGlobals`.
+
+```js
+serializedGlobals: { locale: true, apiToken: false }
+```
+
+A named property holding `undefined` is left out.
+
+> [!WARNING]
+> Serialized values are written into the HTML and can be read by anyone who loads the page. Secrets belong in properties left off the list.
+
 ### `$global.signal`
 
 > <code>[AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | undefined</code>


### PR DESCRIPTION
`$global.serializedGlobals` had no documentation. The template reference lists the `$global` properties Marko acts on (`signal`, `cspNonce`, `renderId`, `runtimeId`) but not the one that decides which of them reach the browser, so nothing described how to make request-scoped data readable from client code. The only mention anywhere was `@marko/run`'s `ctx.serializedGlobals`, in passing under Runtime.

Adds a reference section covering both accepted shapes, and cross-links it from Serializable State, where a reader asking how server data reaches the client is likely to land, and from the Marko Run note that wraps it.

Behaviour was confirmed by rendering rather than read off the source: with no list nothing from `$global` is serialized; `["token"]` and `{ token: true, secret: false }` both serialize only `token`; and a named property holding `undefined` is left out. Verified the generated anchor and that the site has no dangling anchors.