### PR TITLE
docs: tag variable assignment and destructuring rules

### DIFF
--- a/docs/reference/core-tag.md
+++ b/docs/reference/core-tag.md
@@ -138,7 +138,7 @@ This means the previous example can simplified to:
 
 ## `<let>`
 
-The `<let>` tag introduces mutable state through its [Tag Variable](./language.md#tag-variables).
+The `<let>` tag introduces mutable state through its [Tag Variable](./language.md#tag-variables), which is named with a plain identifier.
 
 ```marko
 <let/x=1>
@@ -157,6 +157,8 @@ When a tag variable is updated, everywhere it is used also re-runs. This is the 
 ```
 
 In this template, `count` is incremented when the button is clicked. Since `count` is a [Tag Variable](./language.md#tag-variables), it will cause any downstream expression (in this case the text in the button) to be updated every time it changes.
+
+Assignment belongs inside a function body, such as the [event handler](./native-tag.md#event-handlers) above, a [`<script>`](#script), or a [`<lifecycle>`](#lifecycle) hook. Attribute values and [interpolations](./language.md#dynamic-text) are evaluated during the render, so an assignment written directly in one is a compile error.
 
 > [!NOTE]
 > The `<let>` tag is not reactive to changes in its `value=` attribute unless it is [controllable](#controllable-let). Its tag variable updates only through direct assignment or its change handler.

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -686,7 +686,7 @@ Here, `<my-select>` unconditionally receives the first `@option`, and also all o
 
 Tag variables expose a value from a tag to be used within a template (from a custom tag, the variable is taken from its [`<return>`](./core-tag.md#return)). These variables are not _quite_ like JavaScript variables, as they are used to power [Marko's compiled reactivity](./reactivity.md).
 
-Tag Variables use a `/` followed by a valid JavaScript [identifier](https://developer.mozilla.org/en-US/docs/Glossary/Identifier) or [destructure assignment pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) after the tag name.
+Tag Variables use a `/` followed by a valid JavaScript [identifier](https://developer.mozilla.org/en-US/docs/Glossary/Identifier) after the tag name. A [destructure assignment pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) may be used in that position on [custom tags](./custom-tag.md), [`<const>`](./core-tag.md#const), and [`<style>`](./core-tag.md#style).
 
 ```marko
 <my-tag/foo/>


### PR DESCRIPTION
The `<let>` reference showed `count++` inside a handler without ever saying where assignment is allowed, so it now states that assignment belongs in a function body (event handler, `<script>`, `<lifecycle>`) and that an assignment written directly in a render-time expression is a compile error. The Tag Variables section claimed a tag variable may be an identifier or a destructure pattern, which contradicted `<let>`; destructuring is now scoped to the tags that accept it (custom tags, `<const>`, `<style>`).