### PR TITLE
docs(native-tag): document the content= attribute

### DIFF
--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -404,6 +404,8 @@ export interface Input {
 </div>
 ```
 
+[Native tags](./native-tag.md#content) also accept content as an attribute, so the wrapper above can be written as `<div content=input.content/>`.
+
 ### Dynamic Text
 
 Dynamic text content can be `${interpolated}` in the tag content. This uses the same syntax as [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in JavaScript.

--- a/docs/reference/native-tag.md
+++ b/docs/reference/native-tag.md
@@ -61,6 +61,94 @@ All examples above result in the same HTML:
 <div style="display:block;margin-right:16px;"></div>
 ```
 
+### `content=`
+
+Native tags accept their body content as a `content=` attribute. The value may be a [`<define>`](./core-tag.md#define) tag variable, an imported template, or the [content](./language.md#tag-content) the surrounding template received.
+
+Because `content` arrives as part of `input`, a [spread](./language.md#spread-attributes) is enough to implement a tag that wraps an element around the content it receives.
+
+```marko
+/* field-row.marko */
+<fieldset ...input/>
+```
+
+```marko
+/* signup.marko */
+<field-row class="row">
+  <label for="email">Email</label>
+  <input id="email" name="email" type="email">
+</field-row>
+```
+
+The spread applies `class` to the `<fieldset>` and renders the content inside it:
+
+```html
+<fieldset class="row"><label for="email">Email</label><input id="email" name="email" type="email"></fieldset>
+```
+
+Passing the attribute explicitly places the content on a specific element, such as an inner wrapper:
+
+```marko
+<section class="card">
+  <h2>${input.title}</h2>
+  <div class="card-body" content=input.content/>
+</section>
+```
+
+`content=` is reactive. Swapping the value replaces the rendered content in place, leaving the element itself untouched.
+
+```marko
+<let/expanded=false>
+<define/Summary>
+  <h2>${input.title}</h2>
+</define>
+<define/Details>
+  <h2>${input.title}</h2>
+  <p>${input.description}</p>
+</define>
+
+<article content=(expanded ? Details : Summary)/>
+
+<button onClick() { expanded = !expanded }>toggle</button>
+```
+
+> [!WARNING]
+> A literal body takes precedence over `content=`, which is then never rendered. Any body counts, including one that produces no output of its own, such as a body holding only a [comment](./language.md#comments).
+>
+> ```marko
+> <div content=Summary>
+>   // this comment is body content, so `Summary` never renders
+> </div>
+> ```
+
+Attributes are merged from left to right, so ordering decides the result when `content=` accompanies a spread. Setting it after a spread overrides the content coming from that spread, and `content=undefined` forwards every other attribute while dropping the content entirely.
+
+```marko
+<div ...input content=undefined/>
+```
+
+Tags that cannot contain markup reject the attribute at compile time. [Void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) such as `<img>` report:
+
+```text
+The `<img>` tag cannot have content, so it does not support the `content` attribute.
+```
+
+`<textarea>` and `<title>` take their body as text, and report:
+
+```text
+The `<textarea>` tag takes its content from its body as text, so it does not support the `content` attribute.
+```
+
+> [!NOTE]
+> On [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta), `content` is a real HTML attribute and keeps that meaning, including when applied through a spread. It is the only native tag whose `content` is written to the element instead of rendered as content.
+>
+> ```marko
+> <let/height=630>
+> <meta property="og:image:height" content=height>
+> ```
+
+For typing content on a custom tag, see [Typing `content`](./typescript.md#typing-content).
+
 ### Event Handlers
 
 Attributes on native tags that begin with `on` followed by `-` or a capital letter are attached as [event handlers](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).

--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -217,7 +217,7 @@ export interface Input extends Marko.HTML.Button {
 ```
 
 > [!TIP]
-> Since Marko 6, native tags have supported including [`content`](./language.md#tag-content) as an attribute so there is no need to inject manually
+> Since Marko 6, native tags have supported including [`content`](./native-tag.md#content) as an attribute so there is no need to inject manually
 >
 > ```marko
 > <button style=`color: ${color}` ...attrs>


### PR DESCRIPTION
Native tags accept their body content as a `content=` attribute, which makes `<div ...input/>` the canonical way to write a tag that wraps an element around the content it receives. This was only mentioned in passing in a TIP on the TypeScript page, so it now gets a section in the native tag reference.

Covers the spread pattern, reactivity, the precedence rule where a literal body silently wins over `content=`, the compile errors on void and text-only tags, and `<meta content>` keeping its HTML meaning.