### PR TITLE
Fix skip link bleeding into view and hiding behind the header

### DIFF
--- a/src/routes/+layout.style.scss
+++ b/src/routes/+layout.style.scss
@@ -190,11 +190,11 @@ main {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 10;
+  z-index: 100;
   padding: 0.75rem 1rem;
   background: var(--color-background);
   color: var(--color-foreground);
-  outline: 2px solid currentColor;
+  border: 2px solid currentColor;
   border-radius: 0 0 0.25rem 0;
   transform: translateY(-100%);
 


### PR DESCRIPTION
Replaces the skip link's outline with a border so it no longer peeks into the viewport while hidden, and raises its z-index above the header so it is visible when focused.

---
_Generated by [Claude Code](https://claude.ai/code/session_017j9GwdUY24AhC71djS5aVz)_