### PR TITLE
docs: correct `<id>` value fallback semantics

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -525,7 +525,7 @@ The `<id>` tag exposes a [Tag Variable](./language.md#tag-variables) with a shor
 <input id=cheeseId type="checkbox" name="cheese">
 ```
 
-If the `value=` attribute contains a non-nullable value, it will be used instead of the generated one.
+The `value=` attribute is used instead of the generated id when it is a non-empty string. `null`, `false`, and `""` fall back to the generated one.
 
 ```marko
 /* textbox.marko */
@@ -537,7 +537,7 @@ export interface Input {
 <id/id=input.id>
 
 <input aria-describedby=id>
-<span id=id>${description}</span>
+<span id=id>${input.description}</span>
 ```
 
 ## `<log>`


### PR DESCRIPTION
The `<id>` reference said a "non-nullable" `value=` is used instead of the generated id, but the translator emits `value || _id()`, so `""` and `false` fall back as well. `false` is part of the tag's public type (`string | null | false`), making it a supported way to request the generated id. Also fixes the adjacent `textbox.marko` example, which read a bare `description` instead of `input.description`.