### PR TITLE
agent-feedback: compiler API and language server documentation

### DIFF
--- a/agent-feedback/items/2026-08-20-compiler-api-docs.md
+++ b/agent-feedback/items/2026-08-20-compiler-api-docs.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: high
+effort: med
+site: docs/guide/low-level-apis.md › ## Writing a Migrator
+---
+
+# Document the compiler API the low-level guide promises
+
+`docs/guide/low-level-apis.md` is 379 bytes: one intro paragraph, then `## Writing a Migrator` and `## Writing a Translator` with nothing under either, and it is the only entry `public/llms.txt` offers for the compiler ("Advanced low-level APIs"). Nothing else on the site names the API those sections need. `grep -rniE 'compileSync|compileFile|@marko/compiler|babel-utils' docs/` matches one newsletter sentence, and the generated `/docs/reference-full.md` bundle contains none of it, so an agent asked to write a codemod, a migrator or a bundler integration reverse-engineers `@marko/compiler`'s `index.d.ts`, which exports `compile`, `compileSync`, `compileFile`, `compileFileSync`, `configure`, `getRuntimeEntryFiles` and a `taglib` namespace. The version relationship is unstated too: `marko@6.3.44` depends on `@marko/compiler@^5.42.2`, so a search for the installed compiler's documentation lands on the Marko 5 site, and no page says that pairing is expected. Fill the two sections against the `migrator` and `translator` hooks the taglib loader reads from `marko.json`, and give the compiler entry points a reference page indexed in `llms.txt`.
+
+Check: `grep -rniE 'compileSync|compileFile|@marko/compiler' docs/ | grep -v newsletter` returns nothing and `wc -c docs/guide/low-level-apis.md` prints 379; expect both sections to have bodies and the compiler entry points and their output modes to be documented somewhere under `docs/`.

--- a/agent-feedback/items/2026-08-20-editor-tooling-page.md
+++ b/agent-feedback/items/2026-08-20-editor-tooling-page.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: docs/introduction/integrations.md › ## Editor Tooling
+---
+
+# Give the language server a start-here page and scope the highlighting claim
+
+`## Editor Tooling` states that the Language Server "provides syntax highlighting, IntelliSense, type checking, and accessibility hints for Marko files in any editor that supports the Language Server Protocol", but the server advertises no `semanticTokensProvider` in its initialize response, so highlighting comes from the VS Code extension's TextMate grammar and a bare LSP client opens an without syntax highlighting file with nothing to explain it. Those five lines are also the whole of the site's editor documentation: `docs/introduction/installation.md` › `## IDE Plugin` hands non-VS-Code readers to the language server repository, whose README is four sentences with no launch instructions, and `public/llms.txt` indexes no editor or tooling page at all. Nothing under `docs/` names the `marko-language-server` binary or the `--stdio` transport it requires, and starting it without one exits with "Connection input stream is not set", which is the first thing a reader setting up Neovim, Helix or Zed hits. An Editor Tooling page naming the binary, the transport flag and one non-VS-Code client configuration would close it, with the highlighting sentence scoped to the VS Code extension.
+
+Check: `grep -rn 'marko-language-server\|stdio' docs/ public/llms.txt` returns nothing and `grep -in 'language.server\|editor' public/llms.txt` returns nothing; expect an indexed editor tooling page that names the binary and `--stdio`, and a highlighting sentence that no longer promises it over LSP.

--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json",
   "words": [
+    "codemod",
     "activedescendant",
     "afterbegin",
     "afterend",


### PR DESCRIPTION
Two new items: the low-level guide promises compiler API documentation the page does not contain, and the language server has no start-here page while the syntax-highlighting claim is broader than what ships.
