### PR TITLE
Add CSR-only toggle to playground preview

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -48,6 +48,7 @@
     "marko",
     "markodown",
     "markojs",
+    "merr",
     "microtask",
     "mlog",
     "nbsp",

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -84,6 +84,15 @@ let/debug=!!debugParam
     debugParam = debug ? "1" : null;
   }
 
+let-search-param/csrParam key="csr"
+let/csr=!!csrParam
+  ,valueChange(csr) {
+    csrParam = csr ? "1" : null;
+    if (csr && (outputType === "html" || outputType === "previewHTML")) {
+      outputType = "preview";
+    }
+  }
+
 let-search-param/fullscreenParam key="fullscreen"
 let/fullscreen=!!fullscreenParam
   ,valueChange(fullscreen) {
@@ -130,14 +139,20 @@ div class=styles.result
           option value="preview" -- Preview
           option value="previewJS" -- Bundled JS
           option value="previewCSS" -- Bundled CSS
-          option value="previewHTML" -- Rendered HTML
+          if=!csr
+            option value="previewHTML" -- Rendered HTML
         optgroup label="Compiled"
           option value="dom" -- Client JS
-          option value="html" -- Server JS
+          if=!csr
+            option value="html" -- Server JS
     div class=styles.control
       label class=styles.checkbox
         -- Debug
         input type="checkbox" checked:=debug
+    div class=styles.control
+      label class=styles.checkbox
+        -- CSR only
+        input type="checkbox" checked:=csr
     span class=styles.version -- v${markoVersion}
 
   div class=styles.output
@@ -166,7 +181,7 @@ div class=styles.result
         [styles.hide]: !showPreview,
       }
     if=files.length
-      script -- update($signal, $frame(), files, !debug);
+      script -- update($signal, $frame(), files, !debug, csr);
 
     if=showPreview && !ws.previewReady
       div class=styles.loading role="status"

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -84,11 +84,13 @@ let/debug=!!debugParam
     debugParam = debug ? "1" : null;
   }
 
+static const serverOutputTypes = ["previewHTML", "html"];
+
 let-search-param/csrParam key="csr"
 let/csr=!!csrParam
   ,valueChange(csr) {
     csrParam = csr ? "1" : null;
-    if (csr && (outputType === "html" || outputType === "previewHTML")) {
+    if (csr && serverOutputTypes.includes(outputType)) {
       outputType = "preview";
     }
   }

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -149,7 +149,7 @@ div class=styles.result
         input type="checkbox" checked:=debug
     div class=styles.control
       label class=styles.checkbox
-        abbr title="Client-side rendering only (no server build)" -- CSR
+        abbr title="client-side rendering" -- CSR
         input type="checkbox" checked:=csr
     span class=styles.version -- v${markoVersion}
 

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -139,19 +139,17 @@ div class=styles.result
           option value="preview" -- Preview
           option value="previewJS" -- Bundled JS
           option value="previewCSS" -- Bundled CSS
-          if=!csr
-            option value="previewHTML" -- Rendered HTML
+          option value="previewHTML" disabled=csr -- Rendered HTML
         optgroup label="Compiled"
           option value="dom" -- Client JS
-          if=!csr
-            option value="html" -- Server JS
+          option value="html" disabled=csr -- Server JS
     div class=styles.control
       label class=styles.checkbox
         -- Debug
         input type="checkbox" checked:=debug
     div class=styles.control
       label class=styles.checkbox
-        -- CSR only
+        abbr title="Client-side rendering only (no server build)" -- CSR
         input type="checkbox" checked:=csr
     span class=styles.version -- v${markoVersion}
 

--- a/src/routes/playground/tags/playground/tags/result/result.marko
+++ b/src/routes/playground/tags/playground/tags/result/result.marko
@@ -148,8 +148,8 @@ div class=styles.result
         -- Debug
         input type="checkbox" checked:=debug
     div class=styles.control
-      label class=styles.checkbox
-        abbr title="client-side rendering" -- CSR
+      label class=styles.checkbox title="Client-side rendering only"
+        -- CSR
         input type="checkbox" checked:=csr
     span class=styles.version -- v${markoVersion}
 

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -171,6 +171,7 @@ export async function update(
   // Read before `workspace` is reassigned below: this holds the only reference
   // to the running preview server, which stays up until this build replaces it.
   const previous = workspace;
+  if (csr) previous?.server?.terminate();
   const ws: Workspace = (workspace = {
     fs,
     optimize,
@@ -205,7 +206,6 @@ export async function update(
       }
     }
 
-    if (csr) previous?.server?.terminate();
     const serverBuild = csr
       ? undefined
       : (async function buildServer() {
@@ -344,13 +344,13 @@ export async function update(
         (ev) => {
           const data = ev.source === frame.contentWindow && ev.data;
           if (!data || typeof data !== "object") return;
-          if ("__mlog" in data) {
-            pushLog("client", data.__mlog.method, data.__mlog.text);
-          } else if ("__merr" in data) {
-            const { name, message, stack } = data.__merr;
-            const err = new Error(message);
-            if (name) err.name = name;
-            if (stack) err.stack = stack;
+          const { __mlog: mlog, __merr: merr } = data;
+          if (mlog && typeof mlog === "object") {
+            pushLog("client", String(mlog.method), String(mlog.text));
+          } else if (merr && typeof merr === "object") {
+            const err = new Error(String(merr.message));
+            if (merr.name) err.name = String(merr.name);
+            if (merr.stack) err.stack = String(merr.stack);
             pushRuntimeError(err);
           }
         },

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -310,21 +310,39 @@ export async function update(
       }
 
       frame.addEventListener("error", onRuntimeError, { signal });
+      // Errors and console output are forwarded from a bootstrap script inside
+      // the iframe rather than via listeners attached on its window: those can
+      // only attach once the frame has loaded, which is after the preview
+      // modules have already evaluated (and possibly thrown).
+      window.addEventListener(
+        "message",
+        (ev) => {
+          if (ev.source !== frame.contentWindow) return;
+          const data = ev.data;
+          if (data && typeof data === "object") {
+            if ("__mlog" in data) {
+              pushLog("client", data.__mlog.method, data.__mlog.text);
+            } else if ("__merr" in data && !signal.aborted) {
+              let err = data.__merr;
+              if (!(err instanceof Error)) {
+                err = Object.assign(
+                  new Error(err?.message || "Unknown error"),
+                  err,
+                );
+              }
+              ws.runtimeErrors = ws.runtimeErrors
+                ? [...ws.runtimeErrors, err]
+                : [err];
+              emit();
+            }
+          }
+        },
+        { signal },
+      );
       frame.addEventListener(
         "load",
         async () => {
-          const win = frame.contentWindow! as Window & typeof globalThis;
-          if (typeof window.console === "object") {
-            consoleInjection(win.console, "client", "#c2185b", (method, args) =>
-              pushLog("client", method, formatLogArgs(args)),
-            );
-          }
-          win.addEventListener("error", onRuntimeError, { signal });
-          win.addEventListener("unhandledrejection", onRuntimeError, {
-            signal,
-          });
           if (csr) {
-            ws.runtimeErrors = undefined;
             ws.previewReady = true;
             emit();
             return;
@@ -335,7 +353,6 @@ export async function update(
 
           const domWriter = WritableDOMStream(frame.contentDocument!.body);
           let rawHTML = "";
-          ws.runtimeErrors = undefined;
           server.onmessage = (ev) => {
             if (signal.aborted) return;
             const data = ev.data;
@@ -362,6 +379,41 @@ export async function update(
         { signal },
       );
       frame.srcdoc =
+        `<script>(() => {
+          const post = (data) => {
+            try {
+              parent.postMessage(data, "*");
+            } catch {
+              parent.postMessage(
+                { __merr: { message: String(data.__merr) } },
+                "*",
+              );
+            }
+          };
+          const postError = (err, fallbackMessage) => {
+            if (err && typeof err === "object") {
+              if ("detail" in err) err = err.detail;
+            } else if (err !== undefined) {
+              err = { message: String(err) };
+            }
+            post({ __merr: err || { message: fallbackMessage } });
+          };
+          addEventListener("error", (e) => {
+            if (e.defaultPrevented) return;
+            postError(
+              e.error,
+              e.message + "\\n" + e.filename + ":" + e.lineno + "," + e.colno,
+            );
+          });
+          addEventListener("unhandledrejection", (e) => {
+            if (e.defaultPrevented) return;
+            postError(e.reason, "Unknown error");
+          });
+          (${consoleInjection.toString()})(console, "client", "#c2185b", (method, args) =>
+            post({ __mlog: { method, text: (${formatLogArgs.toString()})(args) } }),
+          );
+        })()</scr` +
+        `ipt>` +
         (cssCode
           ? `<link rel=stylesheet href="${toAssetURL(
               cssFile,

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -135,6 +135,7 @@ export async function update(
   frame: HTMLIFrameElement,
   files: File[],
   optimize: boolean,
+  csr: boolean,
 ) {
   const fs = new FileSystem({});
   // Read before `workspace` is reassigned below: this holds the only reference
@@ -175,6 +176,10 @@ export async function update(
     }
 
     const serverBuild = (async function buildServer() {
+      if (csr) {
+        previous?.server?.terminate();
+        return;
+      }
       const file = "server.js";
       const build = await rollup({
         plugins: [
@@ -245,7 +250,9 @@ export async function update(
           mainPlugin({
             ws,
             browser: true,
-            code: `import "${rootDir}index.marko?hydrate"`,
+            code: csr
+              ? `import t from "${rootDir}index.marko";t.mount({}, document.body)`
+              : `import "${rootDir}index.marko?hydrate"`,
           }),
           markoPlugin({ ws, browser: true }),
           cssPlugin({ browser: true }),
@@ -316,6 +323,12 @@ export async function update(
           win.addEventListener("unhandledrejection", onRuntimeError, {
             signal,
           });
+          if (csr) {
+            ws.runtimeErrors = undefined;
+            ws.previewReady = true;
+            emit();
+            return;
+          }
           await serverBuild;
           const { server } = ws;
           if (!server || signal.aborted) return;

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -116,6 +116,36 @@ const consoleInjection = (
   };
 };
 
+const consoleInjectionScript = (ns: string, color: string, post: string) =>
+  `(${consoleInjection.toString()})(console,${JSON.stringify(ns)},${JSON.stringify(color)},(method,args)=>${post}({__mlog:{method,text:(${formatLogArgs.toString()})(args)}}))`;
+
+const frameBootstrap =
+  `<script>{
+    const post = (data) => parent.postMessage(data, "*");
+    const postError = (err) => {
+      if (err && typeof err === "object" && "detail" in err) err = err.detail;
+      post({
+        __merr: {
+          name: err && err.name,
+          message: String((err && err.message) ?? err ?? "Unknown error"),
+          stack: err && err.stack,
+        },
+      });
+    };
+    addEventListener("error", (e) => {
+      if (!e.defaultPrevented) {
+        postError(
+          e.error ??
+            e.message + "\\n" + e.filename + ":" + e.lineno + "," + e.colno,
+        );
+      }
+    });
+    addEventListener("unhandledrejection", (e) => {
+      if (!e.defaultPrevented) postError(e.reason);
+    });
+    ${consoleInjectionScript("client", "#c2185b", "post")}
+  }</scr` + `ipt>`;
+
 export function subscribe(
   handler: (workspace: Workspace) => void,
   signal: AbortSignal,
@@ -175,73 +205,72 @@ export async function update(
       }
     }
 
-    const serverBuild = (async function buildServer() {
-      if (csr) {
-        previous?.server?.terminate();
-        return;
-      }
-      const file = "server.js";
-      const build = await rollup({
-        plugins: [
-          mainPlugin({
-            ws,
-            browser: false,
-            code: `import t from "${rootDir}index.marko";let m;onmessage=async e=>{m=e;for await(const c of t.render())if(m==e)postMessage(c);else return;m==e&&postMessage(0)}\n(${consoleInjection.toString()})(console, "server", "#00FFFF", (method, args) => postMessage({ __mlog: { method, text: (${formatLogArgs.toString()})(args) } }))`,
-          }),
-          markoPlugin({
-            ws,
-            browser: false,
-          }),
-          cssPlugin({ browser: false }),
-          cdnPlugin({ versions }),
-          minifyScriptPlugin(),
-        ],
-      });
+    if (csr) previous?.server?.terminate();
+    const serverBuild = csr
+      ? undefined
+      : (async function buildServer() {
+          const file = "server.js";
+          const build = await rollup({
+            plugins: [
+              mainPlugin({
+                ws,
+                browser: false,
+                code: `import t from "${rootDir}index.marko";let m;onmessage=async e=>{m=e;for await(const c of t.render())if(m==e)postMessage(c);else return;m==e&&postMessage(0)}\n${consoleInjectionScript("server", "#00FFFF", "postMessage")}`,
+              }),
+              markoPlugin({
+                ws,
+                browser: false,
+              }),
+              cssPlugin({ browser: false }),
+              cdnPlugin({ versions }),
+              minifyScriptPlugin(),
+            ],
+          });
 
-      if (signal.aborted) return;
+          if (signal.aborted) return;
 
-      const { output } = await build.generate({
-        file,
-        format: "es",
-        compact: optimize,
-        sourcemap: "hidden",
-        inlineDynamicImports: true,
-      });
+          const { output } = await build.generate({
+            file,
+            format: "es",
+            compact: optimize,
+            sourcemap: "hidden",
+            inlineDynamicImports: true,
+          });
 
-      if (signal.aborted) return;
+          if (signal.aborted) return;
 
-      const code = getAssetCode(output, file);
-      previous?.server?.terminate();
+          const code = getAssetCode(output, file);
+          previous?.server?.terminate();
 
-      if (!code) {
-        return;
-      }
+          if (!code) {
+            return;
+          }
 
-      const server = new Worker(
-        toAssetURL(
-          file,
-          "application/javascript",
-          code +
-            "onunhandledrejection=e=>{e.preventDefault();throw e.reason}" +
-            getSourceMapComment(file, getAssetCode(output, `${file}.map`)),
-        ),
-        {
-          name: file,
-          type: "module",
-        },
-      );
+          const server = new Worker(
+            toAssetURL(
+              file,
+              "application/javascript",
+              code +
+                "onunhandledrejection=e=>{e.preventDefault();throw e.reason}" +
+                getSourceMapComment(file, getAssetCode(output, `${file}.map`)),
+            ),
+            {
+              name: file,
+              type: "module",
+            },
+          );
 
-      // An abort between the check above and here would otherwise strand this
-      // worker: `workspace` already points at a newer build, so nothing else
-      // holds a reference to terminate it.
-      if (signal.aborted) {
-        server.terminate();
-        return;
-      }
+          // An abort between the check above and here would otherwise strand this
+          // worker: `workspace` already points at a newer build, so nothing else
+          // holds a reference to terminate it.
+          if (signal.aborted) {
+            server.terminate();
+            return;
+          }
 
-      ws.server = server;
-      server.addEventListener("error", onRuntimeError, { signal });
-    })();
+          ws.server = server;
+          server.addEventListener("error", onRuntimeError, { signal });
+        })();
     const browserBuild = (async function buildClient() {
       const file = "client.js";
       const cssFile = "client.css";
@@ -310,31 +339,19 @@ export async function update(
       }
 
       frame.addEventListener("error", onRuntimeError, { signal });
-      // Errors and console output are forwarded from a bootstrap script inside
-      // the iframe rather than via listeners attached on its window: those can
-      // only attach once the frame has loaded, which is after the preview
-      // modules have already evaluated (and possibly thrown).
       window.addEventListener(
         "message",
         (ev) => {
-          if (ev.source !== frame.contentWindow) return;
-          const data = ev.data;
-          if (data && typeof data === "object") {
-            if ("__mlog" in data) {
-              pushLog("client", data.__mlog.method, data.__mlog.text);
-            } else if ("__merr" in data && !signal.aborted) {
-              let err = data.__merr;
-              if (!(err instanceof Error)) {
-                err = Object.assign(
-                  new Error(err?.message || "Unknown error"),
-                  err,
-                );
-              }
-              ws.runtimeErrors = ws.runtimeErrors
-                ? [...ws.runtimeErrors, err]
-                : [err];
-              emit();
-            }
+          const data = ev.source === frame.contentWindow && ev.data;
+          if (!data || typeof data !== "object") return;
+          if ("__mlog" in data) {
+            pushLog("client", data.__mlog.method, data.__mlog.text);
+          } else if ("__merr" in data) {
+            const { name, message, stack } = data.__merr;
+            const err = new Error(message);
+            if (name) err.name = name;
+            if (stack) err.stack = stack;
+            pushRuntimeError(err);
           }
         },
         { signal },
@@ -379,41 +396,7 @@ export async function update(
         { signal },
       );
       frame.srcdoc =
-        `<script>(() => {
-          const post = (data) => {
-            try {
-              parent.postMessage(data, "*");
-            } catch {
-              parent.postMessage(
-                { __merr: { message: String(data.__merr) } },
-                "*",
-              );
-            }
-          };
-          const postError = (err, fallbackMessage) => {
-            if (err && typeof err === "object") {
-              if ("detail" in err) err = err.detail;
-            } else if (err !== undefined) {
-              err = { message: String(err) };
-            }
-            post({ __merr: err || { message: fallbackMessage } });
-          };
-          addEventListener("error", (e) => {
-            if (e.defaultPrevented) return;
-            postError(
-              e.error,
-              e.message + "\\n" + e.filename + ":" + e.lineno + "," + e.colno,
-            );
-          });
-          addEventListener("unhandledrejection", (e) => {
-            if (e.defaultPrevented) return;
-            postError(e.reason, "Unknown error");
-          });
-          (${consoleInjection.toString()})(console, "client", "#c2185b", (method, args) =>
-            post({ __mlog: { method, text: (${formatLogArgs.toString()})(args) } }),
-          );
-        })()</scr` +
-        `ipt>` +
+        frameBootstrap +
         (cssCode
           ? `<link rel=stylesheet href="${toAssetURL(
               cssFile,
@@ -461,9 +444,14 @@ export async function update(
         err = new Error("Unknown error");
       }
 
-      ws.runtimeErrors = ws.runtimeErrors ? [...ws.runtimeErrors, err] : [err];
-      emit();
+      pushRuntimeError(err);
     }
+  }
+
+  function pushRuntimeError(err: Error) {
+    if (signal.aborted) return;
+    ws.runtimeErrors = ws.runtimeErrors ? [...ws.runtimeErrors, err] : [err];
+    emit();
   }
 
   function pushLog(ns: LogEntry["ns"], method: string, text: string) {


### PR DESCRIPTION
Adds a "CSR only" checkbox next to Debug in the playground result pane, synced to a `?csr=1` search param so it survives reloads and share links. When enabled, the workspace skips the server build entirely and mounts `index.marko` client-side with `Template.mount()`. The server-only output views (Rendered HTML, Server JS) are hidden while the toggle is on, and the output selection falls back to Preview if one of them was selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)