### PR TITLE
docs(reference): note when serialized globals reach the page

### DIFF
--- a/docs/reference/template.md
+++ b/docs/reference/template.md
@@ -206,6 +206,8 @@ serializedGlobals: { locale: true, apiToken: false }
 
 A named property holding `undefined` is left out.
 
+The selected values are written into the page alongside the state it resumes, so a page with no client state carries none of them.
+
 > [!WARNING]
 > Serialized values are written into the HTML and can be read by anyone who loads the page. Secrets belong in properties left off the list.
 


### PR DESCRIPTION
The `$global.serializedGlobals` section describes which properties are selected but never says when the selected values are actually written. One sentence now records that they are written alongside the state the page resumes, so a page with no client state carries none of them.