### PR TITLE
docs(core-tag): document `<for>` key, range, and nullish rules

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -116,6 +116,18 @@ The `<for>` tag can iterate over:
   // 2 4 6 8 10
   ```
 
+The `step=` attribute may be negative, counting down from a larger `from=`, or fractional.
+
+```marko
+<for|num| from=10 to=0 step=-5>${num}</for>
+// 10 5 0
+
+<for|num| from=0 to=1 step=0.25>${num}</for>
+// 0 0.25 0.5 0.75 1
+```
+
+A nullish `of=` or `in=` renders nothing, so an optional value such as a [repeated attribute tag](./language.md#repeated-attribute-tags) may be iterated directly.
+
 The `<for>` tag has a `by=` attribute which helps preserve state while reordering content within the loop. The value should be a function (which receives the same parameters as the loop itself) that is used to give each iteration a unique key.
 
 ```marko
@@ -135,6 +147,11 @@ This means the previous example can simplified to:
   ${user.firstName} ${user.lastName}
 </for>
 ```
+
+Each key must be a string or a number, and must be unique within a single loop. An object item is keyed by a stable identifier it carries, such as the `id` above.
+
+> [!WARNING]
+> The `by=` attribute keys a `<for>` that renders [content](./language.md#tag-content). Including it on a `<for>` that [applies attribute tags](./language.md#conditional-attribute-tags) is a compile error.
 
 ## `<let>`
 


### PR DESCRIPTION
Adds three verified `<for>` behaviors to the core tag reference. Ranges gain the negative and fractional `step=` forms, `of=`/`in=` document that a nullish value renders nothing (which is what makes the recommended optional attribute-tag iteration pattern safe), and the `by=` section now states that a key must be a string or number unique within the loop, plus that `by=` on a `<for>` applying attribute tags is a compile error.