### PR TITLE
docs(native-tag): document uncontrolled `open=` on `<details>` and `<dialog>`

### DIFF
--- a/docs/reference/native-tag.md
+++ b/docs/reference/native-tag.md
@@ -512,6 +512,8 @@ The `<details>` tag has a change handler for its `open=` attribute.
 </button>
 ```
 
+Without `openChange=`, `open=` applies only on the render that creates the element, and the browser owns the state from then on. `open:=` keeps the value and the element in sync.
+
 #### `<dialog>` (`openChange=`)
 
 The `<dialog>` tag has a change handler for its `open=` attribute.
@@ -524,6 +526,8 @@ The `<dialog>` tag has a change handler for its `open=` attribute.
   Toggle
 </button>
 ```
+
+Without `openChange=`, `open=` applies only on the render that creates the element, as on [`<details>`](#details-openchange).
 
 > [!Warning]
 > The `open` attribute of the `<dialog>` tag can be used to control a non-modal dialog. However if you need a modal dialog, you should use [the `.showModal()` method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal) directly. Calling this method will _not_ cause `openChange` to fire as the HTML `<dialog>` only fires an event on `close`.


### PR DESCRIPTION
The Change Handlers section showed only the controlled `open:=` form, which leaves the impression that a bare `open=` tracks its value across updates. It applies only on the render that creates the element, after which the browser owns the state. Adds a sentence stating that rule under `<details>` and a one-line cross-link from `<dialog>`, which resolves to the same runtime helper.