### PR TITLE
docs(template): correct render result consumption and pipe semantics

### DIFF
--- a/docs/explanation/streaming.md
+++ b/docs/explanation/streaming.md
@@ -178,22 +178,27 @@ Some [Akamai features designed to mitigate slow backends can ironically slow dow
 
 #### Node.js itself
 
-For extreme cases where [Node streams very small HTML chunks with its built-in compression modules](https://github.com/marko-js/marko/pull/1641), you may need to tweak the compressor stream settings. Here’s an example with `createGzip` and its `Z_PARTIAL_FLUSH` flag:
+For extreme cases where [Node streams very small HTML chunks with its built-in compression modules](https://github.com/marko-js/marko/pull/1641), the compressor stream settings may need tweaking, such as the `Z_PARTIAL_FLUSH` flag on `createGzip`:
 
 ```js
-import http from "http";
-import zlib from "zlib";
+import http from "node:http";
+import zlib from "node:zlib";
 
-import MarkoTemplate from "./something.marko";
+import Template from "./page.marko";
 
 http
-  .createServer(function (request, response) {
-    response.writeHead(200, { "content-type": "text/html;charset=utf-8" });
-    const templateStream = MarkoTemplate.stream({});
-    const gzipStream = zlib.createGzip({
-      flush: zlib.constants.Z_PARTIAL_FLUSH,
+  .createServer((request, response) => {
+    response.writeHead(200, {
+      "content-type": "text/html;charset=utf-8",
+      "content-encoding": "gzip",
     });
-    templateStream.pipe(outputStream).pipe(response);
+
+    const gzip = zlib.createGzip({ flush: zlib.constants.Z_PARTIAL_FLUSH });
+    gzip.pipe(response);
+
+    Template.render({}).pipe(gzip);
   })
   .listen(80);
 ```
+
+[`pipe()`](../reference/template.md#pipe) calls `flush()` on its target after every chunk, so each chunk moves through the compressor instead of waiting for its buffer to fill.

--- a/docs/reference/template.md
+++ b/docs/reference/template.md
@@ -11,6 +11,9 @@ These methods are used to generate an HTML string on the server, and to modify t
 
 For use on the **server**, the `.render()` API on a Marko template provides an object containing a variety of ways to generate an HTML string. Its first parameter becomes the [`input`](./language.md#input) available within the template.
 
+> [!WARNING]
+> A render result holds a single render and the first consumer takes it. Every consumer after that fails with `Cannot read from a consumed render result`, thrown, rejected, or raised as a stream error depending on the consumer. Awaiting more than once is the exception, since the first `await` caches the promise and later ones resolve with the same string.
+
 ### Async Iterator
 
 The render result contains an [async iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), which allows consumption through a [`for await` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of).
@@ -23,9 +26,13 @@ for await (const chunk of Template.render({})) {
 }
 ```
 
+Each iteration yields the HTML flushed since the previous one; a render with no asynchronous content yields a single chunk.
+
+Abandoning the loop with `break`, `return`, or a thrown exception aborts a pending render with the error `Iterator returned before consumed.`, and a later pull rejects with it. The iterator's `throw(reason)` method aborts with the given reason instead.
+
 ### Pipe
 
-The `.pipe()` method in the render result object sends an HTML string into a [NodeJS `stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable).
+The `.pipe()` method in the render result object sends the HTML into a [NodeJS `stream.Writable`](https://nodejs.org/api/stream.html#class-streamwritable). Any object with `write(chunk)` and `end()` serves as a target, and a `flush()` method, if present, is called after every chunk to keep a buffering transform such as [`zlib.createGzip()`](https://nodejs.org/api/zlib.html#zlibcreategzipoptions) streaming.
 
 ```js
 import Template from "./template.marko";
@@ -49,6 +56,8 @@ const webHTMLResponse = new Response(Template.render({}).toReadable(), {
 });
 ```
 
+Reading is deferred to the stream's first pull, so wrapping it in a `Response` that is never read leaves the result unconsumed. Cancelling the stream aborts the render with the cancellation reason.
+
 ### Thenable
 
 The render result is a [thenable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables), so the `.then()`, `.catch()` or `.finally()` methods return a `Promise<string>` that resolves with a buffered HTML string. This may be handled implicitly with the [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) keyword.
@@ -58,7 +67,7 @@ const html = await Template.render({});
 ```
 
 > [!NOTE]
-> By using thenable and `await`, you are opting out of Marko's streaming capabilities.
+> Awaiting buffers the entire document into a string, opting out of streaming.
 
 #### toString
 
@@ -69,7 +78,7 @@ const html = Template.render({}).toString();
 ```
 
 > [!CAUTION]
-> If there is any async behavior (i.e. an [`<await>` tag](./core-tag.md#await)) this method will throw.
+> Any async behavior (i.e. an [`<await>` tag](./core-tag.md#await)) makes this method throw `Cannot consume asynchronous render with 'toString'` instead of returning partial HTML. An already aborted render, for example through an aborted [`$global.signal`](#globalsignal), throws the abort reason.
 
 ## `Template.mount(input, node, position?)`
 


### PR DESCRIPTION
A render result can only be consumed once, and abandoning a consumer aborts a pending render. Neither was documented, so the page read as if the five consumption styles were interchangeable on one result.

Also corrects `pipe()`: on abort it emits an `error` event and never calls `end()`, so the documented `pipe(res)` example could raise an uncaught exception. The Node compression example in streaming.md used `MarkoTemplate.stream()`, a Marko 5 API that does not exist in Marko 6, and chained `pipe()` calls that return void, so it has been rewritten against the real API.