### PR TITLE
fix(docs): correct nested attribute tag input object

### DIFF
--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -563,7 +563,7 @@ export interface Input {
 
 ### Nested Attribute tags
 
-Attribute tags may be nested in other attribute tags.
+Attribute tags may be nested in other attribute tags. A nested attribute tag becomes a property on its parent attribute tag, alongside the parent's own attributes.
 
 ```marko
 <my-tag>
@@ -578,7 +578,7 @@ Would provide the following as input
 ```js
 {
   a: {
-    value: 2,
+    value: 1,
     b: { value: 2 }
   }
 }


### PR DESCRIPTION
The nested attribute tags example in the language reference showed `{ a: { value: 2, b: { value: 2 } } }`, implying a nested attribute tag overwrites its parent's attributes. Compiling the page's own snippet produces `{ a: { value: 1, b: { value: 2 } } }`, so the documented object is corrected and the surrounding sentence now states the real rule: a nested attribute tag becomes a property on its parent attribute tag, alongside the parent's own attributes.