### PR TITLE
docs(core-tag): document `<return>` placement

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -276,6 +276,9 @@ The return value may then be used in the parent template:
 <div>${value}</div>
 ```
 
+> [!WARNING]
+> A template or [tag content](./language.md#tag-content) holds at most one `<return>`, at its top level. A value that varies is expressed within `value=` rather than by nesting a `<return>` under [`<if>`](#if--else) or [`<for>`](#for).
+
 ### Assignable Return Value
 
 By default, an exposed variable can not be assigned a value. Value assignment may be enabled with the `valueChange=` attribute on the `<return>`.


### PR DESCRIPTION
The `<return>` section did not say where a `<return>` may appear, so a reader exposing a value conditionally reaches for an `<if>` and hits a compile error. Adds a warning stating the rule: at most one `<return>` per template or tag content, at its top level, with a varying value expressed within `value=`.