### PR TITLE
Serve marko's code-split runtime dist to the playground

### DIFF
--- a/src/types/stubs.d.ts
+++ b/src/types/stubs.d.ts
@@ -1,3 +1,8 @@
+declare module "virtual:marko-runtime-files" {
+  const files: Record<string, string>;
+  export default files;
+}
+
 declare module "@ebay/browserslist-config" {
   const config: string[];
   export default config;

--- a/src/util/marko-runtime-files.ts
+++ b/src/util/marko-runtime-files.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { Plugin } from "vite";
+
+// The playground compiles user templates in the browser, so it needs the
+// marko runtime sources as text. The runtime dist is code-split (each
+// `*.feat` module is its own entry sharing hashed chunks with the main
+// entries), so every module is captured — not just `marko/dom` etc.
+export default function markoRuntimeFiles(): Plugin {
+  const virtualId = "virtual:marko-runtime-files";
+  const resolvedId = `\0${virtualId}`;
+  return {
+    name: "marko-runtime-files",
+    resolveId(id) {
+      if (id === virtualId) return resolvedId;
+    },
+    load(id) {
+      if (id !== resolvedId) return;
+      const distDir = path.join(
+        path.dirname(
+          createRequire(import.meta.url).resolve("marko/package.json"),
+        ),
+        "dist",
+      );
+      const files: Record<string, string> = {};
+      for (const file of fs.globSync("{,debug/}{dom,html}{,-*,/**/*}.mjs", {
+        cwd: distDir,
+      })) {
+        files[`marko/${file.replaceAll(path.sep, "/")}`] = fs.readFileSync(
+          path.join(distDir, file),
+          "utf8",
+        );
+      }
+      return `export default ${JSON.stringify(files)}`;
+    },
+  };
+}

--- a/src/util/workspace/marko-plugin.test.ts
+++ b/src/util/workspace/marko-plugin.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import path from "path";
+import runtimeFiles from "virtual:marko-runtime-files";
+
+// Mirrors resolveRuntimeModule in marko-plugin.ts (not exported to keep the
+// plugin surface minimal); asserts the captured dist can satisfy every import
+// shape the playground sees.
+function resolveRuntimeModule(id: string, importer?: string) {
+  if (id[0] === ".") {
+    if (!(importer && importer in runtimeFiles)) return;
+    id = path.join(importer, "..", id);
+  } else if (!id.startsWith("marko/")) {
+    return;
+  }
+  if (id in runtimeFiles) return id;
+  const withExtension = `${id}.mjs`;
+  if (withExtension in runtimeFiles) return withExtension;
+}
+
+describe("marko runtime files", () => {
+  it("captures the runtime entries", () => {
+    for (const entry of [
+      "marko/dom",
+      "marko/html",
+      "marko/debug/dom",
+      "marko/debug/html",
+    ]) {
+      const resolved = resolveRuntimeModule(entry);
+      expect(resolved, entry).toBeDefined();
+      expect(runtimeFiles[resolved!]).toBeTypeOf("string");
+    }
+  });
+
+  it("resolves every relative and bare import within the captured files", () => {
+    for (const id in runtimeFiles) {
+      for (const [, ...specs] of runtimeFiles[id].matchAll(
+        /\bfrom\s*"([^"]+)"|\bimport\s*"([^"]+)"|\bimport\("([^"]+)"\)/g,
+      )) {
+        const spec = specs.find(Boolean);
+        if (!(spec && /^\.\.?\/|^marko\//.test(spec))) continue;
+        expect(
+          resolveRuntimeModule(spec, id),
+          `${spec} from ${id}`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("resolves translator feature imports", () => {
+    expect(resolveRuntimeModule("marko/dom/controllable-input.feat")).toBe(
+      "marko/dom/controllable-input.feat.mjs",
+    );
+    expect(resolveRuntimeModule("marko/debug/dom/catch.feat")).toBe(
+      "marko/debug/dom/catch.feat.mjs",
+    );
+  });
+});

--- a/src/util/workspace/marko-plugin.ts
+++ b/src/util/workspace/marko-plugin.ts
@@ -2,10 +2,7 @@ import path from "path";
 import type { Plugin } from "@rollup/browser";
 import * as compiler from "@marko/compiler";
 import * as translator from "marko/translator";
-import runtimeDOM from "marko/dom?raw";
-import runtimeHTML from "marko/html?raw";
-import runtimeDebugDOM from "marko/debug/dom?raw";
-import runtimeDebugHTML from "marko/debug/html?raw";
+import runtimeFiles from "virtual:marko-runtime-files";
 
 import type { Workspace } from "../workspace";
 import { attachErrorFile } from "../compile-error";
@@ -22,12 +19,22 @@ declare module "../workspace" {
 
 const cache = new Map();
 const knownTemplatesForWS = new WeakMap<Workspace, string[]>();
-const runtimeModules: Record<string, string> = {
-  "marko/dom": runtimeDOM,
-  "marko/html": runtimeHTML,
-  "marko/debug/dom": runtimeDebugDOM,
-  "marko/debug/html": runtimeDebugHTML,
-};
+
+// Map a runtime import onto the captured dist files: a bare specifier like
+// `marko/dom` or `marko/dom/controllable-input.feat` gets its `.mjs`
+// appended, and a chunk import (`./dom-Cj4HQ7T_.mjs`) is joined against the
+// importing runtime module's id.
+function resolveRuntimeModule(id: string, importer?: string) {
+  if (id[0] === ".") {
+    if (!(importer && importer in runtimeFiles)) return;
+    id = path.join(importer, "..", id);
+  } else if (!id.startsWith("marko/")) {
+    return;
+  }
+  if (id in runtimeFiles) return id;
+  const withExtension = `${id}.mjs`;
+  if (withExtension in runtimeFiles) return withExtension;
+}
 
 // Shim currently needed because @marko/compiler uses `lasso-package-root`.
 (globalThis as any).process = {
@@ -109,12 +116,10 @@ export function markoPlugin({ ws, browser }: MarkoPluginOptions): Plugin {
           .getTag(tagName);
         return tagDef && (tagDef.template || tagDef.renderer);
       }
-      if (id in runtimeModules) {
-        return id;
-      }
+      return resolveRuntimeModule(id, importer);
     },
     load(id) {
-      return runtimeModules[id];
+      return runtimeFiles[id];
     },
     transform(code, id) {
       const suffix = /\?.*$/.exec(id)?.[0];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { defineConfig } from "vite";
 import marko from "@marko/run/vite";
 import markodown from "./src/util/markodown";
+import markoRuntimeFiles from "./src/util/marko-runtime-files";
 
 export default defineConfig({
   // BASE_URL is set to "/previews/pr-N/" by the PR Preview workflow so the site can be
@@ -47,7 +48,7 @@ export default defineConfig({
     include: ["flexsearch"],
     exclude: ["@rollup/browser", "lightningcss-wasm"],
   },
-  plugins: [markodown(), marko()],
+  plugins: [markoRuntimeFiles(), markodown(), marko()],
   css: {
     modules: {
       generateScopedName:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from "vitest/config";
+import markoRuntimeFiles from "./src/util/marko-runtime-files";
 
 // Kept separate from vite.config.ts on purpose. These are plain unit tests over
 // `src/util`, and resolving the site's plugin chain to run them roughly triples
 // vitest's startup for no benefit.
 export default defineConfig({
+  plugins: [markoRuntimeFiles()],
   test: {
     include: ["src/**/*.test.ts"],
   },


### PR DESCRIPTION
marko 6.3.33 builds each `*.feat` module as a separate entry, so the runtime dist is code-split and `marko/dom` imports a hashed chunk the playground could not resolve (it inlined only the four entry files). A build-time virtual module now captures the full runtime dist, and the playground resolves entries, `*.feat` imports, and chunk-relative imports against it. A regression test asserts every import within the captured files resolves.