### PR TITLE
agent-feedback: URL encoding guidance and the interop tag list

### DIFF
--- a/agent-feedback/items/2026-08-21-dynamic-attribute-url-scheme.md
+++ b/agent-feedback/items/2026-08-21-dynamic-attribute-url-scheme.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: docs/reference/language.md › ## Attributes
+---
+
+# Say that a dynamic `href` or `src` is encoded but not scheme-filtered
+
+`## Attributes` introduces attribute values as plain JavaScript expressions and the only escaping statement on the page, the `[!NOTE]` under Dynamic Text, says interpolated values are escaped to avoid XSS, so a reader has no reason to treat a URL differently from any other string. Rendering `<a href=input.url>` with `javascript:alert(1)` emits `<a href=javascript:alert(1)>`, and `data:text/html,...` and `//evil.example/x` reach `href` and `src` unchanged. The encoding is doing its job (`x" onclick="alert(1)` comes back auto-quoted with `'`), so what is missing is only the statement that the scheme of a URL is the application's policy, and every neighboring hazard already has that statement: `$!{...}`, a string dynamic tag name, and native inline event handler attributes each carry a callout. Add the fourth beside `## Attributes`, saying Marko encodes attribute syntax and does not inspect what a URL-valued attribute points at, and pointing at where an allow-list belongs.
+
+Check: `grep -rin 'javascript:\|url scheme\|protocol-relative' docs/ public/llms.txt` returns nothing today while a compiled `<a href=input.url>` renders `javascript:` verbatim; expect a callout under `## Attributes` in `docs/reference/language.md` matching the existing `$!{...}` and dynamic-tag-name warnings.

--- a/agent-feedback/items/2026-08-21-interop-tags-detection-list-and-anchors.md
+++ b/agent-feedback/items/2026-08-21-interop-tags-detection-list-and-anchors.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: docs/guide/marko-5-interop.md › ### Tags API Syntax
+---
+
+# Sync the interop guide's Tags API tag list with `getFeatureTypeFromCoreTagName`
+
+A single tag in this list decides which runtime compiles a whole file, so an omission reads as "still Class API" and the failure surfaces later as a compile error about a tag the Class runtime does not have. The guide names nine tags (`<const> <debug> <define> <id> <let> <lifecycle> <log> <return> <try>`) while `getFeatureTypeFromCoreTagName`, in marko's `packages/runtime-tags/src/translator/interop/feature-detection.ts`, returns the Tags type for twelve: it also maps `attrs`, `effect` and `show`. Both of the "these tags" links are line ranges into `blob/main` and both now miss the block they name, the Class range `#L180-L188` covering the top of the Tags cases and the Tags range `#L189-L198` starting past them. A line range into a moving branch cannot stay correct, so pin the links to a commit SHA or address the function by name, and guard the list itself against the next core tag with a test that reads the switch out of the installed `marko` package.
+
+Check: `node -e 'const s=require("fs").readFileSync("node_modules/marko/dist/translator/index.js","utf8");console.log(s.match(/function getFeatureTypeFromCoreTagName[\s\S]*?\n}/)[0])'` prints twelve Tags cases against the guide's nine, and neither cited line range covers its `case` list; expect the two sets to be equal and each link to open on the switch.


### PR DESCRIPTION
Two new items: nothing states that a dynamic `href` or `src` is HTML-encoded but not scheme-filtered, and the interop guide's Tags API tag list has drifted from `getFeatureTypeFromCoreTagName`.
