### PR TITLE
agent-feedback: multipart upload and static file documentation

### DIFF
--- a/agent-feedback/items/2026-08-20-marko-run-multipart-uploads.md
+++ b/agent-feedback/items/2026-08-20-marko-run-multipart-uploads.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: med
+site: docs/marko-run/validation.md › ### form
+---
+
+# Show a worked multipart upload under the `form` option
+
+The `form` option's table is the whole of what the site says about uploads: `maxParts`, `maxFiles`, `maxFileBytes` and `onFile` get one cell each, and `onFile`'s reads `(ctx, file) => any called for each uploaded file`. What a handler actually receives is stated nowhere, and it is the expensive part to rediscover: a multipart field arrives on `await ctx.body` as a `File` carrying an extra `fieldName` property, in the same record as the string fields, and a repeated file field collapses to an array of them exactly as a repeated text field does. No page under `docs/` contains an `<input type="file">`, so there is no path from a form to a stored upload anywhere on the site. An example under the `form` option showing the form markup, the options object and reading the `File` back out of the validated body would cover it; it cannot name `onFile`'s second parameter yet, since `Multipart` is not exported from `@marko/run` (filed in that repo's `agent-feedback/dx.md`).
+
+Check: `grep -rin 'multipart\|onFile' docs/` names only `docs/marko-run/validation.md` and `grep -rn 'type="file"' docs/` returns nothing; both should reach an upload example on the validation page.

--- a/agent-feedback/items/2026-08-20-marko-run-static-assets.md
+++ b/agent-feedback/items/2026-08-20-marko-run-static-assets.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: high
+effort: low
+site: docs/marko-run/file-based-routing.md › # File-based Routing
+---
+
+# Document where a file served at a fixed URL belongs
+
+Nothing across the nine `docs/marko-run/*.md` pages says how an application serves a file at a fixed path, so `<link rel="icon" href="/favicon.png">` in a root layout is the plausible first guess and it 404s in production. `src/routes` is a route directory, not a static root: a `favicon.png` sitting beside `+page.marko` never reaches the build output, and the build reports nothing. Vite's public directory is the mechanism, and Marko Run already wires it up, setting `build.copyPublicDir` for the client pass in `packages/run/src/vite/plugin.ts` and serving the client output directory from `serve-static` in its default entry, so `public/favicon.png` builds to `dist/public/favicon.png` and answers at `/favicon.png`. A short Static Assets section naming `public/` and stating that `src/routes` holds only routable files closes it.
+
+Check: `grep -rin 'publicDir\|favicon\|static asset' docs/` returns nothing today and should name `public/`; a built app with `src/routes/favicon.png` answers `GET /favicon.png` with 404 while the same file under `public/` answers 200 `image/png`.


### PR DESCRIPTION
Two new items: the `form` option has no worked multipart upload example, and nothing documents where a file served at a fixed URL belongs.
