### PR TITLE
docs(core-tag): document the `<script>` value form and `await` bodies

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -335,6 +335,45 @@ Often the `<script>` tag is coupled with the [`$signal` api](./language.md#signa
 </script>
 ```
 
+### Function Value
+
+The effect may also be supplied through the `value=` attribute, usually written with the `=` shorthand. The function receives no arguments and re-runs under the same conditions as a body.
+
+```marko
+<video/clip src=input.src controls/>
+
+<script=() => (clip().muted = input.muted)/>
+```
+
+A function declared elsewhere, such as a [`<const>`](#const), may be referenced directly.
+
+```marko
+<const/remember() {
+  sessionStorage.setItem("sidebar", input.collapsed);
+}>
+
+<script=remember/>
+```
+
+### Await
+
+An `await` in a `<script>` body compiles it to an async function. The effect starts that function and returns at the first `await`, so later effects run without waiting for it.
+
+```marko
+<img/photo>
+<script>
+  const signal = $signal;
+  photo().src = input.src;
+  await photo().decode();
+  if (!signal.aborted) photo().classList.add("loaded");
+</script>
+```
+
+> [!WARNING]
+> Each [`$signal`](./language.md#signal) reference resolves to the current run's signal, so after an `await` it may no longer belong to the suspended body. Capture it in a local before awaiting.
+
+<!---->
+
 > [!TIP]
 > There are very few cases where you should be using a _real_ `<script>` tag, but if you absolutely need it you can use the [`<html-script>`](#html-script--html-style) fallback.
 


### PR DESCRIPTION
The `<script>` reference only showed the body form, so two supported shapes were undocumented. Adds a "Function Value" subsection covering `<script=someFn/>` and `<script=() => ...
/>` (the function receives no arguments and re-runs on the same dependencies as a body), and an "Await" subsection describing what a top-level `await` means: the body compiles to an async function that the effect starts and does not wait on, so later effects are not delayed. The await example captures `$signal` in a local before suspending, since each `$signal` reference resolves to the current run's signal.