### PR TITLE
Add board reconcile skill

### DIFF
--- a/skills/board-reconcile/SKILL.md
+++ b/skills/board-reconcile/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: board-reconcile
+description: Reconcile the marko-js "Roadmap" project board against the pull requests actually merged in a month, and fill in the items and fields that are missing. Use before writing a newsletter, or when asked to check, audit, or catch up the project board for a month.
+---
+
+# Board Reconcile
+
+The [marko-js Roadmap board](https://github.com/orgs/marko-js/projects/2) is meant to hold every merged pull request, tagged with the month it shipped. It falls behind during busy months, and a board that is behind is invisibly wrong: the [newsletter](../newsletter/SKILL.md) reads from it, so a gap becomes a month of unreported work.
+
+This skill compares the board against the merged pull requests and closes the difference.
+
+## Authentication
+
+The `reconcile.js` script beside this file talks to the official GitHub API. Do not assume the `gh` CLI is installed. Authenticate with a Personal Access Token in `GITHUB_PROJECT_TOKEN`:
+
+- `check` and `coverage` need `read:project` and `repo`.
+- `apply` needs `project` (write) and `repo`, because it writes board fields and assigns pull requests.
+
+The script needs only Node 18+ (it uses the global `fetch`), has no dependencies, and runs from the repo root.
+
+## Step 1 — Check the month
+
+```bash
+node skills/board-reconcile/reconcile.js check 2026-07
+```
+
+This reports five numbers, all of which should be zero on a healthy month:
+
+- **missing from the board** — merged, not present at all.
+- **wrong or absent iteration** — present, but not filed under the month it merged.
+- **missing Epic/Task/Status** — present and dated, but not fully tagged.
+- **missing an assignee** — the pull request has no assignee, so the item shows as unassigned.
+- **on the iteration but not merged this month** — the reverse error, worth a look by hand.
+
+It also prints anything it refuses to guess at: repositories with no `Epic` mapping, and titles with no conventional-commit prefix.
+
+Run `coverage 2026-01 2026-07` for the same comparison across a range of months. That is how to tell a board that is behind from a board that was never used this way: healthy months sit at 93-100%.
+
+## Step 2 — Read what it refuses to guess
+
+Two things need a person, and both are printed by `check`:
+
+- **A repository with no `Epic` mapping.** Add it to `EPIC_BY_REPO` in the script rather than tagging by hand, so the next month is automatic. Ask which epic a genuinely ambiguous repository belongs to instead of picking one.
+- **A title with no conventional-commit prefix.** These default to `Chore`, which is right for build and tooling work and wrong for anything user-facing. Read the list. A title like `Support ${...} interpolation in <style> tags` is a `Feat`, not a `Chore`, and needs correcting on the board afterwards.
+
+## Step 3 — Apply
+
+Show the plan before writing to a shared board, and start small:
+
+```bash
+node skills/board-reconcile/reconcile.js apply 2026-07 --limit 10
+```
+
+Check those ten on the board, then run the rest:
+
+```bash
+node skills/board-reconcile/reconcile.js apply 2026-07
+```
+
+`apply` is idempotent and resumable. It only touches fields that are actually wrong, adding an item returns the existing one if it is already there, and rerunning after an interruption picks up where it stopped. A busy month is a few thousand mutations, so expect it to take several minutes; it paces itself and retries on rate limits.
+
+Finish by rerunning `check` to confirm every number is zero.
+
+Give it a minute first. Project item indexing lags writes, so a `check` run immediately after `apply` can still report the items it just added as missing. Rerun before concluding that `apply` failed, and confirm against the board itself rather than a second query.
+
+## What the fields mean
+
+The script derives these from conventions the board already follows. Confirm them against the existing items rather than assuming, since they can drift.
+
+| Field       | Derived from                                       |
+| ----------- | -------------------------------------------------- |
+| `Iteration` | The month the pull request merged, e.g. `Jul 2026` |
+| `Epic`      | The repository (`EPIC_BY_REPO`)                    |
+| `Task`      | The conventional-commit prefix (`TASK_BY_PREFIX`)  |
+| `Status`    | `Done`, since every reconciled item is merged      |
+| Assignee    | The pull request author                            |
+
+`Task` maps `fix`, `feat`, `perf`, and `docs` to their obvious counterparts, `refactor` to `Rework`, and `chore`, `test`, `build`, `ci`, and `style` to `Chore`.
+
+## Gotchas
+
+- **Assignee is not a board field.** The board's `Assignees` column reflects the pull request's own assignees, so it cannot be set with `updateProjectV2ItemFieldValue`. The script assigns the pull request itself. Setting every other field and leaving this one produces items that look updated in a table view and unassigned in a board view grouped by assignee.
+- **An outside contributor cannot always be assigned.** GitHub rejects assigning a user without repository access, so the script falls back to `FALLBACK_ASSIGNEE`, matching how such pull requests are already handled.
+- **Bot pull requests stay off the board.** `[ci] release` commits and anything authored by `github-actions` are filtered out, and the counts above exclude them.
+- **Draft issues and issues have no iteration.** The board carries planning items that are not merged pull requests. They are outside this skill's scope, and `check` ignores them rather than reporting them as gaps.
+- **GitHub search caps at 1000 results.** A month past that cap would silently truncate, so the script splits the date range until each slice fits. Do not replace it with a single unsplit query.
+- **Field and option ids are resolved by name at run time.** Renaming a board option is safe; only `PROJECT_ID` is fixed. If the board is ever recreated, update it by querying `organization(login: "marko-js") { projectV2(number: 2) { id } }`.
+- **The board is a moving target.** Pull requests merge while the script runs, so a `check` immediately after an `apply` can legitimately turn up new gaps. Reconciling a month that is still in progress will never settle at zero; wait until the month is over, or accept that a rerun will find whatever merged in between.
+- **Do not treat a clean `check` as a clean board.** It only verifies merged pull requests for one month. Items sitting on the iteration that were not merged that month are reported but never modified, because the right fix is a judgment call.

--- a/skills/board-reconcile/reconcile.js
+++ b/skills/board-reconcile/reconcile.js
@@ -1,0 +1,662 @@
+#!/usr/bin/env node
+// Reconcile the marko-js "Roadmap" project board against the PRs actually
+// merged in a month, and fill in what is missing.
+//
+// No external dependencies: needs Node 18+ (uses the global `fetch`).
+//
+// Auth: set GITHUB_PROJECT_TOKEN to a GitHub PAT. `check` needs `read:project`
+// and `repo`; `apply` needs `project` and `repo` (it writes to the board and
+// assigns pull requests).
+//
+// Usage:
+//   node skills/board-reconcile/reconcile.js check 2026-07
+//   node skills/board-reconcile/reconcile.js apply 2026-07
+//   node skills/board-reconcile/reconcile.js apply 2026-07 --limit 10
+//   node skills/board-reconcile/reconcile.js coverage 2026-01 2026-07
+//
+// Field and option ids are resolved by name at run time, so renaming or
+// reordering board options does not break this script. Only the project id is
+// fixed; if the board is recreated, update PROJECT_ID by querying
+// `organization(login: "marko-js") { projectV2(number: 2) { id } }`.
+
+const token = process.env.GITHUB_PROJECT_TOKEN;
+if (!token) {
+  console.error(
+    "Set GITHUB_PROJECT_TOKEN to a GitHub PAT (check: read:project + repo, apply: project + repo).",
+  );
+  process.exit(1);
+}
+
+const ORG = "marko-js";
+const PROJECT_ID = "PVT_kwDOALUtoM0gQw"; // marko-js "Roadmap" (project #2)
+// Assignee for pull requests whose author cannot be assigned (outside
+// contributors). Mirrors how such PRs are already handled on the board.
+const FALLBACK_ASSIGNEE = "DylanPiercey";
+// Task used when a title carries no conventional-commit prefix. Every such
+// title is printed so a human can correct the ones that deserve better.
+const DEFAULT_TASK = "Chore";
+
+// Which Epic a repository belongs to. Repos absent here are reported rather
+// than guessed at.
+const EPIC_BY_REPO = {
+  marko: "Marko",
+  run: "Marko Run",
+  website: "Website",
+  "language-server": "Language Tools",
+  "htmljs-parser": "Language Tools",
+  prettier: "Language Tools",
+  "tree-sitter": "Language Tools",
+  zed: "Language Tools",
+  vite: "Integrations",
+  "resolve-sync": "Integrations",
+  "relative-import-path": "Integrations",
+  "testing-library": "Integrations",
+  examples: "Community/Examples",
+  cli: "Community/Examples",
+};
+
+// Which Task a conventional-commit prefix maps to.
+const TASK_BY_PREFIX = {
+  fix: "Fix",
+  feat: "Feat",
+  perf: "Perf",
+  docs: "Docs",
+  refactor: "Rework",
+  chore: "Chore",
+  test: "Chore",
+  build: "Chore",
+  ci: "Chore",
+  style: "Chore",
+};
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+const FULL_MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function gql(query, variables = {}) {
+  let lastError;
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    let res;
+    try {
+      res = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+    } catch (err) {
+      lastError = err;
+      await sleep(attempt * 500);
+      continue;
+    }
+    if (res.status === 429 || res.status >= 500) {
+      const retryAfter = Number(res.headers.get("retry-after"));
+      lastError = new Error(`GitHub API ${res.status} ${res.statusText}`);
+      await sleep(retryAfter > 0 ? retryAfter * 1000 : attempt * 1000);
+      continue;
+    }
+    const json = await res.json().catch(() => ({}));
+    if (json.errors) {
+      const message = JSON.stringify(json.errors);
+      if (/rate limit|abuse/i.test(message) && attempt < 5) {
+        await sleep(attempt * 3000);
+        continue;
+      }
+      throw new Error(`GitHub GraphQL error: ${message}`);
+    }
+    return json.data;
+  }
+  throw lastError ?? new Error("request failed");
+}
+
+// Walk a Relay connection fully.
+async function collect(runPage) {
+  const all = [];
+  let cursor = null;
+  for (let page = 0; page < 1000; page++) {
+    const conn = await runPage(cursor);
+    all.push(...conn.nodes);
+    const { hasNextPage, endCursor } = conn.pageInfo;
+    if (!hasNextPage || endCursor == null || endCursor === cursor) break;
+    cursor = endCursor;
+  }
+  return all;
+}
+
+const FIELDS_QUERY = `
+  query ($project: ID!) {
+    node(id: $project) {
+      ... on ProjectV2 {
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2FieldCommon { id name }
+            ... on ProjectV2SingleSelectField { id name options { id name } }
+            ... on ProjectV2IterationField {
+              id name
+              configuration {
+                iterations { id title }
+                completedIterations { id title }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ITEMS_QUERY = `
+  query ($project: ID!, $cursor: String) {
+    node(id: $project) {
+      ... on ProjectV2 {
+        items(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            content {
+              __typename
+              ... on PullRequest {
+                number title repository { name } author { login }
+                assignees(first: 10) { nodes { login } }
+              }
+              ... on Issue {
+                number title repository { name }
+                assignees(first: 10) { nodes { login } }
+              }
+              ... on DraftIssue { title }
+            }
+            fieldValues(first: 40) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue { field { ... on ProjectV2FieldCommon { name } } name }
+                ... on ProjectV2ItemFieldIterationValue { field { ... on ProjectV2FieldCommon { name } } title }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const SEARCH_QUERY = `
+  query ($q: String!, $cursor: String) {
+    search(query: $q, type: ISSUE, first: 100, after: $cursor) {
+      issueCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        ... on PullRequest {
+          id number title mergedAt repository { name } author { login }
+        }
+      }
+    }
+  }
+`;
+
+const fieldValue = (item, name) => {
+  const node = item.fieldValues.nodes.find((n) => n.field?.name === name);
+  return node?.name ?? node?.title;
+};
+
+const isBot = (login) =>
+  !login || login === "github-actions" || /\[bot\]$/.test(login);
+
+const refOf = (pr) => `${pr.repository.name}#${pr.number}`;
+
+const prefixOf = (title) => {
+  const m = /^([a-z]+)(\(|:)/.exec(title ?? "");
+  return m ? m[1] : null;
+};
+
+function parseMonth(ym) {
+  if (!/^\d{4}-\d{2}$/.test(ym ?? "")) {
+    throw new Error("Expected a month as YYYY-MM, e.g. 2026-07");
+  }
+  const [year, month] = ym.split("-").map(Number);
+  if (month < 1 || month > 12) throw new Error(`Bad month: ${ym}`);
+  const lastDay = new Date(year, month, 0).getDate();
+  return {
+    ym,
+    year,
+    month,
+    from: `${ym}-01`,
+    to: `${ym}-${String(lastDay).padStart(2, "0")}`,
+    // The board mostly uses "Jul 2026", with a few older ones spelled out.
+    titles: [
+      `${MONTHS[month - 1]} ${year}`,
+      `${FULL_MONTHS[month - 1]} ${year}`,
+    ],
+  };
+}
+
+// GitHub search returns at most 1000 results for a query, so split the date
+// range until each slice fits.
+async function searchMerged(from, to) {
+  const q = `org:${ORG} is:pr is:merged merged:${from}..${to}`;
+  const first = await gql(SEARCH_QUERY, { q, cursor: null });
+  if (first.search.issueCount > 990 && from !== to) {
+    const mid = new Date((Date.parse(from) + Date.parse(to)) / 2)
+      .toISOString()
+      .slice(0, 10);
+    const nextDay = new Date(Date.parse(mid) + 86400000)
+      .toISOString()
+      .slice(0, 10);
+    const [a, b] = [
+      await searchMerged(from, mid),
+      await searchMerged(nextDay, to),
+    ];
+    const seen = new Set();
+    return [...a, ...b].filter((pr) => {
+      const k = refOf(pr);
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+  }
+  const nodes = await collect(async (cursor) =>
+    cursor === null
+      ? first.search
+      : (await gql(SEARCH_QUERY, { q, cursor })).search,
+  );
+  return nodes.filter((pr) => pr?.repository);
+}
+
+async function loadBoard() {
+  const data = await gql(FIELDS_QUERY, { project: PROJECT_ID });
+  const fields = {};
+  for (const f of data.node.fields.nodes) {
+    if (f?.name) fields[f.name] = f;
+  }
+  const items = await collect(
+    async (cursor) =>
+      (await gql(ITEMS_QUERY, { project: PROJECT_ID, cursor })).node.items,
+  );
+  const byRef = new Map();
+  for (const item of items) {
+    const c = item.content;
+    if (!c?.repository) continue;
+    byRef.set(`${c.repository.name}#${c.number}`, {
+      itemId: item.id,
+      type: c.__typename,
+      title: c.title,
+      author: c.author?.login,
+      assignees: (c.assignees?.nodes ?? []).map((n) => n.login),
+      iteration: fieldValue(item, "Iteration"),
+      epic: fieldValue(item, "Epic"),
+      task: fieldValue(item, "Task"),
+      status: fieldValue(item, "Status"),
+    });
+  }
+  return { fields, items, byRef };
+}
+
+function optionId(fields, fieldName, optionName) {
+  const opt = fields[fieldName]?.options?.find((o) => o.name === optionName);
+  if (!opt)
+    throw new Error(`No "${optionName}" option on the ${fieldName} field`);
+  return { fieldId: fields[fieldName].id, optionId: opt.id };
+}
+
+function iterationId(fields, titles) {
+  const cfg = fields.Iteration?.configuration;
+  if (!cfg) throw new Error("No Iteration field on the board");
+  const all = [...cfg.iterations, ...cfg.completedIterations];
+  for (const t of titles) {
+    const hit = all.find((i) => i.title === t);
+    if (hit)
+      return {
+        fieldId: fields.Iteration.id,
+        iterationId: hit.id,
+        title: hit.title,
+      };
+  }
+  throw new Error(
+    `No iteration titled ${titles.map((t) => `"${t}"`).join(" or ")}. Available: ${all.map((i) => i.title).join(", ")}`,
+  );
+}
+
+// Work out what each merged PR should look like on the board.
+function plan(merged, board, iterationTitle) {
+  const rows = [];
+  const unknownRepo = [];
+  const unprefixed = [];
+  for (const pr of merged) {
+    const ref = refOf(pr);
+    const repo = pr.repository.name;
+    const epic = EPIC_BY_REPO[repo];
+    if (!epic) {
+      unknownRepo.push({ ref, repo, title: pr.title });
+      continue;
+    }
+    const prefix = prefixOf(pr.title);
+    const task = prefix ? TASK_BY_PREFIX[prefix] : null;
+    if (!task) unprefixed.push({ ref, title: pr.title });
+    const existing = board.byRef.get(ref);
+    rows.push({
+      ref,
+      prId: pr.id,
+      title: pr.title,
+      author: pr.author?.login,
+      epic,
+      task: task ?? DEFAULT_TASK,
+      guessedTask: !task,
+      itemId: existing?.itemId ?? null,
+      onBoard: Boolean(existing),
+      needsIteration: existing?.iteration !== iterationTitle,
+      needsEpic: existing?.epic !== epic,
+      needsTask: !existing?.task,
+      needsStatus: existing?.status !== "Done",
+      needsAssignee: !(existing?.assignees ?? []).length,
+    });
+  }
+  return { rows, unknownRepo, unprefixed };
+}
+
+function report(month, merged, board, planned, iterationTitle) {
+  const { rows, unknownRepo, unprefixed } = planned;
+  const missing = rows.filter((r) => !r.onBoard);
+  const wrongIteration = rows.filter((r) => r.onBoard && r.needsIteration);
+  const needsField = rows.filter(
+    (r) =>
+      r.onBoard &&
+      !r.needsIteration &&
+      (r.needsEpic || r.needsTask || r.needsStatus),
+  );
+  const needsAssignee = rows.filter((r) => r.needsAssignee);
+
+  const onIteration = [...board.byRef.values()].filter(
+    (b) => b.iteration === iterationTitle,
+  ).length;
+  // Only pull requests are expected to line up with the merged list. Issues
+  // are tracked on an iteration as planning items and are left alone.
+  const mergedRefs = new Set(rows.map((r) => r.ref));
+  const stale = [...board.byRef.entries()].filter(
+    ([ref, b]) =>
+      b.iteration === iterationTitle &&
+      b.type === "PullRequest" &&
+      !mergedRefs.has(ref),
+  );
+  const issuesOnIteration = [...board.byRef.values()].filter(
+    (b) => b.iteration === iterationTitle && b.type === "Issue",
+  ).length;
+
+  console.log(`Month ${month.ym}  (iteration "${iterationTitle}")`);
+  console.log(`  merged, non-bot:            ${rows.length}`);
+  console.log(`  already on this iteration:  ${onIteration}`);
+  console.log("");
+  console.log(`  missing from the board:     ${missing.length}`);
+  console.log(`  wrong or absent iteration:  ${wrongIteration.length}`);
+  console.log(`  missing Epic/Task/Status:   ${needsField.length}`);
+  console.log(`  missing an assignee:        ${needsAssignee.length}`);
+  console.log(
+    `  pull requests on the iteration but not merged this month: ${stale.length}`,
+  );
+  if (issuesOnIteration) {
+    console.log(
+      `  (plus ${issuesOnIteration} issue(s) tracked on this iteration, left alone)`,
+    );
+  }
+
+  if (unknownRepo.length) {
+    console.log(
+      `\n  NO EPIC MAPPING for ${unknownRepo.length} PR(s); add the repo to EPIC_BY_REPO:`,
+    );
+    for (const u of [...new Set(unknownRepo.map((u) => u.repo))])
+      console.log(`    ${u}`);
+  }
+  if (unprefixed.length) {
+    console.log(
+      `\n  ${unprefixed.length} title(s) with no conventional-commit prefix, defaulting to ${DEFAULT_TASK}:`,
+    );
+    for (const u of unprefixed.slice(0, 40))
+      console.log(`    ${u.ref}\t${u.title}`);
+    if (unprefixed.length > 40)
+      console.log(`    ... and ${unprefixed.length - 40} more`);
+  }
+  if (stale.length) {
+    console.log(
+      `\n  Pull requests on "${iterationTitle}" but not merged in ${month.ym}:`,
+    );
+    for (const [ref, b] of stale.slice(0, 20))
+      console.log(`    ${ref}\t${b.title}`);
+    if (stale.length > 20) console.log(`    ... and ${stale.length - 20} more`);
+  }
+  return { missing, wrongIteration, needsField, needsAssignee, stale };
+}
+
+const ADD_ITEM = `mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}`;
+const SET_SELECT = `mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}}){projectV2Item{id}}}`;
+const SET_ITER = `mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{iterationId:$v}}){projectV2Item{id}}}`;
+const ASSIGN = `mutation($id:ID!,$who:[ID!]!){addAssigneesToAssignable(input:{assignableId:$id,assigneeIds:$who}){clientMutationId}}`;
+
+async function resolveUsers(logins) {
+  const unique = [...new Set(logins.filter(Boolean))];
+  const out = {};
+  for (let i = 0; i < unique.length; i += 50) {
+    const batch = unique.slice(i, i + 50);
+    const q =
+      "query{" +
+      batch
+        .map((l, n) => `u${n}: user(login:${JSON.stringify(l)}){id login}`)
+        .join(" ") +
+      "}";
+    const data = await gql(q);
+    for (let n = 0; n < batch.length; n++) {
+      const u = data[`u${n}`];
+      if (u) out[u.login] = u.id;
+    }
+  }
+  return out;
+}
+
+async function apply(month, limit) {
+  const board = await loadBoard();
+  const iter = iterationId(board.fields, month.titles);
+  const merged = (await searchMerged(month.from, month.to)).filter(
+    (pr) => !isBot(pr.author?.login),
+  );
+  const planned = plan(merged, board, iter.title);
+  const buckets = report(month, merged, board, planned, iter.title);
+
+  const todo = planned.rows.filter(
+    (r) =>
+      !r.onBoard ||
+      r.needsIteration ||
+      r.needsEpic ||
+      r.needsTask ||
+      r.needsStatus ||
+      r.needsAssignee,
+  );
+  const slice = Number.isFinite(limit) ? todo.slice(0, limit) : todo;
+  if (!slice.length) {
+    console.log("\nNothing to do.");
+    return;
+  }
+  console.log(`\nApplying ${slice.length} of ${todo.length} item(s)...`);
+
+  const epicOpt = {};
+  for (const name of new Set(slice.map((r) => r.epic)))
+    epicOpt[name] = optionId(board.fields, "Epic", name);
+  const taskOpt = {};
+  for (const name of new Set(slice.map((r) => r.task)))
+    taskOpt[name] = optionId(board.fields, "Task", name);
+  const doneOpt = optionId(board.fields, "Status", "Done");
+  const users = await resolveUsers([
+    ...slice.map((r) => r.author),
+    FALLBACK_ASSIGNEE,
+  ]);
+
+  let ok = 0,
+    fellBack = 0;
+  const failures = [];
+  for (const r of slice) {
+    try {
+      let itemId = r.itemId;
+      if (!itemId) {
+        const added = await gql(ADD_ITEM, { p: PROJECT_ID, c: r.prId });
+        itemId = added.addProjectV2ItemById.item.id;
+      }
+      if (!r.onBoard || r.needsIteration) {
+        await gql(SET_ITER, {
+          p: PROJECT_ID,
+          i: itemId,
+          f: iter.fieldId,
+          v: iter.iterationId,
+        });
+      }
+      if (!r.onBoard || r.needsEpic) {
+        await gql(SET_SELECT, {
+          p: PROJECT_ID,
+          i: itemId,
+          f: epicOpt[r.epic].fieldId,
+          v: epicOpt[r.epic].optionId,
+        });
+      }
+      if (!r.onBoard || r.needsTask) {
+        await gql(SET_SELECT, {
+          p: PROJECT_ID,
+          i: itemId,
+          f: taskOpt[r.task].fieldId,
+          v: taskOpt[r.task].optionId,
+        });
+      }
+      if (!r.onBoard || r.needsStatus) {
+        await gql(SET_SELECT, {
+          p: PROJECT_ID,
+          i: itemId,
+          f: doneOpt.fieldId,
+          v: doneOpt.optionId,
+        });
+      }
+      if (r.needsAssignee) {
+        const primary = users[r.author];
+        try {
+          if (!primary) throw new Error("author not resolvable");
+          await gql(ASSIGN, { id: r.prId, who: [primary] });
+        } catch {
+          // Outside contributors cannot always be assigned.
+          await gql(ASSIGN, { id: r.prId, who: [users[FALLBACK_ASSIGNEE]] });
+          fellBack++;
+        }
+      }
+      ok++;
+      if (ok % 25 === 0) process.stdout.write(`  ${ok}/${slice.length}\r`);
+    } catch (err) {
+      failures.push({ ref: r.ref, error: String(err.message).slice(0, 200) });
+    }
+    await sleep(110);
+  }
+  console.log(
+    `\nApplied ${ok}/${slice.length}` +
+      (fellBack
+        ? ` (assignee fell back to ${FALLBACK_ASSIGNEE} on ${fellBack})`
+        : ""),
+  );
+  if (failures.length) {
+    console.log(`Failures (${failures.length}):`);
+    for (const f of failures.slice(0, 20))
+      console.log(`  ${f.ref}: ${f.error}`);
+  }
+  if (buckets.stale.length) {
+    console.log(
+      `\n${buckets.stale.length} item(s) sit on "${iter.title}" without being merged that month; review them by hand.`,
+    );
+  }
+}
+
+async function check(month) {
+  const board = await loadBoard();
+  const iter = iterationId(board.fields, month.titles);
+  const merged = (await searchMerged(month.from, month.to)).filter(
+    (pr) => !isBot(pr.author?.login),
+  );
+  report(month, merged, board, plan(merged, board, iter.title), iter.title);
+}
+
+async function coverage(fromYm, toYm) {
+  const board = await loadBoard();
+  const start = parseMonth(fromYm);
+  const end = parseMonth(toYm ?? fromYm);
+  console.log("month      merged  onBoard  covered  coverage");
+  for (
+    let y = start.year, m = start.month;
+    y < end.year || (y === end.year && m <= end.month);
+    m === 12 ? ((y += 1), (m = 1)) : (m += 1)
+  ) {
+    const month = parseMonth(`${y}-${String(m).padStart(2, "0")}`);
+    let title;
+    try {
+      title = iterationId(board.fields, month.titles).title;
+    } catch {
+      title = month.titles[0];
+    }
+    const merged = (await searchMerged(month.from, month.to)).filter(
+      (pr) => !isBot(pr.author?.login),
+    );
+    const onBoard = [...board.byRef.entries()].filter(
+      ([, b]) => b.iteration === title,
+    );
+    const refs = new Set(onBoard.map(([ref]) => ref));
+    const covered = merged.filter((pr) => refs.has(refOf(pr))).length;
+    // Floor rather than round, so a single missing item cannot read as 100%.
+    const pct = merged.length
+      ? String(Math.floor((covered / merged.length) * 100))
+      : "-";
+    console.log(
+      `${title.padEnd(10)} ${String(merged.length).padStart(5)}  ${String(onBoard.length).padStart(6)}  ${String(covered).padStart(7)}  ${pct.padStart(6)}%`,
+    );
+  }
+}
+
+const [cmd, ...args] = process.argv.slice(2);
+const limitFlag = args.indexOf("--limit");
+const limit = limitFlag > -1 ? Number(args[limitFlag + 1]) : Infinity;
+const positional = args.filter(
+  (a, i) => !a.startsWith("--") && !(limitFlag > -1 && i === limitFlag + 1),
+);
+
+const run =
+  cmd === "check"
+    ? () => check(parseMonth(positional[0]))
+    : cmd === "apply"
+      ? () => apply(parseMonth(positional[0]), limit)
+      : cmd === "coverage"
+        ? () => coverage(positional[0], positional[1])
+        : () => {
+            throw new Error(
+              "Usage: reconcile.js <check|apply|coverage> <YYYY-MM> [--limit N]",
+            );
+          };
+
+run().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a `board-reconcile` skill that compares the marko-js Roadmap board against the pull requests actually merged in a month and fills in what is missing. `check` reports the gaps, `apply` closes them, and `coverage` shows the hit rate across a range of months.

Written after July's board turned out to hold 117 of 474 merged PRs, which the newsletter reads from and so silently under-reports. Field and option ids resolve by name at run time, the merged search splits its date range so it cannot hit GitHub's 1000-result cap, and `apply` is idempotent and resumable.

Assignee is handled explicitly: the board's Assignees column reflects the pull request's own assignees rather than a project field, so setting the other four fields alone leaves items that look updated in a table view and unassigned in a board view.

Supersedes the `agent-feedback/dx.md` entry added in #269, which should be dropped when that lands.