### PR TITLE
fix: parent example renders non-existent value

### DIFF
--- a/docs/explanation/controllable-components.md
+++ b/docs/explanation/controllable-components.md
@@ -162,7 +162,7 @@ export interface Input {
 <let/count=input.count valueChange=input.countChange>
 
 <button onClick() { count++ }>
-  Count: ${input.count}
+  Count: ${count}
 </button>
 ```
 
@@ -196,7 +196,7 @@ export interface Input {
 <let/count:=input.count>
 
 <button onClick() { count++ }>
-  Count: ${input.count}
+  Count: ${count}
 </button>
 ```
 
@@ -206,7 +206,7 @@ export interface Input {
 
 <counter count:=parentCount/>
 
-<output>${count}</output>
+<output>${parentCount}</output>
 ```
 
 ### Refining Functions


### PR DESCRIPTION
Fixes a minor mistake in the controllable docs. Example attempts to render `count` in the parent component, but that value doesn’t exist in that scope.

Also edit count examples to render `count` rather than `input.count` since we're assigning `input.count` to `count` in the `<let>`

Unsure if rendering `input.count` in the controllable examples was intentional. I'm open to removing that edit if it was.