### PR TITLE
docs(template): correct renderId and runtimeId defaults

### DIFF
--- a/docs/reference/template.md
+++ b/docs/reference/template.md
@@ -216,10 +216,19 @@ This value should be a string that represents a valid [csp nonce](https://develo
 
 > `string | undefined`
 
-The `renderId` is used to isolate distinct server renders (using the same runtime) and is not automatically set. This value should be set such that all server rendered segments of `html` have a unique `renderId` string to avoid conflicts. This is particularly useful for solutions such as [micro-frame](https://github.com/marko-js/micro-frame).
+The `renderId` isolates one render from every other render sharing a runtime in the same document. It always has a value, `"_"` by default.
+
+A template with no `html`, `head`, or `body` tag, compiled with the `linkAssets` compiler option that [`@marko/vite`](https://github.com/marko-js/vite) configures, instead gets a fresh random value on every [`render()`](#templaterenderinput) call, so such renders never collide in one document. [`mount()`](#templatemountinput-node-position) always defaults to `"_"`.
+
+Set an explicit value when several renders of a page template share a document, so each one resumes against its own data.
+
+> [!WARNING]
+> `renderId` and `runtimeId` become JavaScript identifiers in the inline resume-data scripts, so each must start with a letter or underscore and contain only letters, numbers, and underscores. A UUID, or a hyphenated name such as `my-app`, is not a valid value.
 
 ### `$global.runtimeId`
 
 > `string | undefined`
 
-The `runtimeId` is used to isolate runtimes when there are multiple copies on the same page, and is generally not necessary as `@marko/vite` and `@marko/webpack` plugins will automatically provide one based off of the project level `package.json` name.
+The `runtimeId` names the global variable holding the resume data for every render in the document, and defaults to `"M"`. Overriding it isolates multiple copies of Marko sharing a page. It follows the same identifier rule as [`renderId`](#globalrenderid).
+
+Server and browser builds must agree on the value, so it belongs in the bundler configuration rather than an individual render. [`@marko/vite`](https://github.com/marko-js/vite) accepts a `runtimeId` option and bakes it into the generated entries, which apply it to `$global.runtimeId`.


### PR DESCRIPTION
The `renderId` section said the value "is not automatically set". One is always assigned: `"_"` by default, or a fresh value per `render()` call for an embeddable template. `runtimeId` defaults to `"M"`, which was also unstated.

Both values become JavaScript identifiers in the inline resume scripts, so a UUID or a hyphenated name is rejected in a debug build and silently emits broken script in an optimized one. That constraint is now documented, since the page previously recommended a per-fragment `renderId` with no character rules.