### PR TITLE
Let long inline code wrap on narrow viewports

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -27,3 +27,16 @@ to the generic site description and library-integration advertises itself to
 search engines as "Use <lifecycle> tag". Writing an intro paragraph for each
 fixes both at once. Re-verify with `npm run build` and then
 `grep -h '"description"' src/routes/docs/_compiled-docs/{explanation/optimizing-performance,guide/publishing-components,guide/library-integration}+meta.json`.
+
+## Remove the empty token-type branch in the markodown walker
+
+`src/util/markodown.ts` › `markoDocs` | 2026-07-29 | impact:low | effort:low
+
+Inside `markoDocs()`'s `walkTokens`, after the code-fence handling there is a
+chain that begins `if (token.type === "code" && token.lang === "marko") {}`
+with an empty body, followed by an `else if (token.type === "codespan")`
+branch whose only content is a commented-out line. Only the final
+`else if (token.type === "link")` branch does anything. The two dead branches
+read as if they carry behavior and slow down anyone tracing how tokens are
+transformed; collapsing the chain to a single `if (token.type === "link")`
+preserves behavior. Re-verify by reading the chain and running `pnpm test`.

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "browserslist",
     "Brrrrr",
     "codegen",
+    "codespan",
     "contenteditable",
     "dblclick",
     "defunkt",

--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -141,7 +141,10 @@ pre {
 code {
   font-family: "Ubuntu Mono", monospace;
   line-height: 1.5;
-  text-wrap: nowrap;
+
+  pre > & {
+    text-wrap: nowrap;
+  }
 
   :not(pre) > & {
     color: var(--section-color);


### PR DESCRIPTION
Scopes `text-wrap: nowrap` to code inside `pre` so long inline code (like the compat-layer error message in the Marko 5 interop guide) wraps instead of forcing horizontal overflow on mobile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mh2Dhbbgnx9p3M33ZmWrcN)_