### PR TITLE
docs(serializable-state): correct the imported-function bullet

### DIFF
--- a/docs/explanation/serializable-state.md
+++ b/docs/explanation/serializable-state.md
@@ -48,7 +48,7 @@ Some values cannot be serialized. When these values are encountered the Marko ru
 Examples of unserializable data include:
 
 - Closures (top level functions are fine!)
-- Functions that come from arbitrary javascript code or imports
+- Functions that come from arbitrary javascript code, such as a `.js` or `.ts` module
 - Class instances (except built-ins explicitly supported by the runtime)
 - DOM nodes and elements
 


### PR DESCRIPTION
The unserializable-data list said "Functions that come from arbitrary javascript code or imports". The "or imports" half is not true for `.marko` imports: an exported function is registered and serializes by reference, so state holding one resumes in the browser. The bullet now names the case that does hold.