### PR TITLE
docs(native-tag): explain how a `<textarea>` body becomes its value

### DIFF
--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -487,7 +487,7 @@ This example renders:
 > [!WARNING]
 > A line break between two tags leaves no space between them. Keep a separating space on the same line as both tags.
 
-Whitespace is preserved inside [`<pre>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre) and inside the tags whose body is text rather than markup: [`<textarea>`](./native-tag.md#textarea), [`<script>`](./core-tag.md#script), [`<style>`](./core-tag.md#style), [`<html-script>` and `<html-style>`](./native-tag.md#enhanced-tags).
+Whitespace is preserved inside [`<pre>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre), [`<textarea>`](./native-tag.md#textarea), [`<script>`](./core-tag.md#script), [`<style>`](./core-tag.md#style), [`<html-script>` and `<html-style>`](./native-tag.md#enhanced-tags). A [`<title>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title) body is text, but its whitespace collapses.
 
 ## Attribute Tags
 

--- a/docs/reference/native-tag.md
+++ b/docs/reference/native-tag.md
@@ -296,7 +296,30 @@ Every `<option>` inside a `<select>` that has `value=` or `valueChange=` must ca
 
 #### `<textarea>`
 
-In HTML, `<textarea>` holds its value inside its body. In Marko, this state can also be held in the `value=` attribute, which is useful for the textarea change handler.
+In HTML, `<textarea>` holds its value inside its body. In Marko, this state can also be held in the `value=` attribute, which pairs with the [`valueChange=` handler](#textarea-valuechange).
+
+The compiler folds a body into `value=`. A body holds text and [interpolations](./language.md#dynamic-text), and an interpolated body updates like an interpolated `value=`.
+
+```marko no-format
+<textarea name="reply">Hi ${input.author},
+
+Thanks for the review.</textarea>
+```
+
+Whitespace in a body is preserved rather than [collapsed](./language.md#whitespace). The HTML parser drops a single newline directly after the start tag: the compiler removes that newline from a body, and a value that begins with one is rendered with a second so it survives parsing.
+
+> [!WARNING]
+> Only that one newline is dropped, so an indented body carries its indentation into the value.
+>
+> ```marko no-format
+> // ❌ (INCORRECT) the value is `"  Ready to publish\n"`
+> <textarea>
+>   Ready to publish
+> </textarea>
+>
+> // ✅
+> <textarea>Ready to publish</textarea>
+> ```
 
 ### Change Handlers
 


### PR DESCRIPTION
The `<textarea>` reference section said its value can live in the body or in `value=` without explaining how the two relate. It now covers the compile-time fold of a body into `value=`, interpolated bodies, whitespace being kept verbatim, and the single newline the HTML parser drops after the start tag. The whitespace section in the language reference drops a generalization that wrongly implied `<title>` preserves whitespace.