### PR TITLE
docs: correct where element references and hoisted tag variables may be read

### DIFF
--- a/docs/explanation/class-vs-tags-api.md
+++ b/docs/explanation/class-vs-tags-api.md
@@ -78,7 +78,7 @@ export interface Input {
 
 ## Element Refs
 
-Instead of [`getEl`](https://v5.markojs.com/docs/class-components/#getelkey-index), native tags [expose a tag variable](../reference/native-tag.md#element-references) with a getter to the DOM node. Since it is a function it can be used anywhere in the template.
+Instead of [`getEl`](https://v5.markojs.com/docs/class-components/#getelkey-index), native tags [expose a tag variable](../reference/native-tag.md#element-references) with a getter to the DOM node. It is in scope throughout the template, and a [`<script>`](../reference/core-tag.md#script) body or [event handler](../reference/native-tag.md#event-handlers) reads the node by calling it.
 
 ```marko
 <input/$el/>

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -688,7 +688,7 @@ Using the [core `<return>` tag](./core-tag.md#return), any custom tag can return
 
 ### Tag Var Scope
 
-Tag variables are automatically [hoisted](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) and can be accessed anywhere in the template except for in [module statements](#statements). This means that it is possible to read tag variables from anywhere in the tree.
+Tag variables are automatically [hoisted](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting), so a variable declared deep in the tree is in scope everywhere in the template except in [module statements](#statements).
 
 ```marko
 <form>
@@ -700,6 +700,16 @@ Tag variables are automatically [hoisted](https://developer.mozilla.org/en-US/do
   console.log(myInput())
 </script>
 ```
+
+Hoisting determines where a tag variable may be referenced, not when its value may be read. A hoisted read, including an [element reference](./native-tag.md#element-references), belongs in code that runs after render, such as a [`<script>`](./core-tag.md#script) body, a [`<lifecycle>`](./core-tag.md#lifecycle) hook, or an [event handler](./native-tag.md#event-handlers).
+
+> [!WARNING]
+> An attribute value, a [`<const>`](./core-tag.md#const), or an [interpolation](#dynamic-text) is evaluated during the render, before a hoisted value may be read.
+>
+> ```marko
+> // ❌ (INCORRECT) `myInput` is read while the template renders
+> <div>${myInput().value}</div>
+> ```
 
 ### Repeated Tag Vars
 

--- a/docs/reference/native-tag.md
+++ b/docs/reference/native-tag.md
@@ -15,7 +15,7 @@ All native tags expose a [Tag Variable](./language.md#tag-variables) that provid
 ```
 
 > [!CAUTION]
-> The node reference is only available in the browser. Attempting to access a DOM node from the server will result in an error.
+> The DOM node exists only in the browser, and the getter is readable only from code that runs after render, such as a [`<script>`](./core-tag.md#script) body, a [`<lifecycle>`](./core-tag.md#lifecycle) hook, or an [event handler](#event-handlers). An attribute value, a [`<const>`](./core-tag.md#const), or an [interpolation](./language.md#dynamic-text) is evaluated earlier in the render.
 
 ## Enhanced Attributes
 


### PR DESCRIPTION
The Element References callout said the node getter was unavailable only on the server, and Tag Var Scope said hoisted tag variables "can be accessed anywhere in the template". Both are too permissive: hoisting governs where a name is in scope, while the value itself is readable only from code that runs after render, so an attribute value, a `<const>`, or an interpolation is evaluated too early. Both pages now state the same rule and cross-link each other, and the matching sentence in the Class API comparison is updated to agree.