### PR TITLE
docs(native-tag): document form reset for controlled elements

### DIFF
--- a/docs/reference/native-tag.md
+++ b/docs/reference/native-tag.md
@@ -528,6 +528,26 @@ The `<dialog>` tag has a change handler for its `open=` attribute.
 > [!Warning]
 > The `open` attribute of the `<dialog>` tag can be used to control a non-modal dialog. However if you need a modal dialog, you should use [the `.showModal()` method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal) directly. Calling this method will _not_ cause `openChange` to fire as the HTML `<dialog>` only fires an event on `close`.
 
+#### Form Reset
+
+Resetting a form, through a `<button type="reset">` or [`form.reset()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset), returns each controlled form element to the value it was first rendered with. Later updates to the bound state change the element without changing that default. Marko calls the change handler of every element the reset changed, passing the restored value, so the bound state follows the element back.
+
+```marko
+<let/tracking="1Z999AA10">
+
+<form>
+  <input value:=tracking>
+  <button type="reset">Reset</button>
+</form>
+
+<div>${tracking}</div>
+```
+
+Editing the field and resetting the form restores `1Z999AA10` to both the `<input>` and `tracking`.
+
+> [!NOTE]
+> The change handlers run in an animation frame after the reset, so the element updates immediately while the bound state follows on the next frame. Calling `preventDefault()` on the `reset` event cancels the reset along with those handler calls.
+
 ## Attribute Spreads
 
 A [spread](./language.md#spread-attributes) supplies a native tag's attributes as an object, and that object owns the element's attribute set. An attribute the object stops providing is removed on the next update.


### PR DESCRIPTION
Adds a Form Reset subsection to the Change Handlers section of the native tag reference. It covers what a `<button type="reset">` or `form.reset()` does to controlled elements: the element returns to the value it was first rendered with, later state updates do not move that default, and Marko calls the change handler of each element the reset changed so the bound state follows. A note records that those handlers run in an animation frame and that `preventDefault()` on the reset event cancels them along with the reset.